### PR TITLE
Feature: Use UUIDs, persist with /etc/fstab, allow smaller snapshot disk size

### DIFF
--- a/template/0.8.2/ansible/cmn/find_unmounted_disks.sh
+++ b/template/0.8.2/ansible/cmn/find_unmounted_disks.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
 
-find_unmounted_nvme_disks() {
-    lsblk -nr -o NAME,TYPE,SIZE,MOUNTPOINT | awk '
-    $2 == "disk" && 
-    $1 ~ /^nvme/ && 
-    (($3 ~ /G$/ && substr($3, 1, length($3)-1) + 0 >= 800) || 
-     ($3 ~ /T$/ && substr($3, 1, length($3)-1) + 0 >= 0.8)) && 
-    ($4 == "" || $4 ~ /^[[:space:]]*$/) && 
-    system("lsblk -nr -o TYPE /dev/" $1 " | grep -q part") != 0 {print $1}'
+# This script discovers unmounted, unpartitioned disks >=400GB,
+# prioritizes NVMe over others, and sorts by size descending.
+
+find_unmounted_disks() {
+  lsblk -nr -o NAME,TYPE,SIZE,MOUNTPOINT | awk '
+    $2 == "disk" &&
+    ($4 == "" || $4 ~ /^[[:space:]]*$/) &&
+    system("lsblk -nr -o TYPE /dev/" $1 " | grep -q part") != 0 {
+      size = $3
+      suffix = substr(size, length(size), 1)
+      base = substr(size, 1, length(size)-1) + 0
+      if (suffix == "T") base *= 1000
+      if (base >= 400) {
+        nvme = ($1 ~ /^nvme/) ? 1 : 0
+        print nvme, base, $1
+      }
+    }' | sort -k1,1nr -k2,2nr | awk '{print $3}'
 }
 
-find_unmounted_nvme_disks
+find_unmounted_disks

--- a/template/0.8.2/ansible/cmn/mount_disks.yml
+++ b/template/0.8.2/ansible/cmn/mount_disks.yml
@@ -41,21 +41,16 @@
         mode: "0755"
       loop: "{{ mount_dirs }}"
 
+    - name: Upload shell script to find unmounted disks
+      template:
+        src: templates/find_unmounted_disks.sh
+        dest: /home/solv/find_unmounted_disks.sh
+        mode: '0755'
+        owner: solv
+        group: solv
+    
     - name: Execute shell script to find unmounted disks
-      shell: |
-        lsblk -nr -o NAME,TYPE,SIZE,MOUNTPOINT | awk '
-        $2 == "disk" &&
-        ($4 == "" || $4 ~ /^[[:space:]]*$/) &&
-        system("lsblk -nr -o TYPE /dev/" $1 " | grep -q part") != 0 {
-          size = $3
-          suffix = substr(size, length(size), 1)
-          base = substr(size, 1, length(size)-1) + 0
-          if (suffix == "T") base *= 1000
-          if (base >= 400) {
-            nvme = ($1 ~ /^nvme/) ? 1 : 0
-            print nvme, base, $1
-          }
-        }' | sort -k1,1nr -k2,2nr | awk '{print $3}'
+      shell: ./find_unmounted_disks.sh
       register: unmounted_disks_output
       args:
         chdir: /home/solv
@@ -135,4 +130,3 @@
             regexp: "^UUID={{ item.value.uuid }}\\s+{{ item.key }}\\s+"
             state: present
           loop: "{{ mount_map | dict2items }}"
-          

--- a/template/0.8.2/ansible/cmn/mount_disks.yml
+++ b/template/0.8.2/ansible/cmn/mount_disks.yml
@@ -1,5 +1,5 @@
 ---
-- name: Mount and configure disks with NVMe prioritization
+- name: Mount and configure disks with NVMe prioritization, using UUIDs
   hosts: all
   become: true
   vars:
@@ -44,12 +44,18 @@
     - name: Execute shell script to find unmounted disks
       shell: |
         lsblk -nr -o NAME,TYPE,SIZE,MOUNTPOINT | awk '
-        $2 == "disk" && 
-        $1 ~ /^nvme/ && 
-        (($3 ~ /G$/ && substr($3, 1, length($3)-1) + 0 >= 800) || 
-        ($3 ~ /T$/ && substr($3, 1, length($3)-1) + 0 >= 0.8)) && 
-        ($4 == "" || $4 ~ /^[[:space:]]*$/) && 
-        system("lsblk -nr -o TYPE /dev/" $1 " | grep -q part") != 0 {print $1}'
+        $2 == "disk" &&
+        ($4 == "" || $4 ~ /^[[:space:]]*$/) &&
+        system("lsblk -nr -o TYPE /dev/" $1 " | grep -q part") != 0 {
+          size = $3
+          suffix = substr(size, length(size), 1)
+          base = substr(size, 1, length(size)-1) + 0
+          if (suffix == "T") base *= 1000
+          if (base >= 400) {
+            nvme = ($1 ~ /^nvme/) ? 1 : 0
+            print nvme, base, $1
+          }
+        }' | sort -k1,1nr -k2,2nr | awk '{print $3}'
       register: unmounted_disks_output
       args:
         chdir: /home/solv
@@ -78,30 +84,55 @@
           loop_control:
             label: "{{ item }}"
 
-        - name: Mount /mnt/ledger
-          mount:
-            path: /mnt/ledger
-            src: "/dev/{{ unmounted_disks_output.stdout_lines[0] }}"
-            fstype: ext4
-            state: mounted
-            opts: defaults,noatime
-          when: unmounted_disks_output.stdout_lines | length >= 1
+        - name: Get disk size and UUID
+          shell: |
+            size=$(lsblk -b -nr -o SIZE /dev/{{ item }} | awk '{print int($1 / 1000000000)}')
+            uuid=$(blkid -s UUID -o value /dev/{{ item }})
+            echo "{{ item }} $size $uuid"
+          register: disk_info_raw
+          loop: "{{ unmounted_disks_output.stdout_lines }}"
+          changed_when: false
 
-        - name: Mount /mnt/accounts
-          mount:
-            path: /mnt/accounts
-            src: "/dev/{{ unmounted_disks_output.stdout_lines[1] }}"
-            fstype: ext4
-            state: mounted
-            opts: defaults,noatime
-          when: unmounted_disks_output.stdout_lines | length >= 2
+        - name: Parse disk info into structured list
+          set_fact:
+            eligible_disks: >-
+              {{
+                disk_info_raw.results
+                | map(attribute='stdout')
+                | map('regex_search', '^(\\S+) (\\d+) (\\S+)$')
+                | map('list')
+                | map('combine', [{'name': 0, 'size_gb': 1 | int, 'uuid': 2}])
+                | list
+              }}
 
-        - name: Mount /mnt/snapshot
+        - name: Assign disks to mount points based on size
+          set_fact:
+            mount_map: >-
+              {{
+                dict([
+                  ['/mnt/ledger', eligible_disks | selectattr('size_gb', '>=', 800) | list | first],
+                  ['/mnt/accounts', eligible_disks | selectattr('size_gb', '>=', 800) | list | nth(1)],
+                  ['/mnt/snapshot', eligible_disks
+                                     | rejectattr('uuid', 'equalto', (mount_map["/mnt/ledger"].uuid if mount_map["/mnt/ledger"] is defined else "")) 
+                                     | rejectattr('uuid', 'equalto', (mount_map["/mnt/accounts"].uuid if mount_map["/mnt/accounts"] is defined else "")) 
+                                     | selectattr('size_gb', '>=', 400) | list | first]
+                ] | select('defined') | map('items') | list | flatten(1))
+              }}
+
+        - name: Mount selected disks using UUIDs
           mount:
-            path: /mnt/snapshot
-            src: "/dev/{{ unmounted_disks_output.stdout_lines[2] }}"
+            path: "{{ item.key }}"
+            src: "UUID={{ item.value.uuid }}"
             fstype: ext4
             state: mounted
             opts: defaults,noatime
-          when: unmounted_disks_output.stdout_lines | length >= 3
-      when: unmounted_disks_output.stdout_lines | length > 0
+          loop: "{{ mount_map | dict2items }}"
+
+        - name: Add UUID-based entries to /etc/fstab
+          lineinfile:
+            path: /etc/fstab
+            line: "UUID={{ item.value.uuid }} {{ item.key }} ext4 defaults,noatime 0 0"
+            regexp: "^UUID={{ item.value.uuid }}\\s+{{ item.key }}\\s+"
+            state: present
+          loop: "{{ mount_map | dict2items }}"
+          

--- a/template/0.8.2/ansible/mainnet-rpc/mount_disks.yml
+++ b/template/0.8.2/ansible/mainnet-rpc/mount_disks.yml
@@ -79,30 +79,56 @@
           loop_control:
             label: '{{ item }}'
 
-        - name: Mount /mnt/ledger
-          mount:
-            path: /mnt/ledger
-            src: '/dev/{{ unmounted_disks_output.stdout_lines[0] }}'
-            fstype: ext4
-            state: mounted
-            opts: defaults,noatime
-          when: unmounted_disks_output.stdout_lines | length >= 1
+        - name: Get disk size and UUID
+          shell: |
+            size=$(lsblk -b -nr -o SIZE /dev/{{ item }} | awk '{print int($1 / 1000000000)}')
+            uuid=$(blkid -s UUID -o value /dev/{{ item }})
+            echo "{{ item }} $size $uuid"
+          register: disk_info_raw
+          loop: '{{ unmounted_disks_output.stdout_lines }}'
+          changed_when: false
 
-        - name: Mount /mnt/accounts
-          mount:
-            path: /mnt/accounts
-            src: '/dev/{{ unmounted_disks_output.stdout_lines[1] }}'
-            fstype: ext4
-            state: mounted
-            opts: defaults,noatime
-          when: unmounted_disks_output.stdout_lines | length >= 2
+        - name: Parse disk info into structured list
+          set_fact:
+            eligible_disks: >-
+              {{
+                disk_info_raw.results
+                | map(attribute='stdout')
+                | map('regex_search', '^(\S+) (\d+) (\S+)$')
+                | map('list')
+                | map('combine', [{'name': 0, 'size_gb': 1 | int, 'uuid': 2}])
+                | list
+              }}
 
-        - name: Mount /mnt/snapshot
+        - name: Assign disks to mount points based on size
+          set_fact:
+            mount_map: >-
+              {{
+                dict([
+                  ['/mnt/ledger', eligible_disks | selectattr('size_gb', '>=', 800) | list | first],
+                  ['/mnt/accounts', eligible_disks | selectattr('size_gb', '>=', 800) | list | nth(1)],
+                  ['/mnt/snapshot', eligible_disks
+                                     | rejectattr('uuid', 'equalto', (mount_map["/mnt/ledger"].uuid if mount_map["/mnt/ledger"] is defined else ""))
+                                     | rejectattr('uuid', 'equalto', (mount_map["/mnt/accounts"].uuid if mount_map["/mnt/accounts"] is defined else ""))
+                                     | selectattr('size_gb', '>=', 400)
+                                     | list | first]
+                ] | select('defined') | map('items') | list | flatten(1))
+              }}
+
+        - name: Mount selected disks using UUIDs
           mount:
-            path: /mnt/snapshot
-            src: '/dev/{{ unmounted_disks_output.stdout_lines[2] }}'
+            path: '{{ item.key }}'
+            src: 'UUID={{ item.value.uuid }}'
             fstype: ext4
             state: mounted
             opts: defaults,noatime
-          when: unmounted_disks_output.stdout_lines | length >= 3
+          loop: '{{ mount_map | dict2items }}'
+
+        - name: Add UUID-based entries to /etc/fstab
+          lineinfile:
+            path: /etc/fstab
+            line: 'UUID={{ item.value.uuid }} {{ item.key }} ext4 defaults,noatime 0 0'
+            regexp: '^UUID={{ item.value.uuid }}\s+{{ item.key }}\s+'
+            state: present
+          loop: '{{ mount_map | dict2items }}'
       when: unmounted_disks_output.stdout_lines | length > 0


### PR DESCRIPTION
This is my attempt at accomplishing the following goals:
- Use UUID to mount disks (NVMe can have issues on reboot with just label alone)
- Persist changes in `/etc/fstab`
- Leverage unmounted disk script in both mount playbooks
- Allow disks 400GB or greater to be used for `/mnt/snapshot` if disks are available

If there is a better way to make this PR let me know! I will also follow up after testing.