### PR TITLE
feat(storage): add --prefix option for bulk delete

### DIFF
--- a/cli/src/storage/delete/deleteAction.ts
+++ b/cli/src/storage/delete/deleteAction.ts
@@ -146,22 +146,28 @@ const deleteByPrefix = async (
 
   let succeeded = 0
   let failed = 0
-  const deleteSpinner = new Kia(colors.cyan(`Deleting ${allFiles.length} file(s)...`))
+  const total = allFiles.length
+  const concurrency = 10
+  const deleteSpinner = new Kia(colors.cyan(`Deleting ${total} file(s)...`))
   deleteSpinner.start()
 
-  for (const filePath of allFiles) {
-    try {
-      const result = await storageDelete(apiKey, filePath, region)
-      if (result.success) {
+  // Process in batches of `concurrency` for parallel deletion
+  for (let i = 0; i < total; i += concurrency) {
+    const batch = allFiles.slice(i, i + concurrency)
+    const results = await Promise.allSettled(
+      batch.map((filePath) =>
+        storageDelete(apiKey, filePath, region).then((r) => r.success)
+      ),
+    )
+    for (const r of results) {
+      if (r.status === 'fulfilled' && r.value) {
         succeeded++
       } else {
         failed++
       }
-    } catch {
-      failed++
     }
     deleteSpinner.set(
-      colors.cyan(`Deleting... (${succeeded + failed}/${allFiles.length})`),
+      colors.cyan(`Deleting... (${succeeded + failed}/${total})`),
     )
   }
 

--- a/cli/src/storage/delete/deleteAction.ts
+++ b/cli/src/storage/delete/deleteAction.ts
@@ -21,7 +21,7 @@ export const deleteAction = async (
 
   // Prefix mode: bulk delete all files matching prefix
   if (options.prefix) {
-    return await deletByPrefix(apiKey, options.prefix, region, options.yes)
+    return await deleteByPrefix(apiKey, options.prefix, region, options.yes)
   }
 
   // Interactive: select file from list if path not provided
@@ -78,7 +78,7 @@ const deleteSingle = async (
   }
 }
 
-const deletByPrefix = async (
+const deleteByPrefix = async (
   apiKey: string,
   prefix: string,
   region?: StorageRegion,

--- a/cli/src/storage/delete/deleteAction.ts
+++ b/cli/src/storage/delete/deleteAction.ts
@@ -147,28 +147,29 @@ const deleteByPrefix = async (
   let succeeded = 0
   let failed = 0
   const total = allFiles.length
-  const concurrency = 10
   const deleteSpinner = new Kia(colors.cyan(`Deleting ${total} file(s)...`))
   deleteSpinner.start()
 
-  // Process in batches of `concurrency` for parallel deletion
-  for (let i = 0; i < total; i += concurrency) {
-    const batch = allFiles.slice(i, i + concurrency)
-    const results = await Promise.allSettled(
-      batch.map((filePath) =>
-        storageDelete(apiKey, filePath, region).then((r) => r.success)
-      ),
-    )
-    for (const r of results) {
-      if (r.status === 'fulfilled' && r.value) {
+  const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+  for (const filePath of allFiles) {
+    try {
+      const result = await storageDelete(apiKey, filePath, region)
+      if (result.success) {
         succeeded++
       } else {
         failed++
       }
+    } catch {
+      failed++
     }
     deleteSpinner.set(
       colors.cyan(`Deleting... (${succeeded + failed}/${total})`),
     )
+    // API rate limit: 1 request per second
+    if (succeeded + failed < total) {
+      await delay(1000)
+    }
   }
 
   if (failed === 0) {

--- a/cli/src/storage/delete/deleteAction.ts
+++ b/cli/src/storage/delete/deleteAction.ts
@@ -3,6 +3,7 @@ import { getApiKeyFromYml } from '/lib/getApiKeyFromYml.ts'
 import { colors } from '@cliffy/colors'
 import {
   storageDelete,
+  storageList,
   StorageApiError,
   type StorageRegion,
 } from '/src/storage/api.ts'
@@ -11,12 +12,17 @@ import Kia from 'https://deno.land/x/kia@0.4.1/mod.ts'
 
 export const deleteAction = async (
   remotePath: string | undefined,
-  options: { region?: StorageRegion; yes?: boolean },
+  options: { region?: StorageRegion; prefix?: string; yes?: boolean },
 ) => {
   const apiKey = await getApiKeyFromYml()
 
   // Interactive: prompt for region if not provided
   const region = options.region ?? await promptRegion()
+
+  // Prefix mode: bulk delete all files matching prefix
+  if (options.prefix) {
+    return await deletByPrefix(apiKey, options.prefix, region, options.yes)
+  }
 
   // Interactive: select file from list if path not provided
   if (!remotePath) {
@@ -42,6 +48,14 @@ export const deleteAction = async (
     }
   }
 
+  return await deleteSingle(apiKey, remotePath, region)
+}
+
+const deleteSingle = async (
+  apiKey: string,
+  remotePath: string,
+  region?: StorageRegion,
+): Promise<boolean> => {
   const spinner = new Kia(colors.cyan(`Deleting ${remotePath}...`))
   spinner.start()
 
@@ -62,4 +76,102 @@ export const deleteAction = async (
     }
     return false
   }
+}
+
+const deletByPrefix = async (
+  apiKey: string,
+  prefix: string,
+  region?: StorageRegion,
+  skipConfirm?: boolean,
+): Promise<boolean> => {
+  // Collect all files matching the prefix
+  const spinner = new Kia(colors.cyan(`Listing files with prefix "${prefix}"...`))
+  spinner.start()
+
+  const allFiles: string[] = []
+  let cursor: string | undefined
+  try {
+    do {
+      const res = await storageList(apiKey, { prefix, region, cursor })
+      for (const f of res.files) {
+        allFiles.push(f.path)
+      }
+      cursor = res.truncated ? res.cursor : undefined
+    } while (cursor)
+  } catch (error) {
+    spinner.fail('Failed to list files')
+    if (error instanceof StorageApiError) {
+      console.log(colors.red(`\n${error.message}`))
+    } else {
+      console.log(colors.red(String(error)))
+    }
+    return false
+  }
+
+  spinner.stop()
+
+  if (allFiles.length === 0) {
+    console.log(colors.yellow(`No files found with prefix "${prefix}"`))
+    return false
+  }
+
+  console.log(
+    colors.white(`\nFound ${colors.bold(String(allFiles.length))} file(s) with prefix "${prefix}":`),
+  )
+  // Show first 10 files as preview
+  const preview = allFiles.slice(0, 10)
+  for (const f of preview) {
+    console.log(colors.gray(`  ${f}`))
+  }
+  if (allFiles.length > 10) {
+    console.log(colors.gray(`  ... and ${allFiles.length - 10} more`))
+  }
+
+  if (!skipConfirm) {
+    const { confirmed } = await prompt([
+      {
+        type: Confirm,
+        name: 'confirmed',
+        message: colors.yellow(
+          `Are you sure you want to delete all ${allFiles.length} file(s)?`,
+        ),
+        default: false,
+      },
+    ])
+    if (!confirmed) {
+      console.log(colors.yellow('Delete cancelled'))
+      return false
+    }
+  }
+
+  let succeeded = 0
+  let failed = 0
+  const deleteSpinner = new Kia(colors.cyan(`Deleting ${allFiles.length} file(s)...`))
+  deleteSpinner.start()
+
+  for (const filePath of allFiles) {
+    try {
+      const result = await storageDelete(apiKey, filePath, region)
+      if (result.success) {
+        succeeded++
+      } else {
+        failed++
+      }
+    } catch {
+      failed++
+    }
+    deleteSpinner.set(
+      colors.cyan(`Deleting... (${succeeded + failed}/${allFiles.length})`),
+    )
+  }
+
+  if (failed === 0) {
+    deleteSpinner.succeed(`Deleted ${succeeded} file(s) with prefix "${prefix}"`)
+  } else {
+    deleteSpinner.warn(
+      `Deleted ${succeeded} file(s), ${failed} failed (prefix: "${prefix}")`,
+    )
+  }
+
+  return failed === 0
 }

--- a/cli/src/storage/index.ts
+++ b/cli/src/storage/index.ts
@@ -85,17 +85,19 @@ export const storageCmd = new Command()
       limit: options.limit,
     })
   })
-  .command('delete', 'Delete a file from cloud storage')
+  .command('delete', 'Delete files from cloud storage')
   .alias('rm')
   .arguments('[path:string]')
   .option(
     '-r, --region <region:string>',
     'Storage region',
   )
+  .option('-p, --prefix <prefix:string>', 'Delete all files matching prefix')
   .option('-y, --yes', 'Skip confirmation')
   .action(async (options, path?: string) => {
     await deleteAction(path, {
       region: validateRegion(options.region),
+      prefix: options.prefix,
       yes: options.yes,
     })
   })


### PR DESCRIPTION
## Summary
- `slv storage delete --prefix <prefix>` で、プレフィックスに一致するファイルを一括削除できるようにした
- resticバックアップ等で大量に生成されるファイルを効率的にクリーンアップ可能に
- 既存の単一ファイル削除の動作はそのまま維持

## Test plan
- [ ] `slv storage delete --prefix restic/` でrestic配下のファイルが一括削除されること
- [ ] `slv storage delete --prefix restic/ -y` で確認スキップが動作すること
- [ ] `slv storage delete --prefix nonexistent/` で「No files found」が表示されること
- [ ] 従来の `slv storage delete <path>` が引き続き動作すること
- [ ] `slv storage delete` (引数なし) のインタラクティブ選択が引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)