### PR TITLE
feat(onboard): i18n, bot init agreement, prefilled defaults

### DIFF
--- a/cli/src/ai/config.ts
+++ b/cli/src/ai/config.ts
@@ -13,6 +13,8 @@ export type AiConfig = {
 type ApiYml = {
   slv: { api_key: string | null }
   ai?: AiConfig
+  lang?: string
+  agreed_slv_init_bot?: boolean
 }
 
 const getApiYmlPath = (): string => {
@@ -65,6 +67,39 @@ export const writeAiConfig = async (config: AiConfig): Promise<void> => {
     yml.ai = config
     await Deno.writeTextFile(path, stringify(yml as Record<string, unknown>))
   }
+  await Deno.chmod(path, 0o600)
+}
+
+export const readLang = async (): Promise<string> => {
+  const yml = await readApiYml()
+  return yml.lang && yml.lang.trim().length > 0 ? yml.lang.trim() : 'en'
+}
+
+export const hasLangSet = async (): Promise<boolean> => {
+  const yml = await readApiYml()
+  return typeof yml.lang === 'string' && yml.lang.trim().length > 0
+}
+
+export const writeLang = async (lang: string): Promise<void> => {
+  const path = getApiYmlPath()
+  await Deno.mkdir(dirname(path), { recursive: true })
+  const yml = await readApiYml()
+  yml.lang = lang
+  await Deno.writeTextFile(path, stringify(yml as Record<string, unknown>))
+  await Deno.chmod(path, 0o600)
+}
+
+export const readBotAgreement = async (): Promise<boolean> => {
+  const yml = await readApiYml()
+  return yml.agreed_slv_init_bot === true
+}
+
+export const writeBotAgreement = async (agreed: boolean): Promise<void> => {
+  const path = getApiYmlPath()
+  await Deno.mkdir(dirname(path), { recursive: true })
+  const yml = await readApiYml()
+  yml.agreed_slv_init_bot = agreed
+  await Deno.writeTextFile(path, stringify(yml as Record<string, unknown>))
   await Deno.chmod(path, 0o600)
 }
 

--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -14,6 +14,7 @@ import {
 } from '@mariozechner/pi-tui'
 import chalk from 'chalk'
 import { readAiConfig } from '@/ai/config.ts'
+import { initI18n, t } from '@/ai/i18n/index.ts'
 import { OpenAIProvider } from '@/ai/console/providers/openai.ts'
 import { AnthropicProvider } from '@/ai/console/providers/anthropic.ts'
 import { SLVProvider } from '@/ai/console/providers/slv.ts'
@@ -245,32 +246,36 @@ async function buildLocalGreeting(home: string): Promise<string> {
     // skill not installed
   }
 
-  const greetLine = userName ? `Hey ${userName}! 👋` : 'Hey there! 👋'
+  const greetLine = userName
+    ? t('Hey {name}! 👋').replace('{name}', userName)
+    : t('Hey there! 👋')
 
   const introLine = agentName !== 'your SLV assistant'
-    ? `I'm ${agentName}, your SLV commander.`
-    : `I'm your SLV assistant.`
+    ? t("I'm {agent}, your SLV commander.").replace('{agent}', agentName)
+    : t("I'm your SLV assistant.")
 
   const agentDescriptions: Record<string, string> = {
-    'Cecil': 'Solana Validator deployments & management',
-    'Tina': 'RPC nodes (Index RPC, gRPC Geyser, combos)',
-    'Setzer': 'Trading bots & Solana apps',
-    'Figaro': 'Find optimized Solana server resources',
-    'Cid': 'Benchmarks & connectivity testing',
+    'Cecil': t('Solana Validator deployments & management'),
+    'Tina': t('RPC nodes (Index RPC, gRPC Geyser, combos)'),
+    'Setzer': t('Trading bots & Solana apps'),
+    'Figaro': t('Find optimized Solana server resources'),
+    'Cid': t('Benchmarks & connectivity testing'),
   }
 
   const preferredOrder = ['Cecil', 'Tina', 'Setzer', 'Figaro', 'Cid']
   const crew = preferredOrder.filter((agent) => enabledAgents.includes(agent))
   let crewSection = ''
   if (crew.length > 0) {
-    crewSection = ` Here's my crew:\n\n${
+    crewSection = ` ${t("Here's my crew:")}\n\n${
       crew.map((a) => `- ${a} — ${agentDescriptions[a]}`).join('\n')
     }\n\n`
   } else {
     crewSection = ' '
   }
 
-  return `${greetLine}\n\n${introLine}${crewSection}What would you like to work on today?`
+  return `${greetLine}\n\n${introLine}${crewSection}${
+    t('What would you like to work on today?')
+  }`
 }
 
 async function checkDependencies(): Promise<string[]> {
@@ -474,6 +479,7 @@ async function promptInstallDependencies(missing: string[]): Promise<void> {
 }
 
 export const consoleAction = async () => {
+  await initI18n()
   // Reset lazy-loaded tools, context modules, and demand-driven caches at session start
   resetActiveTools()
   resetContextModules()
@@ -509,21 +515,26 @@ export const consoleAction = async () => {
   // Header
   chatLog.addChild(new Spacer(1))
   chatLog.addChild(
-    new Text(greenBold(`  SLV AI Console v${denoJson.version}`), 1),
+    new Text(
+      greenBold(`  ${t('SLV AI Console')} v${denoJson.version}`),
+      1,
+    ),
   )
   chatLog.addChild(
     new Text(
       white(
         config.provider === 'slv'
-          ? `  Provider: ${providerLabel}`
-          : `  Provider: ${providerLabel} | Model: ${config.model}`,
+          ? `  ${t('Provider:')} ${providerLabel}`
+          : `  ${t('Provider:')} ${providerLabel} | ${t('Model:')} ${config.model}`,
       ),
       1,
     ),
   )
   chatLog.addChild(
     new Text(
-      gray('  Type /exit to quit, /clear to reset. Press Enter to send.'),
+      gray(
+        `  ${t('Type /exit to quit, /clear to reset. Press Enter to send.')}`,
+      ),
       1,
     ),
   )
@@ -979,7 +990,7 @@ RULES:
     }
     tui.stop()
     await terminal.drainInput()
-    console.log('\n  Goodbye!\n')
+    console.log(`\n  ${t('Goodbye!')}\n`)
     Deno.exit(0)
   }
 

--- a/cli/src/ai/console/systemPrompt.ts
+++ b/cli/src/ai/console/systemPrompt.ts
@@ -2,6 +2,7 @@ import { parse } from '@std/yaml'
 import { resolveHome } from '/lib/getApiKeyFromYml.ts'
 import { VERSION } from '@cmn/constants/version.ts'
 import { DISCORD_LINK } from '@cmn/constants/url.ts'
+import { readLang } from '@/ai/config.ts'
 
 // --- Context module state management ---
 
@@ -441,6 +442,11 @@ This user operates in REMOTE mode. Deployments target remote servers via SSH.
     .map((s) => `${s.name} (${s.agent})`)
     .join(', ')
 
+  const preferredLang = await readLang().catch(() => 'en')
+  const languageRule = preferredLang === 'en'
+    ? `- Respond in the language of the user's current message. Do not switch to Japanese unless the current message is in Japanese.`
+    : `- The user's preferred language is "${preferredLang}". Respond in that language by default. If the user writes in a different language, match theirs.`
+
   return `You are the main SLV assistant for Solana node operators.
 You are the user's only visible point of contact.
 If SOUL.md defines a name, use it. Otherwise introduce yourself as "your SLV assistant".
@@ -457,7 +463,7 @@ ${modeSection}
 - Use bullet points instead of markdown tables.
 - Show payment or purchase links as the full URL on its own line.
 - Warn before destructive actions.
-- Respond in the language of the user's current message. Do not switch to Japanese unless the current message is in Japanese.
+${languageRule}
 ${
     configPresence.discordWebhook
       ? `- A Discord webhook is configured (\`notifications.discord_webhook\` in ~/.slv/api.yml). When you produce content the user is likely to save or share — payment links, benchmark summaries, deployment results, important URLs — proactively ask whether to post it to Discord and use \`send_notification\` when they confirm. Do not send silently, and do not read or display the webhook URL itself.`

--- a/cli/src/ai/i18n/index.ts
+++ b/cli/src/ai/i18n/index.ts
@@ -1,0 +1,159 @@
+import { messages as en } from '@/ai/i18n/messages/en.ts'
+import { messages as ja } from '@/ai/i18n/messages/ja.ts'
+import { messages as zh } from '@/ai/i18n/messages/zh.ts'
+import { messages as ru } from '@/ai/i18n/messages/ru.ts'
+import { messages as vi } from '@/ai/i18n/messages/vi.ts'
+import { readLang } from '@/ai/config.ts'
+import { dirname } from '@std/path'
+import { parse } from '@std/yaml'
+
+export const BUILTIN_LANGS: Record<string, Record<string, string>> = {
+  en,
+  ja,
+  zh,
+  ru,
+  vi,
+}
+
+let loaded: Record<string, string> = en
+let currentLang = 'en'
+let initialized = false
+
+const cachePath = (lang: string): string => {
+  const home = Deno.env.get('HOME') || ''
+  return `${home}/.slv/i18n/${lang}.json`
+}
+
+const loadCache = async (lang: string): Promise<Record<string, string> | null> => {
+  try {
+    const raw = await Deno.readTextFile(cachePath(lang))
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, string>
+    }
+  } catch { /* no cache */ }
+  return null
+}
+
+const saveCache = async (
+  lang: string,
+  dict: Record<string, string>,
+): Promise<void> => {
+  const path = cachePath(lang)
+  await Deno.mkdir(dirname(path), { recursive: true })
+  await Deno.writeTextFile(path, JSON.stringify(dict, null, 2))
+}
+
+const getSlvApiKey = async (): Promise<string | null> => {
+  const home = Deno.env.get('HOME')
+  if (!home) return null
+  try {
+    const raw = await Deno.readTextFile(`${home}/.slv/api.yml`)
+    const yml = parse(raw) as { slv?: { api_key?: string } } | null
+    const key = yml?.slv?.api_key
+    return typeof key === 'string' && key.trim().length > 0 ? key.trim() : null
+  } catch {
+    return null
+  }
+}
+
+// Batch-translate the English dictionary to `lang` via SLV AI.
+// Returns null if no API key or the call fails (caller falls back to English).
+const translateViaSlvAi = async (
+  lang: string,
+  dict: Record<string, string>,
+): Promise<Record<string, string> | null> => {
+  const apiKey = await getSlvApiKey()
+  if (!apiKey) return null
+
+  const sourceEntries = Object.entries(dict)
+  const sourceObj: Record<string, string> = {}
+  for (const [k, v] of sourceEntries) sourceObj[k] = v
+
+  const system =
+    `You are a professional translator. Translate the VALUES of the given JSON object from English to the target language. Keep the KEYS exactly unchanged. Preserve markdown, punctuation, emojis, backticks, URLs, and placeholders. Respond with ONLY the translated JSON object, no prose, no code fences.`
+  const user =
+    `Target language: ${lang}\n\nJSON:\n${JSON.stringify(sourceObj)}`
+
+  try {
+    const response = await fetch('https://user-api.erpc.global/v3/ai/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'slv-ai-default',
+        max_tokens: 8192,
+        system,
+        messages: [{ role: 'user', content: user }],
+      }),
+      signal: AbortSignal.timeout(120_000),
+    })
+    if (!response.ok) return null
+    const data = await response.json()
+    if (!data || !Array.isArray(data.content)) return null
+    let text = ''
+    for (const block of data.content) {
+      if (block?.type === 'text') text += block.text
+    }
+    text = text.trim()
+    // Strip accidental code fences just in case.
+    if (text.startsWith('```')) {
+      text = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '')
+    }
+    const parsed = JSON.parse(text) as Record<string, string>
+    if (!parsed || typeof parsed !== 'object') return null
+    // Fill any missing keys from the English source.
+    const merged: Record<string, string> = { ...dict }
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === 'string' && v.trim().length > 0) merged[k] = v
+    }
+    return merged
+  } catch {
+    return null
+  }
+}
+
+export const initI18n = async (): Promise<void> => {
+  currentLang = await readLang()
+  if (BUILTIN_LANGS[currentLang]) {
+    loaded = BUILTIN_LANGS[currentLang]
+    initialized = true
+    return
+  }
+  // Non-builtin: try cache, then AI translation, else fall back to English.
+  const cached = await loadCache(currentLang)
+  if (cached) {
+    loaded = { ...en, ...cached }
+    initialized = true
+    return
+  }
+  const translated = await translateViaSlvAi(currentLang, en)
+  if (translated) {
+    await saveCache(currentLang, translated).catch(() => {})
+    loaded = translated
+    initialized = true
+    return
+  }
+  // Fallback: English.
+  loaded = en
+  initialized = true
+}
+
+export const t = (key: string): string => {
+  if (!initialized) return key
+  return loaded[key] ?? key
+}
+
+export const getCurrentLang = (): string => currentLang
+
+// Language options shown in the onboard Select prompt.
+export const LANG_OPTIONS = [
+  { name: 'English', value: 'en' },
+  { name: '日本語 (Japanese)', value: 'ja' },
+  { name: '中文 (Chinese)', value: 'zh' },
+  { name: 'Русский (Russian)', value: 'ru' },
+  { name: 'Tiếng Việt (Vietnamese)', value: 'vi' },
+  { name: 'Other (type your language)', value: '__other__' },
+]

--- a/cli/src/ai/i18n/messages/en.ts
+++ b/cli/src/ai/i18n/messages/en.ts
@@ -1,0 +1,115 @@
+// English is the source of truth. Keys are the same as values so callers can
+// write `t('Some English text')` and fall back cleanly when no translation exists.
+
+export const messages: Record<string, string> = {
+  // --- Onboard ---
+  'SLV AI Onboarding': 'SLV AI Onboarding',
+  'Select your language': 'Select your language',
+  'Language saved. Please run `slv onboard` again to continue.':
+    'Language saved. Please run `slv onboard` again to continue.',
+
+  'Security warning — please read.': 'Security warning — please read.',
+  'SLV AI Console can execute commands on your system.':
+    'SLV AI Console can execute commands on your system.',
+  'A bad prompt can trick it into doing unsafe things.':
+    'A bad prompt can trick it into doing unsafe things.',
+  'Recommended:': 'Recommended:',
+  "- Don't paste untrusted prompts.": "- Don't paste untrusted prompts.",
+  '- `slv bot init` ships a Solana transaction sample designed to be improved with your AI before real use. When using real SOL, assets may decrease — use at your own risk.':
+    '- `slv bot init` ships a Solana transaction sample designed to be improved with your AI before real use. When using real SOL, assets may decrease — use at your own risk.',
+  '- Keep secrets out of the conversation.':
+    '- Keep secrets out of the conversation.',
+  'I understand this is powerful and inherently risky. Continue?':
+    'I understand this is powerful and inherently risky. Continue?',
+  'Yes': 'Yes',
+  'No': 'No',
+  'Setup cancelled.': 'Setup cancelled.',
+
+  'SLV API Key': 'SLV API Key',
+  'Get your free API key: https://discord.gg/S2gEbJTGJA':
+    'Get your free API key: https://discord.gg/S2gEbJTGJA',
+  '🔑 SLV API Key (or press Enter to skip)':
+    '🔑 SLV API Key (or press Enter to skip)',
+  'SLV API Key saved.': 'SLV API Key saved.',
+  'Skipped. You can run `slv login` later.':
+    'Skipped. You can run `slv login` later.',
+  'Using SLV AI (powered by your SLV API Key).':
+    'Using SLV AI (powered by your SLV API Key).',
+
+  'Agent Setup': 'Agent Setup',
+  'Your name': 'Your name',
+  'Name is required': 'Name is required',
+  'What should the AI call you?': 'What should the AI call you?',
+  'Name your main AI agent': 'Name your main AI agent',
+  'What will you be doing? (↑↓ move, Space toggle, Enter confirm)':
+    'What will you be doing? (↑↓ move, Space toggle, Enter confirm)',
+  'Deployment mode': 'Deployment mode',
+  'Local — deploy to this machine': 'Local — deploy to this machine',
+  'Remote — deploy to remote servers via SSH':
+    'Remote — deploy to remote servers via SSH',
+
+  'GitHub Setup (optional)': 'GitHub Setup (optional)',
+  'GitHub CLI already authenticated.': 'GitHub CLI already authenticated.',
+  'GitHub CLI (gh) not found. Install it from https://cli.github.com/':
+    'GitHub CLI (gh) not found. Install it from https://cli.github.com/',
+  'Skipped. You can set up GitHub later.':
+    'Skipped. You can set up GitHub later.',
+  'Set up GitHub authentication? (enables repo creation, PRs, etc.)':
+    'Set up GitHub authentication? (enables repo creation, PRs, etc.)',
+  'Yes — run gh auth login': 'Yes — run gh auth login',
+  'Skip for now': 'Skip for now',
+  'Running `gh auth login`...': 'Running `gh auth login`...',
+  'GitHub authenticated.': 'GitHub authenticated.',
+  'GitHub authentication failed. You can retry with `gh auth login`.':
+    'GitHub authentication failed. You can retry with `gh auth login`.',
+  'Skipped. You can run `gh auth login` later.':
+    'Skipped. You can run `gh auth login` later.',
+
+  'Notifications (optional)': 'Notifications (optional)',
+  'Discord Webhook URL for notifications (Enter to skip)':
+    'Discord Webhook URL for notifications (Enter to skip)',
+  'Discord Webhook saved to ~/.slv/api.yml':
+    'Discord Webhook saved to ~/.slv/api.yml',
+  'Skipped.': 'Skipped.',
+
+  'Agent files saved to ~/.slv/agent/':
+    'Agent files saved to ~/.slv/agent/',
+  'AI configuration saved to ~/.slv/api.yml':
+    'AI configuration saved to ~/.slv/api.yml',
+  'Agent:': 'Agent:',
+  'Run `slv c` to start the AI console.':
+    'Run `slv c` to start the AI console.',
+
+  // --- Bot init agreement ---
+  'slv bot init — trade-app is an example only':
+    'slv bot init — trade-app is an example only',
+  'The trade-app template is only an example of Solana on-chain transaction detection and submission. When the app starts, a wallet.json is created; trading begins once you deposit SOL into it, and your assets may decrease. Use this sample as a base for your own AI-assisted improvements — it can greatly reduce the effort of building Solana apps, but it is powerful and may cause financial loss in some cases.':
+    'The trade-app template is only an example of Solana on-chain transaction detection and submission. When the app starts, a wallet.json is created; trading begins once you deposit SOL into it, and your assets may decrease. Use this sample as a base for your own AI-assisted improvements — it can greatly reduce the effort of building Solana apps, but it is powerful and may cause financial loss in some cases.',
+  'I understand the above and will use it at my own risk.':
+    'I understand the above and will use it at my own risk.',
+  'bot init cancelled. You can run `slv bot init` again when ready.':
+    'bot init cancelled. You can run `slv bot init` again when ready.',
+
+  // --- AI Console ---
+  'SLV AI Console': 'SLV AI Console',
+  'Provider:': 'Provider:',
+  'Model:': 'Model:',
+  'Type /exit to quit, /clear to reset. Press Enter to send.':
+    'Type /exit to quit, /clear to reset. Press Enter to send.',
+  'Hey there! 👋': 'Hey there! 👋',
+  'Hey {name}! 👋': 'Hey {name}! 👋',
+  "I'm {agent}, your SLV commander.": "I'm {agent}, your SLV commander.",
+  "I'm your SLV assistant.": "I'm your SLV assistant.",
+  "Here's my crew:": "Here's my crew:",
+  'What would you like to work on today?':
+    'What would you like to work on today?',
+  'Solana Validator deployments & management':
+    'Solana Validator deployments & management',
+  'RPC nodes (Index RPC, gRPC Geyser, combos)':
+    'RPC nodes (Index RPC, gRPC Geyser, combos)',
+  'Trading bots & Solana apps': 'Trading bots & Solana apps',
+  'Find optimized Solana server resources':
+    'Find optimized Solana server resources',
+  'Benchmarks & connectivity testing': 'Benchmarks & connectivity testing',
+  'Goodbye!': 'Goodbye!',
+}

--- a/cli/src/ai/i18n/messages/ja.ts
+++ b/cli/src/ai/i18n/messages/ja.ts
@@ -1,0 +1,109 @@
+export const messages: Record<string, string> = {
+  'SLV AI Onboarding': 'SLV AI オンボーディング',
+  'Select your language': '言語を選択してください',
+  'Language saved. Please run `slv onboard` again to continue.':
+    '言語を保存しました。もう一度 `slv onboard` を実行してください。',
+
+  'Security warning — please read.': 'セキュリティに関する注意 — 必ずお読みください。',
+  'SLV AI Console can execute commands on your system.':
+    'SLV AI Console はあなたのシステム上でコマンドを実行できます。',
+  'A bad prompt can trick it into doing unsafe things.':
+    '悪意あるプロンプトにより、危険な動作を引き起こす可能性があります。',
+  'Recommended:': '推奨事項:',
+  "- Don't paste untrusted prompts.": '- 信頼できないプロンプトを貼り付けないでください。',
+  '- `slv bot init` ships a Solana transaction sample designed to be improved with your AI before real use. When using real SOL, assets may decrease — use at your own risk.':
+    '- `slv bot init` のテンプレは Solana トランザクションのサンプルです。お手元の AI で改善して使う前提でご利用ください。実際に SOL を利用する場合、資産が減ることがあるリスクを理解した上で使用してください。',
+  '- Keep secrets out of the conversation.':
+    '- 会話の中に機密情報を含めないでください。',
+  'I understand this is powerful and inherently risky. Continue?':
+    'これは強力でリスクを伴うことを理解しました。続行しますか？',
+  'Yes': 'はい',
+  'No': 'いいえ',
+  'Setup cancelled.': 'セットアップを中止しました。',
+
+  'SLV API Key': 'SLV API キー',
+  'Get your free API key: https://discord.gg/S2gEbJTGJA':
+    '無料 API キーの取得: https://discord.gg/S2gEbJTGJA',
+  '🔑 SLV API Key (or press Enter to skip)':
+    '🔑 SLV API キー（Enter でスキップ）',
+  'SLV API Key saved.': 'SLV API キーを保存しました。',
+  'Skipped. You can run `slv login` later.':
+    'スキップしました。後で `slv login` を実行できます。',
+  'Using SLV AI (powered by your SLV API Key).':
+    'SLV AI を使用します（SLV API キーで動作）。',
+
+  'Agent Setup': 'エージェント設定',
+  'Your name': 'あなたの名前',
+  'Name is required': '名前は必須です',
+  'What should the AI call you?': 'AI に何と呼ばれたいですか？',
+  'Name your main AI agent': 'メイン AI エージェントの名前',
+  'What will you be doing? (↑↓ move, Space toggle, Enter confirm)':
+    '何に使いますか？（↑↓ 移動、Space 選択、Enter 確定）',
+  'Deployment mode': 'デプロイモード',
+  'Local — deploy to this machine': 'ローカル — このマシンにデプロイ',
+  'Remote — deploy to remote servers via SSH':
+    'リモート — SSH 経由でリモートサーバーにデプロイ',
+
+  'GitHub Setup (optional)': 'GitHub 設定（任意）',
+  'GitHub CLI already authenticated.': 'GitHub CLI は既に認証済みです。',
+  'GitHub CLI (gh) not found. Install it from https://cli.github.com/':
+    'GitHub CLI (gh) が見つかりません。https://cli.github.com/ からインストールしてください。',
+  'Skipped. You can set up GitHub later.':
+    'スキップしました。後で GitHub を設定できます。',
+  'Set up GitHub authentication? (enables repo creation, PRs, etc.)':
+    'GitHub 認証を設定しますか？（リポジトリ作成、PR などが可能に）',
+  'Yes — run gh auth login': 'はい — `gh auth login` を実行',
+  'Skip for now': '今はスキップ',
+  'Running `gh auth login`...': '`gh auth login` を実行中...',
+  'GitHub authenticated.': 'GitHub 認証完了。',
+  'GitHub authentication failed. You can retry with `gh auth login`.':
+    'GitHub 認証に失敗しました。`gh auth login` で再試行してください。',
+  'Skipped. You can run `gh auth login` later.':
+    'スキップしました。後で `gh auth login` を実行できます。',
+
+  'Notifications (optional)': '通知設定（任意）',
+  'Discord Webhook URL for notifications (Enter to skip)':
+    '通知用 Discord Webhook URL（Enter でスキップ）',
+  'Discord Webhook saved to ~/.slv/api.yml':
+    'Discord Webhook を ~/.slv/api.yml に保存しました',
+  'Skipped.': 'スキップしました。',
+
+  'Agent files saved to ~/.slv/agent/':
+    'エージェントファイルを ~/.slv/agent/ に保存しました',
+  'AI configuration saved to ~/.slv/api.yml':
+    'AI 設定を ~/.slv/api.yml に保存しました',
+  'Agent:': 'エージェント:',
+  'Run `slv c` to start the AI console.':
+    'AI コンソールを起動するには `slv c` を実行してください。',
+
+  'slv bot init — trade-app is an example only':
+    'slv bot init — trade-app はサンプルです',
+  'The trade-app template is only an example of Solana on-chain transaction detection and submission. When the app starts, a wallet.json is created; trading begins once you deposit SOL into it, and your assets may decrease. Use this sample as a base for your own AI-assisted improvements — it can greatly reduce the effort of building Solana apps, but it is powerful and may cause financial loss in some cases.':
+    'trade-app はあくまでも Solana チェーンを使ったトランザクションの検知・送信などの例です。アプリを起動したときに wallet.json が作成され、そこに SOL をデポジットすることでトレードが始まり、資産が減る場合があることを理解してください。このサンプルをもとにお手元の AI で改善を進めることで、Solana アプリ構築の手間を大幅に削減できるはずです。しかし、これはとてもパワフルで、場合によっては資産を減らすことがあることを理解してください。',
+  'I understand the above and will use it at my own risk.':
+    '上記のことを理解した上で使用します。',
+  'bot init cancelled. You can run `slv bot init` again when ready.':
+    'bot init を中止しました。準備ができたら再度 `slv bot init` を実行してください。',
+
+  'SLV AI Console': 'SLV AI コンソール',
+  'Provider:': 'プロバイダー:',
+  'Model:': 'モデル:',
+  'Type /exit to quit, /clear to reset. Press Enter to send.':
+    '/exit で終了、/clear でリセット。Enter で送信します。',
+  'Hey there! 👋': 'こんにちは！👋',
+  'Hey {name}! 👋': 'こんにちは、{name}さん！👋',
+  "I'm {agent}, your SLV commander.": '私は {agent}、あなたの SLV コマンダーです。',
+  "I'm your SLV assistant.": '私はあなたの SLV アシスタントです。',
+  "Here's my crew:": '私のクルーを紹介します:',
+  'What would you like to work on today?':
+    '今日は何を進めましょうか？',
+  'Solana Validator deployments & management':
+    'Solana バリデータのデプロイと管理',
+  'RPC nodes (Index RPC, gRPC Geyser, combos)':
+    'RPC ノード (Index RPC、gRPC Geyser、組み合わせ)',
+  'Trading bots & Solana apps': 'トレードボットと Solana アプリ',
+  'Find optimized Solana server resources':
+    '最適な Solana サーバーリソースの調達',
+  'Benchmarks & connectivity testing': 'ベンチマークと接続性テスト',
+  'Goodbye!': 'さようなら！',
+}

--- a/cli/src/ai/i18n/messages/ru.ts
+++ b/cli/src/ai/i18n/messages/ru.ts
@@ -1,0 +1,110 @@
+export const messages: Record<string, string> = {
+  'SLV AI Onboarding': 'Настройка SLV AI',
+  'Select your language': 'Выберите язык',
+  'Language saved. Please run `slv onboard` again to continue.':
+    'Язык сохранён. Пожалуйста, запустите `slv onboard` снова, чтобы продолжить.',
+
+  'Security warning — please read.': 'Предупреждение о безопасности — прочтите.',
+  'SLV AI Console can execute commands on your system.':
+    'SLV AI Console может выполнять команды в вашей системе.',
+  'A bad prompt can trick it into doing unsafe things.':
+    'Вредоносный запрос может заставить его выполнить небезопасные действия.',
+  'Recommended:': 'Рекомендуется:',
+  "- Don't paste untrusted prompts.": '- Не вставляйте непроверенные запросы.',
+  '- `slv bot init` ships a Solana transaction sample designed to be improved with your AI before real use. When using real SOL, assets may decrease — use at your own risk.':
+    '- `slv bot init` предоставляет образец транзакций Solana, который предполагается доработать вашим ИИ перед реальным использованием. При использовании настоящих SOL активы могут уменьшиться — используйте на свой страх и риск.',
+  '- Keep secrets out of the conversation.':
+    '- Не включайте секреты в диалог.',
+  'I understand this is powerful and inherently risky. Continue?':
+    'Я понимаю, что это мощный и рискованный инструмент. Продолжить?',
+  'Yes': 'Да',
+  'No': 'Нет',
+  'Setup cancelled.': 'Настройка отменена.',
+
+  'SLV API Key': 'SLV API ключ',
+  'Get your free API key: https://discord.gg/S2gEbJTGJA':
+    'Получите бесплатный API-ключ: https://discord.gg/S2gEbJTGJA',
+  '🔑 SLV API Key (or press Enter to skip)':
+    '🔑 SLV API ключ (Enter чтобы пропустить)',
+  'SLV API Key saved.': 'SLV API ключ сохранён.',
+  'Skipped. You can run `slv login` later.':
+    'Пропущено. Вы можете позже запустить `slv login`.',
+  'Using SLV AI (powered by your SLV API Key).':
+    'Используется SLV AI (на базе вашего SLV API ключа).',
+
+  'Agent Setup': 'Настройка агента',
+  'Your name': 'Ваше имя',
+  'Name is required': 'Имя обязательно',
+  'What should the AI call you?': 'Как ИИ должен к вам обращаться?',
+  'Name your main AI agent': 'Имя главного ИИ-агента',
+  'What will you be doing? (↑↓ move, Space toggle, Enter confirm)':
+    'Чем вы будете заниматься? (↑↓ перемещение, Space выбор, Enter подтверждение)',
+  'Deployment mode': 'Режим развёртывания',
+  'Local — deploy to this machine': 'Локально — развернуть на этой машине',
+  'Remote — deploy to remote servers via SSH':
+    'Удалённо — развернуть на удалённые серверы через SSH',
+
+  'GitHub Setup (optional)': 'Настройка GitHub (необязательно)',
+  'GitHub CLI already authenticated.': 'GitHub CLI уже авторизован.',
+  'GitHub CLI (gh) not found. Install it from https://cli.github.com/':
+    'GitHub CLI (gh) не найден. Установите с https://cli.github.com/',
+  'Skipped. You can set up GitHub later.':
+    'Пропущено. Вы можете настроить GitHub позже.',
+  'Set up GitHub authentication? (enables repo creation, PRs, etc.)':
+    'Настроить аутентификацию GitHub? (создание репозиториев, PR и т.д.)',
+  'Yes — run gh auth login': 'Да — запустить gh auth login',
+  'Skip for now': 'Пропустить пока',
+  'Running `gh auth login`...': 'Запуск `gh auth login`...',
+  'GitHub authenticated.': 'GitHub авторизован.',
+  'GitHub authentication failed. You can retry with `gh auth login`.':
+    'Ошибка аутентификации GitHub. Повторите с `gh auth login`.',
+  'Skipped. You can run `gh auth login` later.':
+    'Пропущено. Вы можете позже запустить `gh auth login`.',
+
+  'Notifications (optional)': 'Уведомления (необязательно)',
+  'Discord Webhook URL for notifications (Enter to skip)':
+    'Discord Webhook URL для уведомлений (Enter чтобы пропустить)',
+  'Discord Webhook saved to ~/.slv/api.yml':
+    'Discord Webhook сохранён в ~/.slv/api.yml',
+  'Skipped.': 'Пропущено.',
+
+  'Agent files saved to ~/.slv/agent/':
+    'Файлы агента сохранены в ~/.slv/agent/',
+  'AI configuration saved to ~/.slv/api.yml':
+    'Конфигурация ИИ сохранена в ~/.slv/api.yml',
+  'Agent:': 'Агент:',
+  'Run `slv c` to start the AI console.':
+    'Запустите `slv c`, чтобы открыть консоль ИИ.',
+
+  'slv bot init — trade-app is an example only':
+    'slv bot init — trade-app является лишь примером',
+  'The trade-app template is only an example of Solana on-chain transaction detection and submission. When the app starts, a wallet.json is created; trading begins once you deposit SOL into it, and your assets may decrease. Use this sample as a base for your own AI-assisted improvements — it can greatly reduce the effort of building Solana apps, but it is powerful and may cause financial loss in some cases.':
+    'Шаблон trade-app — это лишь пример обнаружения и отправки транзакций в сети Solana. При запуске приложения создаётся wallet.json; торговля начинается после того, как вы внесёте на него SOL, и ваши средства могут уменьшиться. Используйте этот пример как основу для доработки вашим ИИ — это значительно сократит усилия по созданию Solana-приложений. Однако он очень мощный и в некоторых случаях может привести к финансовым потерям.',
+  'I understand the above and will use it at my own risk.':
+    'Я понимаю вышеуказанное и использую это на свой страх и риск.',
+  'bot init cancelled. You can run `slv bot init` again when ready.':
+    'bot init отменён. Вы можете запустить `slv bot init` снова, когда будете готовы.',
+
+  'SLV AI Console': 'SLV AI Консоль',
+  'Provider:': 'Провайдер:',
+  'Model:': 'Модель:',
+  'Type /exit to quit, /clear to reset. Press Enter to send.':
+    'Введите /exit для выхода, /clear для сброса. Нажмите Enter для отправки.',
+  'Hey there! 👋': 'Привет! 👋',
+  'Hey {name}! 👋': 'Привет, {name}! 👋',
+  "I'm {agent}, your SLV commander.": 'Я {agent}, ваш SLV командир.',
+  "I'm your SLV assistant.": 'Я ваш SLV ассистент.',
+  "Here's my crew:": 'Вот моя команда:',
+  'What would you like to work on today?':
+    'Над чем хотите поработать сегодня?',
+  'Solana Validator deployments & management':
+    'Развёртывание и управление валидаторами Solana',
+  'RPC nodes (Index RPC, gRPC Geyser, combos)':
+    'RPC-узлы (Index RPC, gRPC Geyser, комбо)',
+  'Trading bots & Solana apps': 'Торговые боты и приложения Solana',
+  'Find optimized Solana server resources':
+    'Поиск оптимальных серверных ресурсов Solana',
+  'Benchmarks & connectivity testing':
+    'Бенчмарки и тестирование соединения',
+  'Goodbye!': 'До свидания!',
+}

--- a/cli/src/ai/i18n/messages/vi.ts
+++ b/cli/src/ai/i18n/messages/vi.ts
@@ -1,0 +1,110 @@
+export const messages: Record<string, string> = {
+  'SLV AI Onboarding': 'Cài đặt SLV AI',
+  'Select your language': 'Chọn ngôn ngữ của bạn',
+  'Language saved. Please run `slv onboard` again to continue.':
+    'Đã lưu ngôn ngữ. Vui lòng chạy lại `slv onboard` để tiếp tục.',
+
+  'Security warning — please read.': 'Cảnh báo bảo mật — vui lòng đọc.',
+  'SLV AI Console can execute commands on your system.':
+    'SLV AI Console có thể thực thi lệnh trên hệ thống của bạn.',
+  'A bad prompt can trick it into doing unsafe things.':
+    'Một prompt xấu có thể khiến nó thực hiện những việc không an toàn.',
+  'Recommended:': 'Khuyến nghị:',
+  "- Don't paste untrusted prompts.": '- Không dán các prompt không đáng tin cậy.',
+  '- `slv bot init` ships a Solana transaction sample designed to be improved with your AI before real use. When using real SOL, assets may decrease — use at your own risk.':
+    '- `slv bot init` cung cấp mẫu giao dịch Solana, được thiết kế để bạn cải tiến bằng AI của mình trước khi sử dụng thực tế. Khi dùng SOL thật, tài sản có thể giảm — vui lòng tự chịu rủi ro khi sử dụng.',
+  '- Keep secrets out of the conversation.':
+    '- Không đưa thông tin bí mật vào hội thoại.',
+  'I understand this is powerful and inherently risky. Continue?':
+    'Tôi hiểu điều này mạnh mẽ và tiềm ẩn rủi ro. Tiếp tục?',
+  'Yes': 'Có',
+  'No': 'Không',
+  'Setup cancelled.': 'Đã hủy cài đặt.',
+
+  'SLV API Key': 'Khóa SLV API',
+  'Get your free API key: https://discord.gg/S2gEbJTGJA':
+    'Nhận khóa API miễn phí: https://discord.gg/S2gEbJTGJA',
+  '🔑 SLV API Key (or press Enter to skip)':
+    '🔑 Khóa SLV API (nhấn Enter để bỏ qua)',
+  'SLV API Key saved.': 'Đã lưu khóa SLV API.',
+  'Skipped. You can run `slv login` later.':
+    'Đã bỏ qua. Bạn có thể chạy `slv login` sau.',
+  'Using SLV AI (powered by your SLV API Key).':
+    'Đang sử dụng SLV AI (dùng khóa SLV API của bạn).',
+
+  'Agent Setup': 'Cài đặt Agent',
+  'Your name': 'Tên của bạn',
+  'Name is required': 'Tên là bắt buộc',
+  'What should the AI call you?': 'AI nên gọi bạn là gì?',
+  'Name your main AI agent': 'Đặt tên cho AI agent chính',
+  'What will you be doing? (↑↓ move, Space toggle, Enter confirm)':
+    'Bạn sẽ làm gì? (↑↓ di chuyển, Space chọn, Enter xác nhận)',
+  'Deployment mode': 'Chế độ triển khai',
+  'Local — deploy to this machine': 'Local — triển khai trên máy này',
+  'Remote — deploy to remote servers via SSH':
+    'Remote — triển khai lên máy chủ từ xa qua SSH',
+
+  'GitHub Setup (optional)': 'Cài đặt GitHub (tùy chọn)',
+  'GitHub CLI already authenticated.': 'GitHub CLI đã được xác thực.',
+  'GitHub CLI (gh) not found. Install it from https://cli.github.com/':
+    'Không tìm thấy GitHub CLI (gh). Cài đặt từ https://cli.github.com/',
+  'Skipped. You can set up GitHub later.':
+    'Đã bỏ qua. Bạn có thể cài đặt GitHub sau.',
+  'Set up GitHub authentication? (enables repo creation, PRs, etc.)':
+    'Cài đặt xác thực GitHub? (cho phép tạo repo, PR, v.v.)',
+  'Yes — run gh auth login': 'Có — chạy gh auth login',
+  'Skip for now': 'Bỏ qua lúc này',
+  'Running `gh auth login`...': 'Đang chạy `gh auth login`...',
+  'GitHub authenticated.': 'GitHub đã được xác thực.',
+  'GitHub authentication failed. You can retry with `gh auth login`.':
+    'Xác thực GitHub thất bại. Bạn có thể thử lại với `gh auth login`.',
+  'Skipped. You can run `gh auth login` later.':
+    'Đã bỏ qua. Bạn có thể chạy `gh auth login` sau.',
+
+  'Notifications (optional)': 'Thông báo (tùy chọn)',
+  'Discord Webhook URL for notifications (Enter to skip)':
+    'URL Discord Webhook cho thông báo (Enter để bỏ qua)',
+  'Discord Webhook saved to ~/.slv/api.yml':
+    'Đã lưu Discord Webhook vào ~/.slv/api.yml',
+  'Skipped.': 'Đã bỏ qua.',
+
+  'Agent files saved to ~/.slv/agent/':
+    'Đã lưu tệp agent vào ~/.slv/agent/',
+  'AI configuration saved to ~/.slv/api.yml':
+    'Đã lưu cấu hình AI vào ~/.slv/api.yml',
+  'Agent:': 'Agent:',
+  'Run `slv c` to start the AI console.':
+    'Chạy `slv c` để khởi động AI console.',
+
+  'slv bot init — trade-app is an example only':
+    'slv bot init — trade-app chỉ là ví dụ',
+  'The trade-app template is only an example of Solana on-chain transaction detection and submission. When the app starts, a wallet.json is created; trading begins once you deposit SOL into it, and your assets may decrease. Use this sample as a base for your own AI-assisted improvements — it can greatly reduce the effort of building Solana apps, but it is powerful and may cause financial loss in some cases.':
+    'Template trade-app chỉ là một ví dụ về việc phát hiện và gửi giao dịch trên chuỗi Solana. Khi ứng dụng khởi động, một wallet.json sẽ được tạo; giao dịch bắt đầu khi bạn nạp SOL vào đó, và tài sản của bạn có thể giảm. Hãy sử dụng ví dụ này làm nền tảng để cải tiến với AI của bạn — nó có thể giảm đáng kể công sức xây dựng ứng dụng Solana. Tuy nhiên, nó rất mạnh mẽ và trong một số trường hợp có thể gây thiệt hại tài chính.',
+  'I understand the above and will use it at my own risk.':
+    'Tôi hiểu những điều trên và sử dụng với rủi ro của bản thân.',
+  'bot init cancelled. You can run `slv bot init` again when ready.':
+    'Đã hủy bot init. Bạn có thể chạy lại `slv bot init` khi sẵn sàng.',
+
+  'SLV AI Console': 'Bảng điều khiển SLV AI',
+  'Provider:': 'Nhà cung cấp:',
+  'Model:': 'Mô hình:',
+  'Type /exit to quit, /clear to reset. Press Enter to send.':
+    'Gõ /exit để thoát, /clear để đặt lại. Nhấn Enter để gửi.',
+  'Hey there! 👋': 'Xin chào! 👋',
+  'Hey {name}! 👋': 'Xin chào, {name}! 👋',
+  "I'm {agent}, your SLV commander.": 'Tôi là {agent}, chỉ huy SLV của bạn.',
+  "I'm your SLV assistant.": 'Tôi là trợ lý SLV của bạn.',
+  "Here's my crew:": 'Đây là đội của tôi:',
+  'What would you like to work on today?':
+    'Hôm nay bạn muốn làm gì?',
+  'Solana Validator deployments & management':
+    'Triển khai & quản lý Solana Validator',
+  'RPC nodes (Index RPC, gRPC Geyser, combos)':
+    'Nút RPC (Index RPC, gRPC Geyser, kết hợp)',
+  'Trading bots & Solana apps': 'Bot giao dịch & ứng dụng Solana',
+  'Find optimized Solana server resources':
+    'Tìm tài nguyên máy chủ Solana tối ưu',
+  'Benchmarks & connectivity testing':
+    'Kiểm thử hiệu năng & kết nối',
+  'Goodbye!': 'Tạm biệt!',
+}

--- a/cli/src/ai/i18n/messages/zh.ts
+++ b/cli/src/ai/i18n/messages/zh.ts
@@ -1,0 +1,105 @@
+export const messages: Record<string, string> = {
+  'SLV AI Onboarding': 'SLV AI 初始化',
+  'Select your language': '请选择语言',
+  'Language saved. Please run `slv onboard` again to continue.':
+    '语言已保存。请再次运行 `slv onboard` 以继续。',
+
+  'Security warning — please read.': '安全警告 — 请阅读。',
+  'SLV AI Console can execute commands on your system.':
+    'SLV AI Console 可以在您的系统上执行命令。',
+  'A bad prompt can trick it into doing unsafe things.':
+    '恶意提示可能会诱使其执行不安全的操作。',
+  'Recommended:': '建议:',
+  "- Don't paste untrusted prompts.": '- 请勿粘贴不受信任的提示。',
+  '- `slv bot init` ships a Solana transaction sample designed to be improved with your AI before real use. When using real SOL, assets may decrease — use at your own risk.':
+    '- `slv bot init` 提供的是 Solana 交易示例模板，设计为先用您的 AI 改进后再实际使用。使用真实 SOL 时，资产可能减少，请自行承担风险。',
+  '- Keep secrets out of the conversation.': '- 不要在对话中包含敏感信息。',
+  'I understand this is powerful and inherently risky. Continue?':
+    '我了解其功能强大并存在风险。继续吗？',
+  'Yes': '是',
+  'No': '否',
+  'Setup cancelled.': '已取消设置。',
+
+  'SLV API Key': 'SLV API 密钥',
+  'Get your free API key: https://discord.gg/S2gEbJTGJA':
+    '获取免费 API 密钥: https://discord.gg/S2gEbJTGJA',
+  '🔑 SLV API Key (or press Enter to skip)': '🔑 SLV API 密钥（按 Enter 跳过）',
+  'SLV API Key saved.': 'SLV API 密钥已保存。',
+  'Skipped. You can run `slv login` later.':
+    '已跳过。您可以稍后运行 `slv login`。',
+  'Using SLV AI (powered by your SLV API Key).':
+    '使用 SLV AI（由您的 SLV API 密钥驱动）。',
+
+  'Agent Setup': '代理设置',
+  'Your name': '您的姓名',
+  'Name is required': '姓名为必填项',
+  'What should the AI call you?': 'AI 应如何称呼您？',
+  'Name your main AI agent': '为您的主 AI 代理命名',
+  'What will you be doing? (↑↓ move, Space toggle, Enter confirm)':
+    '您将用于什么？（↑↓ 移动，空格切换，Enter 确认）',
+  'Deployment mode': '部署模式',
+  'Local — deploy to this machine': '本地 — 部署到本机',
+  'Remote — deploy to remote servers via SSH':
+    '远程 — 通过 SSH 部署到远程服务器',
+
+  'GitHub Setup (optional)': 'GitHub 设置（可选）',
+  'GitHub CLI already authenticated.': 'GitHub CLI 已认证。',
+  'GitHub CLI (gh) not found. Install it from https://cli.github.com/':
+    '未找到 GitHub CLI (gh)。请从 https://cli.github.com/ 安装。',
+  'Skipped. You can set up GitHub later.': '已跳过。您可以稍后设置 GitHub。',
+  'Set up GitHub authentication? (enables repo creation, PRs, etc.)':
+    '设置 GitHub 认证？（启用仓库创建、PR 等）',
+  'Yes — run gh auth login': '是 — 运行 gh auth login',
+  'Skip for now': '暂时跳过',
+  'Running `gh auth login`...': '正在运行 `gh auth login`...',
+  'GitHub authenticated.': 'GitHub 已认证。',
+  'GitHub authentication failed. You can retry with `gh auth login`.':
+    'GitHub 认证失败。您可以使用 `gh auth login` 重试。',
+  'Skipped. You can run `gh auth login` later.':
+    '已跳过。您可以稍后运行 `gh auth login`。',
+
+  'Notifications (optional)': '通知（可选）',
+  'Discord Webhook URL for notifications (Enter to skip)':
+    '用于通知的 Discord Webhook URL（Enter 跳过）',
+  'Discord Webhook saved to ~/.slv/api.yml':
+    'Discord Webhook 已保存到 ~/.slv/api.yml',
+  'Skipped.': '已跳过。',
+
+  'Agent files saved to ~/.slv/agent/':
+    '代理文件已保存到 ~/.slv/agent/',
+  'AI configuration saved to ~/.slv/api.yml':
+    'AI 配置已保存到 ~/.slv/api.yml',
+  'Agent:': '代理:',
+  'Run `slv c` to start the AI console.':
+    '运行 `slv c` 启动 AI 控制台。',
+
+  'slv bot init — trade-app is an example only':
+    'slv bot init — trade-app 仅为示例',
+  'The trade-app template is only an example of Solana on-chain transaction detection and submission. When the app starts, a wallet.json is created; trading begins once you deposit SOL into it, and your assets may decrease. Use this sample as a base for your own AI-assisted improvements — it can greatly reduce the effort of building Solana apps, but it is powerful and may cause financial loss in some cases.':
+    'trade-app 模板只是 Solana 链上交易检测与提交的示例。应用启动时会创建 wallet.json；一旦您向其中存入 SOL，交易便会开始，您的资产可能会减少。请将此示例作为基础，结合您手头的 AI 进行改进 — 这将大幅减少构建 Solana 应用的工作量。但是，它非常强大，在某些情况下可能导致资金损失，请务必理解这一点。',
+  'I understand the above and will use it at my own risk.':
+    '我已理解上述内容，并自行承担风险使用。',
+  'bot init cancelled. You can run `slv bot init` again when ready.':
+    '已取消 bot init。准备好后可再次运行 `slv bot init`。',
+
+  'SLV AI Console': 'SLV AI 控制台',
+  'Provider:': '提供商:',
+  'Model:': '模型:',
+  'Type /exit to quit, /clear to reset. Press Enter to send.':
+    '输入 /exit 退出，/clear 重置。按 Enter 发送。',
+  'Hey there! 👋': '你好！👋',
+  'Hey {name}! 👋': '你好，{name}！👋',
+  "I'm {agent}, your SLV commander.": '我是 {agent}，您的 SLV 指挥官。',
+  "I'm your SLV assistant.": '我是您的 SLV 助手。',
+  "Here's my crew:": '这是我的团队:',
+  'What would you like to work on today?': '今天想做什么？',
+  'Solana Validator deployments & management':
+    'Solana 验证者部署与管理',
+  'RPC nodes (Index RPC, gRPC Geyser, combos)':
+    'RPC 节点 (Index RPC、gRPC Geyser、组合)',
+  'Trading bots & Solana apps': '交易机器人与 Solana 应用',
+  'Find optimized Solana server resources':
+    '寻找最优 Solana 服务器资源',
+  'Benchmarks & connectivity testing': '基准测试与连通性测试',
+  'Goodbye!': '再见！',
+}

--- a/cli/src/ai/onboard/onboardAction.ts
+++ b/cli/src/ai/onboard/onboardAction.ts
@@ -6,9 +6,95 @@ import denoJson from '/deno.json' with { type: 'json' }
 import {
   type AiProvider,
   // ANTHROPIC_MODELS and OPENAI_MODELS available via manual ~/.slv/api.yml config
+  hasLangSet,
+  readLang,
   writeAiConfig,
+  writeLang,
 } from '@/ai/config.ts'
+import { BUILTIN_LANGS, initI18n, t } from '@/ai/i18n/index.ts'
 import { isValidApiKey, resolveHome } from '/lib/getApiKeyFromYml.ts'
+
+// Approximate monospace display width: CJK/wide characters take 2 columns,
+// combining marks take 0, most others 1. Used to pad i18n lines inside boxes
+// so translated strings (Japanese, Chinese, …) don't break the borders.
+const displayWidth = (text: string): number => {
+  let w = 0
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0
+    if (cp === 0) continue
+    // Combining marks
+    if ((cp >= 0x0300 && cp <= 0x036f) || (cp >= 0x1ab0 && cp <= 0x1aff)) {
+      continue
+    }
+    // Wide ranges: CJK, Hangul, full-width forms, emoji presentation, etc.
+    if (
+      (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+      (cp >= 0x2e80 && cp <= 0x303e) || // CJK Radicals, Kangxi
+      (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana/Katakana/CJK symbols
+      (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Ext A
+      (cp >= 0x4e00 && cp <= 0x9fff) || // CJK Unified
+      (cp >= 0xa000 && cp <= 0xa4cf) || // Yi
+      (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
+      (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compat Ideographs
+      (cp >= 0xfe30 && cp <= 0xfe4f) || // CJK Compat Forms
+      (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth Forms
+      (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth signs
+      (cp >= 0x1f300 && cp <= 0x1f64f) || // Misc Symbols / Emoji
+      (cp >= 0x1f680 && cp <= 0x1f6ff) || // Transport
+      (cp >= 0x1f900 && cp <= 0x1f9ff) || // Supplemental Symbols
+      (cp >= 0x20000 && cp <= 0x2fffd) // CJK Ext B-F
+    ) {
+      w += 2
+      continue
+    }
+    w += 1
+  }
+  return w
+}
+
+// Wrap a plain (unstyled) string into lines that fit `maxWidth` display cells.
+// Breaks on spaces when possible; falls back to hard-cut for long CJK runs.
+const wrapToWidth = (text: string, maxWidth: number): string[] => {
+  const lines: string[] = []
+  const words = text.split(/(\s+)/) // keep whitespace tokens
+  let current = ''
+  let currentW = 0
+  const flush = () => {
+    if (current.length > 0) {
+      lines.push(current)
+      current = ''
+      currentW = 0
+    }
+  }
+  for (const tok of words) {
+    const tw = displayWidth(tok)
+    if (currentW + tw <= maxWidth) {
+      current += tok
+      currentW += tw
+      continue
+    }
+    if (tok.trim().length === 0) {
+      flush()
+      continue
+    }
+    // Token doesn't fit — if current has content, break first.
+    if (currentW > 0) flush()
+    if (tw <= maxWidth) {
+      current = tok
+      currentW = tw
+      continue
+    }
+    // Hard-cut long token character-by-character.
+    for (const ch of tok) {
+      const cw = displayWidth(ch)
+      if (currentW + cw > maxWidth) flush()
+      current += ch
+      currentW += cw
+    }
+  }
+  flush()
+  return lines.length > 0 ? lines : ['']
+}
 
 const printSecurityWarning = () => {
   const w = 72
@@ -19,9 +105,21 @@ const printSecurityWarning = () => {
       /\x1b\[[0-9;]*m/g,
       '',
     )
-    const pad = w - 2 - stripped.length
+    const pad = w - 2 - displayWidth(stripped)
     return border('│') + ' ' + text + ' '.repeat(Math.max(0, pad - 1)) +
       border('│')
+  }
+  // Print a possibly-wrapped translated string as one or more box lines. The
+  // colorize callback is applied to each wrapped segment so styling is
+  // preserved across lines.
+  const printWrapped = (
+    raw: string,
+    colorize: (s: string) => string,
+  ): void => {
+    const innerWidth = w - 4 // 2 borders + leading space + trailing space
+    for (const seg of wrapToWidth(raw, innerWidth)) {
+      console.log(line(colorize(seg)))
+    }
   }
 
   console.log()
@@ -29,48 +127,31 @@ const printSecurityWarning = () => {
     border('┌─ Security ') + border('─'.repeat(w - 13)) + border('┐'),
   )
   console.log(line(''))
-  console.log(
-    line(
-      colors.bold.white('Security warning — please read.'),
-    ),
+  printWrapped(t('Security warning — please read.'), (s) => colors.bold.white(s))
+  console.log(line(''))
+  printWrapped(
+    t('SLV AI Console can execute commands on your system.'),
+    (s) => colors.white(s),
+  )
+  printWrapped(
+    t('A bad prompt can trick it into doing unsafe things.'),
+    (s) => colors.white(s),
   )
   console.log(line(''))
-  console.log(
-    line(
-      colors.white(
-        'SLV AI Console can execute commands on your system.',
-      ),
-    ),
+  printWrapped(t('Recommended:'), (s) => colors.white(s))
+  printWrapped(
+    t("- Don't paste untrusted prompts."),
+    (s) => colors.white(s),
   )
-  console.log(
-    line(
-      colors.white(
-        'A bad prompt can trick it into doing unsafe things.',
-      ),
-    ),
+  printWrapped(
+    t('- Keep secrets out of the conversation.'),
+    (s) => colors.white(s),
   )
-  console.log(line(''))
-  console.log(
-    line(colors.white('Recommended:')),
-  )
-  console.log(
-    line(
-      colors.white(
-        '- Review commands before confirming execution.',
-      ),
+  printWrapped(
+    t(
+      '- `slv bot init` ships a Solana transaction sample designed to be improved with your AI before real use. When using real SOL, assets may decrease — use at your own risk.',
     ),
-  )
-  console.log(
-    line(
-      colors.white("- Don't paste untrusted prompts."),
-    ),
-  )
-  console.log(
-    line(
-      colors.white(
-        '- Keep secrets out of the conversation.',
-      ),
-    ),
+    (s) => colors.white(s),
   )
   console.log(line(''))
   console.log(
@@ -88,6 +169,70 @@ const SKILL_MAP: Record<string, { name: string; agent: string }> = {
   'Server Procurement': { name: 'slv-server-procurement', agent: 'Figaro' },
 }
 
+type ExistingDefaults = {
+  userName?: string
+  callMe?: string
+  agentName?: string
+  enabledOps?: string[]
+  deployMode?: 'local' | 'remote'
+  discordWebhook?: string
+}
+
+const loadExistingDefaults = async (
+  home: string,
+): Promise<ExistingDefaults> => {
+  const agentDir = `${home}/.slv/agent`
+  const defaults: ExistingDefaults = {}
+
+  try {
+    const userMd = await Deno.readTextFile(`${agentDir}/USER.md`)
+    const nameMatch = userMd.match(/\*\*Name:\*\*\s*(.+)/)
+    const callMatch = userMd.match(/\*\*Call me:\*\*\s*(.+)/)
+    if (nameMatch) defaults.userName = nameMatch[1].trim()
+    if (callMatch) defaults.callMe = callMatch[1].trim()
+  } catch { /* no USER.md */ }
+
+  try {
+    const soulMd = await Deno.readTextFile(`${agentDir}/SOUL.md`)
+    const nameMatch = soulMd.match(/\*\*Name:\*\*\s*(.+)/)
+    if (nameMatch) defaults.agentName = nameMatch[1].trim()
+  } catch { /* no SOUL.md */ }
+
+  try {
+    const raw = await Deno.readTextFile(`${agentDir}/config.yml`)
+    const cfg = parse(raw) as {
+      skills?: { name: string; enabled: boolean }[]
+      mode?: string
+    } | null
+    if (cfg?.skills?.length) {
+      // Reverse-map skill name → onboarding op label.
+      const nameToOp: Record<string, string> = {}
+      for (const [op, meta] of Object.entries(SKILL_MAP)) {
+        nameToOp[meta.name] = op
+      }
+      defaults.enabledOps = cfg.skills
+        .filter((s) => s.enabled && nameToOp[s.name])
+        .map((s) => nameToOp[s.name])
+    }
+    if (cfg?.mode === 'local' || cfg?.mode === 'remote') {
+      defaults.deployMode = cfg.mode
+    }
+  } catch { /* no config.yml */ }
+
+  try {
+    const raw = await Deno.readTextFile(`${home}/.slv/api.yml`)
+    const yml = parse(raw) as {
+      notifications?: { discord_webhook?: string }
+    } | null
+    const hook = yml?.notifications?.discord_webhook
+    if (typeof hook === 'string' && hook.trim().length > 0) {
+      defaults.discordWebhook = hook.trim()
+    }
+  } catch { /* no api.yml */ }
+
+  return defaults
+}
+
 const hasBenchmarkOps = (selectedOps: string[]) =>
   selectedOps.includes('Index RPC Node Operations') ||
   selectedOps.includes('gRPC Geyser Streaming')
@@ -95,22 +240,71 @@ const hasBenchmarkOps = (selectedOps: string[]) =>
 export const onboardAction = async () => {
   slvAA(denoJson.version)
 
+  // --- Language gate ---
+  // On first run (no lang in api.yml) prompt once. If user picks a non-English
+  // builtin language we save it and ask them to re-run so the rest of onboard
+  // can show in that language. On subsequent runs we skip this block entirely
+  // (avoids the re-run loop) and just load the saved language.
+  if (!(await hasLangSet())) {
+    const picked = await Select.prompt({
+      message: 'Select your language / 言語を選択 / Выберите язык',
+      options: [
+        { name: 'English', value: 'en' },
+        { name: '日本語 (Japanese)', value: 'ja' },
+        { name: '中文 (Chinese)', value: 'zh' },
+        { name: 'Русский (Russian)', value: 'ru' },
+        { name: 'Tiếng Việt (Vietnamese)', value: 'vi' },
+        { name: 'Other (type your language)', value: '__other__' },
+      ],
+      default: 'en',
+    })
+
+    let chosenLang: string = picked
+    if (picked === '__other__') {
+      const typed = await Input.prompt({
+        message: 'Enter your language (e.g. "de", "Français", "日本語")',
+        default: 'en',
+        validate: (v) => v.trim().length > 0 || 'Language is required',
+      })
+      chosenLang = typed.trim()
+    }
+
+    await writeLang(chosenLang)
+
+    if (chosenLang !== 'en') {
+      // Load i18n now so the re-run notice can be shown in the chosen language
+      // (built-in langs only; "other" may fall back to English here if the AI
+      // key isn't set yet, which is fine — the message is short).
+      await initI18n()
+      console.log()
+      console.log(
+        colors.yellow(
+          `  ${t('Language saved. Please run `slv onboard` again to continue.')}`,
+        ),
+      )
+      console.log()
+      return
+    }
+  }
+
+  await initI18n()
+
   console.log(
-    colors.bold.rgb24('\n┌  SLV AI Onboarding\n│', 0x14f195),
+    colors.bold.rgb24(`\n┌  ${t('SLV AI Onboarding')}\n│`, 0x14f195),
   )
 
   printSecurityWarning()
 
   const accepted = await Select.prompt({
-    message: 'I understand this is powerful and inherently risky. Continue?',
+    message: t('I understand this is powerful and inherently risky. Continue?'),
     options: [
-      { name: 'Yes', value: 'yes' },
-      { name: 'No', value: 'no' },
+      { name: t('Yes'), value: 'yes' },
+      { name: t('No'), value: 'no' },
     ],
   })
 
   if (accepted !== 'yes') {
-    console.log(colors.yellow('\n  Setup cancelled.\n'))
+    console.log(colors.yellow(`\n  ${t('Setup cancelled.')}\n`))
     return
   }
 
@@ -126,16 +320,16 @@ export const onboardAction = async () => {
 
   if (!hasSlvKey) {
     console.log(
-      colors.bold.rgb24('│  SLV API Key', 0x14f195),
+      colors.bold.rgb24(`│  ${t('SLV API Key')}`, 0x14f195),
     )
     console.log(
       colors.white(
-        `  Get your free API key: https://discord.gg/S2gEbJTGJA\n`,
+        `  ${t('Get your free API key: https://discord.gg/S2gEbJTGJA')}\n`,
       ),
     )
 
     const slvApiKey = await Secret.prompt({
-      message: '🔑 SLV API Key (or press Enter to skip)',
+      message: t('🔑 SLV API Key (or press Enter to skip)'),
     })
 
     if (slvApiKey && slvApiKey.trim().length > 0) {
@@ -149,15 +343,22 @@ export const onboardAction = async () => {
       existing.slv = { api_key: slvApiKey.trim() }
       await Deno.writeTextFile(apiYmlPath, stringify(existing))
       await Deno.chmod(apiYmlPath, 0o600)
-      console.log(colors.green('  ✔ SLV API Key saved.\n'))
+      console.log(colors.green(`  ✔ ${t('SLV API Key saved.')}\n`))
+      // The just-entered SLV key unlocks AI translation for non-builtin langs.
+      const currentLang = await readLang()
+      if (!BUILTIN_LANGS[currentLang]) {
+        await initI18n()
+      }
     } else {
-      console.log(colors.rgb24('  Skipped. You can run `slv login` later.\n', 0x888888))
+      console.log(
+        colors.rgb24(`  ${t('Skipped. You can run `slv login` later.')}\n`, 0x888888),
+      )
     }
   }
 
   // Default to SLV AI — no provider selection needed
   // Users can manually configure OpenAI/Anthropic in ~/.slv/api.yml if desired
-  console.log(colors.green('  ✔ Using SLV AI (powered by your SLV API Key).\n'))
+  console.log(colors.green(`  ✔ ${t('Using SLV AI (powered by your SLV API Key).')}\n`))
 
   await writeAiConfig({
     provider: 'slv' as AiProvider,
@@ -167,42 +368,78 @@ export const onboardAction = async () => {
 
   // --- Agent setup ---
   console.log(
-    colors.bold.rgb24('\n│  Agent Setup', 0x14f195),
+    colors.bold.rgb24(`\n│  ${t('Agent Setup')}`, 0x14f195),
   )
 
+  // Pre-fill defaults from any existing agent config so a second-run onboard
+  // just needs Enter-Enter-Enter unless the user wants to change something.
+  const existing = await loadExistingDefaults(home)
+
   const userName = await Input.prompt({
-    message: 'Your name',
-    validate: (v) => v.trim().length > 0 || 'Name is required',
+    message: t('Your name'),
+    default: existing.userName,
+    validate: (v) => v.trim().length > 0 || t('Name is required'),
   })
 
   const callMe = await Input.prompt({
-    message: 'What should the AI call you?',
-    default: userName,
+    message: t('What should the AI call you?'),
+    default: existing.callMe ?? userName,
   })
 
   const agentName = await Input.prompt({
-    message: 'Name your main AI agent',
-    default: 'SLV Agent',
+    message: t('Name your main AI agent'),
+    default: existing.agentName ?? 'SLV Agent',
   })
 
+  // Default the Checkbox to previously-enabled ops; fall back to first-run
+  // defaults when nothing is saved yet.
+  const isChecked = (op: string, firstRunDefault: boolean): boolean => {
+    if (existing.enabledOps) return existing.enabledOps.includes(op)
+    return firstRunDefault
+  }
   const selectedOps: string[] = await Checkbox.prompt({
-    message: 'What will you be doing? (↑↓ move, Space toggle, Enter confirm)',
+    message: t('What will you be doing? (↑↓ move, Space toggle, Enter confirm)'),
     options: [
-      { name: 'Solana Validator Operations', value: 'Solana Validator Operations', checked: true },
-      { name: 'Index RPC Node Operations', value: 'Index RPC Node Operations', checked: true },
-      { name: 'gRPC Geyser Streaming', value: 'gRPC Geyser Streaming', checked: true },
-      { name: 'Benchmark & Connectivity Testing', value: 'Benchmark & Connectivity Testing', checked: true },
-      { name: 'Solana App Development (Trade Bot)', value: 'Solana App Development' },
-      { name: 'Server Procurement', value: 'Server Procurement', checked: true },
+      {
+        name: 'Solana Validator Operations',
+        value: 'Solana Validator Operations',
+        checked: isChecked('Solana Validator Operations', true),
+      },
+      {
+        name: 'Index RPC Node Operations',
+        value: 'Index RPC Node Operations',
+        checked: isChecked('Index RPC Node Operations', true),
+      },
+      {
+        name: 'gRPC Geyser Streaming',
+        value: 'gRPC Geyser Streaming',
+        checked: isChecked('gRPC Geyser Streaming', true),
+      },
+      {
+        name: 'Benchmark & Connectivity Testing',
+        value: 'Benchmark & Connectivity Testing',
+        checked: isChecked('Benchmark & Connectivity Testing', true),
+      },
+      {
+        name: 'Solana App Development (Trade Bot)',
+        value: 'Solana App Development',
+        checked: isChecked('Solana App Development', false),
+      },
+      {
+        name: 'Server Procurement',
+        value: 'Server Procurement',
+        checked: isChecked('Server Procurement', true),
+      },
     ],
   })
 
   // --- Deployment mode ---
   const deployMode = await Select.prompt({
-    message: 'Deployment mode',
+    message: t('Deployment mode'),
+    default: existing.deployMode,
     options: [
-      { name: 'Local — deploy to this machine', value: 'local' },
-      { name: 'Remote — deploy to remote servers via SSH', value: 'remote' },
+      { name: t('Local — deploy to this machine'), value: 'local' },
+      { name: t('Remote — deploy to remote servers via SSH'), value: 'remote' },
     ],
   })
 
@@ -267,7 +504,7 @@ Session history and important notes.
 
   // --- GitHub Setup (optional) ---
   console.log(
-    colors.bold.rgb24('\n│  GitHub Setup (optional)', 0x14f195),
+    colors.bold.rgb24(`\n│  ${t('GitHub Setup (optional)')}`, 0x14f195),
   )
 
   // Check if gh CLI is available and authenticated
@@ -285,7 +522,7 @@ Session history and important notes.
   }
 
   if (ghAuthenticated) {
-    console.log(colors.green('  ✔ GitHub CLI already authenticated.\n'))
+    console.log(colors.green(`  ✔ ${t('GitHub CLI already authenticated.')}\n`))
   } else {
     // Check if gh is installed
     let ghInstalled = false
@@ -304,25 +541,29 @@ Session history and important notes.
     if (!ghInstalled) {
       console.log(
         colors.rgb24(
-          '  GitHub CLI (gh) not found. Install it from https://cli.github.com/\n',
+          `  ${t('GitHub CLI (gh) not found. Install it from https://cli.github.com/')}\n`,
           0x888888,
         ),
       )
       console.log(
-        colors.rgb24('  Skipped. You can set up GitHub later.\n', 0x888888),
+        colors.rgb24(
+          `  ${t('Skipped. You can set up GitHub later.')}\n`,
+          0x888888,
+        ),
       )
     } else {
       const setupGh = await Select.prompt({
-        message:
+        message: t(
           'Set up GitHub authentication? (enables repo creation, PRs, etc.)',
+        ),
         options: [
-          { name: 'Yes — run gh auth login', value: 'yes' },
-          { name: 'Skip for now', value: 'skip' },
+          { name: t('Yes — run gh auth login'), value: 'yes' },
+          { name: t('Skip for now'), value: 'skip' },
         ],
       })
 
       if (setupGh === 'yes') {
-        console.log(colors.white('\n  Running `gh auth login`...\n'))
+        console.log(colors.white(`\n  ${t('Running `gh auth login`...')}\n`))
         const proc = new Deno.Command('gh', {
           args: ['auth', 'login'],
           stdin: 'inherit',
@@ -331,18 +572,20 @@ Session history and important notes.
         })
         const { success } = await proc.output()
         if (success) {
-          console.log(colors.green('\n  ✔ GitHub authenticated.\n'))
+          console.log(colors.green(`\n  ✔ ${t('GitHub authenticated.')}\n`))
         } else {
           console.log(
             colors.yellow(
-              '\n  ⚠ GitHub authentication failed. You can retry with `gh auth login`.\n',
+              `\n  ⚠ ${
+                t('GitHub authentication failed. You can retry with `gh auth login`.')
+              }\n`,
             ),
           )
         }
       } else {
         console.log(
           colors.rgb24(
-            '  Skipped. You can run `gh auth login` later.\n',
+            `  ${t('Skipped. You can run `gh auth login` later.')}\n`,
             0x888888,
           ),
         )
@@ -352,12 +595,12 @@ Session history and important notes.
 
   // --- Notifications (optional) ---
   console.log(
-    colors.bold.rgb24('\n│  Notifications (optional)', 0x14f195),
+    colors.bold.rgb24(`\n│  ${t('Notifications (optional)')}`, 0x14f195),
   )
 
   const discordWebhook = await Input.prompt({
-    message: 'Discord Webhook URL for notifications (Enter to skip)',
-    default: '',
+    message: t('Discord Webhook URL for notifications (Enter to skip)'),
+    default: existing.discordWebhook ?? '',
   })
 
   if (discordWebhook && discordWebhook.trim().length > 0) {
@@ -371,32 +614,34 @@ Session history and important notes.
     existing.notifications = { discord_webhook: discordWebhook.trim() }
     await Deno.writeTextFile(apiYmlPath, stringify(existing))
     await Deno.chmod(apiYmlPath, 0o600)
-    console.log(colors.green('  ✔ Discord Webhook saved to ~/.slv/api.yml\n'))
+    console.log(
+      colors.green(`  ✔ ${t('Discord Webhook saved to ~/.slv/api.yml')}\n`),
+    )
   } else {
-    console.log(colors.rgb24('  Skipped.\n', 0x888888))
+    console.log(colors.rgb24(`  ${t('Skipped.')}\n`, 0x888888))
   }
 
   console.log(
     colors.bold.rgb24('\n│', 0x14f195),
   )
   console.log(
-    colors.green('◇  Agent files saved to ~/.slv/agent/'),
+    colors.green(`◇  ${t('Agent files saved to ~/.slv/agent/')}`),
   )
   console.log(
     colors.bold.rgb24('│', 0x14f195),
   )
   console.log(
-    colors.white(`  Agent:    ${colors.bold(agentName)}`),
+    colors.white(`  ${t('Agent:')}    ${colors.bold(agentName)}`),
   )
   console.log(
-    colors.green('◇  AI configuration saved to ~/.slv/api.yml'),
+    colors.green(`◇  ${t('AI configuration saved to ~/.slv/api.yml')}`),
   )
   console.log(
     colors.bold.rgb24('│', 0x14f195),
   )
   console.log(
     colors.rgb24(
-      `└  Run \`slv c\` to start the AI console.\n`,
+      `└  ${t('Run `slv c` to start the AI console.')}\n`,
       0x14f195,
     ),
   )

--- a/cli/src/bot/init/initBotTemplate.ts
+++ b/cli/src/bot/init/initBotTemplate.ts
@@ -10,6 +10,47 @@ import {
   BotTempDirMap,
   BotTempTypeArray,
 } from '@cmn/zod/bot.ts'
+import { readBotAgreement, writeBotAgreement } from '@/ai/config.ts'
+import { initI18n, t } from '@/ai/i18n/index.ts'
+
+const confirmBotInitAgreement = async (): Promise<boolean> => {
+  if (await readBotAgreement()) return true
+  await initI18n()
+
+  console.log()
+  console.log(
+    colors.bold.yellow(`⚠ ${t('slv bot init — trade-app is an example only')}`),
+  )
+  console.log()
+  console.log(
+    colors.white(
+      t(
+        'The trade-app template is only an example of Solana on-chain transaction detection and submission. When the app starts, a wallet.json is created; trading begins once you deposit SOL into it, and your assets may decrease. Use this sample as a base for your own AI-assisted improvements — it can greatly reduce the effort of building Solana apps, but it is powerful and may cause financial loss in some cases.',
+      ),
+    ),
+  )
+  console.log()
+
+  const accepted = await Select.prompt({
+    message: t('I understand the above and will use it at my own risk.'),
+    options: [
+      { name: t('Yes'), value: 'yes' },
+      { name: t('No'), value: 'no' },
+    ],
+  })
+
+  if (accepted !== 'yes') {
+    console.log(
+      colors.yellow(
+        `\n⚠ ${t('bot init cancelled. You can run `slv bot init` again when ready.')}\n`,
+      ),
+    )
+    return false
+  }
+
+  await writeBotAgreement(true)
+  return true
+}
 
 /**
  * Initialize a new Solana trade bot application by downloading the template
@@ -20,6 +61,9 @@ import {
 
 export const initBotTemplate = async (options: { queue: boolean; template?: string; name?: string; yes?: boolean }) => {
   try {
+    if (!(await confirmBotInitAgreement())) {
+      return false
+    }
     // Create a directory for the bot if it doesn't exist
     const botConfigDir = join(configRoot, 'bot')
     try {


### PR DESCRIPTION
## Summary

- Extends `~/.slv/api.yml` with `lang` and `agreed_slv_init_bot` fields.
- Adds a language gate to `slv onboard` (5 built-in languages + free-form "Other") and localizes the onboard flow.
- Adds a one-time localized disclaimer to `slv bot init` emphasizing that the template is a sample meant to be improved with AI before real use.
- Prefills onboard prompts from existing config so re-running `slv onboard` only needs changes where the user wants them.

## What's new

**Config (`cli/src/ai/config.ts`)**
- `lang?`, `agreed_slv_init_bot?` fields + `readLang` / `hasLangSet` / `writeLang` / `readBotAgreement` / `writeBotAgreement` helpers.

**i18n module (`cli/src/ai/i18n/`)**
- Hybrid strategy: static templates for `en / ja / zh / ru / vi`; other languages are translated at runtime via the SLV AI proxy and cached to `~/.slv/i18n/<lang>.json`.
- Keys are English source strings — callers use ``t('English text')`` and fall back cleanly when a translation is missing.

**`slv onboard`**
- Prompts for language on first run only. Non-English picks save the choice and ask the user to re-run so the rest of onboard renders in the selected language (avoids a re-run loop on subsequent invocations).
- CJK-aware display-width helper + word wrap for the security warning so translated text doesn't break the box borders.
- Second-run onboard prefills defaults from `USER.md` / `SOUL.md` / `config.yml` / `api.yml` — Enter-through keeps existing values.
- Security warning now includes a positive-framed note about the bot init sample being designed to be improved with your AI before real use.

**`slv bot init`**
- One-time localized disclaimer + Yes/No gate. Consent is persisted in `agreed_slv_init_bot`, so subsequent invocations skip the prompt.

**`slv c` (AI console)**
- Header, provider/model labels, instruction line, local greeting (including crew descriptions), and goodbye message are localized.
- `systemPrompt.ts` injects the user's preferred language into Core Rules when it differs from English.

## Test plan

- [ ] Backup existing config: `mv ~/.slv ~/.slv.bak`
- [ ] First run `slv onboard` → language prompt appears, select 日本語 → re-run message shown in Japanese → exit
- [ ] Second run `slv onboard` → no language prompt; all messages in Japanese; Enter through prompts to confirm defaults come from prior values
- [ ] `slv bot init -t trade-app -n test-bot` → localized disclaimer + Yes/No; Yes continues, No aborts
- [ ] Re-run `slv bot init` → disclaimer skipped
- [ ] `slv c` → header, greeting, goodbye all in Japanese; AI responses default to Japanese
- [ ] Select "Other" with a non-builtin language (e.g. `de`) → verify `~/.slv/i18n/de.json` cache is created on first use (requires SLV API key)
- [ ] Security warning box borders align correctly for CJK characters
- [ ] Restore: `rm -rf ~/.slv && mv ~/.slv.bak ~/.slv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)