### PR TITLE
feat(bot): drop blocking prompt, add run_command spinner

### DIFF
--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -556,6 +556,59 @@ export const consoleAction = async () => {
   let cmdFlushTimer: ReturnType<typeof setTimeout> | null = null
   let cmdTotalLineCount = 0
 
+  // Activity spinner shown while `run_command` executes. Long commands
+  // (cargo build, curl downloads, ansible plays) can produce little or no
+  // output for a while, so we show a rotating spinner with elapsed time so
+  // the user knows work is in progress.
+  let commandLoader: Loader | null = null
+  let commandStartedAt = 0
+  let commandLabel = ''
+  let commandTimer: ReturnType<typeof setInterval> | null = null
+
+  const formatElapsed = (ms: number): string => {
+    const s = Math.floor(ms / 1000)
+    if (s < 60) return `${s}s`
+    const m = Math.floor(s / 60)
+    return `${m}m ${s % 60}s`
+  }
+
+  const startCommandLoader = (command: string) => {
+    stopCommandLoader() // guard against overlap
+    // Keep the label short so it fits on one line in narrow terminals.
+    const cleaned = command.replace(/\s+/g, ' ').trim()
+    commandLabel = cleaned.length > 56
+      ? cleaned.slice(0, 53) + '...'
+      : cleaned
+    commandStartedAt = Date.now()
+    commandLoader = new Loader(
+      tui,
+      (s: string) => chalk.hex('#14f195')(s),
+      (s: string) => chalk.gray(s),
+      `Running: ${commandLabel} (0s)`,
+    )
+    chatLog.addChild(commandLoader)
+    commandLoader.start()
+    commandTimer = setInterval(() => {
+      if (!commandLoader) return
+      const elapsed = formatElapsed(Date.now() - commandStartedAt)
+      commandLoader.setMessage(`Running: ${commandLabel} (${elapsed})`)
+      tui.requestRender()
+    }, 1000)
+    tui.requestRender()
+  }
+
+  const stopCommandLoader = () => {
+    if (commandTimer) {
+      clearInterval(commandTimer)
+      commandTimer = null
+    }
+    if (commandLoader) {
+      chatLog.removeChild(commandLoader)
+      commandLoader.stop()
+      commandLoader = null
+    }
+  }
+
   const flushCmdOutput = () => {
     if (cmdOutputLines.length === 0) return
     // Show last N lines as a rolling window so the user always sees progress
@@ -606,10 +659,15 @@ export const consoleAction = async () => {
     cmdOutputLines = []
     cmdOutputText = null
     cmdTotalLineCount = 0
+    stopCommandLoader()
   }, (taskName: string) => {
-    // Ansible task-title spinner mode: update the loader message
-    if (loader) {
-      loader.setMessage(taskName)
+    // Ansible task-title spinner mode: update the running-command loader with
+    // the current task name while keeping the elapsed-time counter.
+    if (commandLoader) {
+      const elapsed = formatElapsed(Date.now() - commandStartedAt)
+      commandLabel = taskName
+      commandLoader.setMessage(`Running: ${taskName} (${elapsed})`)
+      tui.requestRender()
     }
   })
 
@@ -741,6 +799,17 @@ export const consoleAction = async () => {
       if (name === 'run_command') {
         currentTaskDescription = 'Running a command'
         if (!currentTaskStartedAt) currentTaskStartedAt = Date.now()
+        // Parse the command out of the tool detail JSON so the spinner label
+        // reflects what's actually running (e.g. `cargo build --release`).
+        let cmd = ''
+        try {
+          const parsed = JSON.parse(detail) as { command?: string }
+          if (typeof parsed.command === 'string') cmd = parsed.command
+        } catch {
+          const m = detail.match(/"command"\s*:\s*"([^"]+)"/)
+          if (m) cmd = m[1]
+        }
+        if (cmd) startCommandLoader(cmd)
       } else if (name === 'call_mcp') {
         currentTaskDescription = 'Calling SLV Cloud API'
         if (!currentTaskStartedAt) currentTaskStartedAt = Date.now()

--- a/cli/src/bot/init/initBotTemplate.ts
+++ b/cli/src/bot/init/initBotTemplate.ts
@@ -13,8 +13,12 @@ import {
 import { readBotAgreement, writeBotAgreement } from '@/ai/config.ts'
 import { initI18n, t } from '@/ai/i18n/index.ts'
 
-const confirmBotInitAgreement = async (): Promise<boolean> => {
-  if (await readBotAgreement()) return true
+// Show the sample-usage disclaimer once per user (first `slv bot init`), then
+// proceed automatically. This used to be an interactive Yes/No prompt, but it
+// blocked AI agents (e.g. Setzer) that invoke `slv bot init` as a subprocess.
+// Now it's a one-time informational notice — no blocking, no prompts.
+const showBotInitNoticeOnce = async (): Promise<void> => {
+  if (await readBotAgreement()) return
   await initI18n()
 
   console.log()
@@ -31,25 +35,7 @@ const confirmBotInitAgreement = async (): Promise<boolean> => {
   )
   console.log()
 
-  const accepted = await Select.prompt({
-    message: t('I understand the above and will use it at my own risk.'),
-    options: [
-      { name: t('Yes'), value: 'yes' },
-      { name: t('No'), value: 'no' },
-    ],
-  })
-
-  if (accepted !== 'yes') {
-    console.log(
-      colors.yellow(
-        `\n⚠ ${t('bot init cancelled. You can run `slv bot init` again when ready.')}\n`,
-      ),
-    )
-    return false
-  }
-
   await writeBotAgreement(true)
-  return true
 }
 
 /**
@@ -61,9 +47,7 @@ const confirmBotInitAgreement = async (): Promise<boolean> => {
 
 export const initBotTemplate = async (options: { queue: boolean; template?: string; name?: string; yes?: boolean }) => {
   try {
-    if (!(await confirmBotInitAgreement())) {
-      return false
-    }
+    await showBotInitNoticeOnce()
     // Create a directory for the bot if it doesn't exist
     const botConfigDir = join(configRoot, 'bot')
     try {


### PR DESCRIPTION
## Summary

- `slv bot init` no longer asks interactive Yes/No. The sample-usage disclaimer is shown once per user as an informational notice, then bot init proceeds automatically.
- Adds an activity spinner for `run_command` in the AI console so long commands (`cargo build`, downloads, ansible) visibly show progress.

## Why

The previous Yes/No gate in `slv bot init` hung AI agents (Setzer) that invoke it as a subprocess — they had no stdin to answer with. Converting the gate to a one-time informational notice preserves the "first-run reminder" UX without blocking automation.

For long-running commands, the console previously showed no activity indicator between output lines. `cargo build` and similar commands can be silent for long stretches, making it look like the session froze. A rotating spinner with elapsed time fixes that.

## Changes

**`cli/src/bot/init/initBotTemplate.ts`**
- `confirmBotInitAgreement()` → `showBotInitNoticeOnce()`: prints the disclaimer (localized via the existing i18n layer) and sets `agreed_slv_init_bot: true`, then returns. No prompt, no blocking.

**`cli/src/ai/console/consoleAction.ts`**
- New `commandLoader` (pi-tui `Loader`) with start/stop helpers and a 1s interval timer. Label format: ``Running: <short cmd> (<elapsed>)``.
- `onToolCall` starts the loader when `run_command` fires, extracting the command from the tool detail JSON.
- `setCommandOutputCallback`'s complete handler stops the loader (covers success, failure, and timeout paths via `tools.ts`).
- The ansible task-title callback updates the same loader's label with the current TASK name while keeping the elapsed counter.

## Test plan

- [ ] `slv bot init -t trade-app -n test-bot` runs end-to-end without prompting
- [ ] Setzer / AI agent can invoke `slv bot init` without hanging
- [ ] First run prints the localized disclaimer; second run prints nothing extra
- [ ] `slv c` → ask the AI to run a long command (e.g. `sleep 10 && echo done`) → spinner with elapsed time is visible and disappears on completion
- [ ] Running an ansible playbook shows current TASK label + elapsed time

🤖 Generated with [Claude Code](https://claude.com/claude-code)