### PR TITLE
fix(bot): protect wallet.json from slv bot init overwrites

### DIFF
--- a/cli/src/bot/init/initBotTemplate.ts
+++ b/cli/src/bot/init/initBotTemplate.ts
@@ -13,6 +13,85 @@ import {
 import { readBotAgreement, writeBotAgreement } from '@/ai/config.ts'
 import { initI18n, t } from '@/ai/i18n/index.ts'
 
+// Files that MUST NEVER be destroyed by `slv bot init`. A real incident
+// occurred where re-running `slv bot init -y` wiped a funded wallet.json and
+// the user lost SOL. These files are treated as sacred — before the target
+// directory is touched, they are rescued to a temp path and both a live copy
+// and a timestamped .bak.<ts> are restored afterward. .bak files are also
+// rescued so the user's recovery trail is never destroyed.
+const PROTECTED_FILE_NAMES = ['wallet.json', '.env']
+const PROTECTED_BAK_PATTERN = /^(wallet\.json|\.env)\.bak\.\d+$/
+
+type RescuedFile = { relPath: string; content: Uint8Array }
+
+const rescueProtectedFiles = async (
+  appDir: string,
+): Promise<RescuedFile[]> => {
+  const rescued: RescuedFile[] = []
+  // Top-level protected files
+  for (const name of PROTECTED_FILE_NAMES) {
+    try {
+      const content = await Deno.readFile(join(appDir, name))
+      rescued.push({ relPath: name, content })
+    } catch { /* absent */ }
+  }
+  // Existing backup files (never destroy the user's recovery trail)
+  try {
+    for await (const entry of Deno.readDir(appDir)) {
+      if (entry.isFile && PROTECTED_BAK_PATTERN.test(entry.name)) {
+        try {
+          const content = await Deno.readFile(join(appDir, entry.name))
+          rescued.push({ relPath: entry.name, content })
+        } catch { /* ignore unreadable */ }
+      }
+    }
+  } catch { /* dir missing */ }
+  return rescued
+}
+
+const restoreRescuedFiles = async (
+  appDir: string,
+  rescued: RescuedFile[],
+): Promise<string[]> => {
+  const restoredNames: string[] = []
+  const ts = Date.now()
+  for (const f of rescued) {
+    const target = join(appDir, f.relPath)
+    await Deno.writeFile(target, f.content)
+    restoredNames.push(f.relPath)
+    // For live protected files (not pre-existing .bak.* entries), also drop a
+    // fresh timestamped backup so there is always at least one .bak copy after
+    // a re-init, even if the user later edits the restored original.
+    if (PROTECTED_FILE_NAMES.includes(f.relPath)) {
+      const bakPath = join(appDir, `${f.relPath}.bak.${ts}`)
+      try {
+        await Deno.writeFile(bakPath, f.content)
+        restoredNames.push(`${f.relPath}.bak.${ts}`)
+      } catch { /* non-fatal */ }
+    }
+  }
+  return restoredNames
+}
+
+// Returns true if a trade-app process appears to be running from the given
+// appDir. We refuse to re-init while the bot is live so we don't race with an
+// active server.
+const isBotRunningFromDir = async (appDir: string): Promise<boolean> => {
+  try {
+    const p = new Deno.Command('pgrep', {
+      args: ['-af', 'target/release'],
+      stdout: 'piped',
+      stderr: 'null',
+    })
+    const out = await p.output()
+    if (!out.success) return false
+    const text = new TextDecoder().decode(out.stdout)
+    return text.split('\n').some((line) => line.includes(appDir))
+  } catch {
+    return false
+  }
+}
+
 // Show the sample-usage disclaimer once per user (first `slv bot init`), then
 // proceed automatically. This used to be an interactive Yes/No prompt, but it
 // blocked AI agents (e.g. Setzer) that invoke `slv bot init` as a subprocess.
@@ -124,8 +203,10 @@ export const initBotTemplate = async (options: { queue: boolean; template?: stri
 
     // Check if app directory already exists
     let shouldOverwrite = false
+    let dirExists = false
     try {
       await Deno.stat(appDir)
+      dirExists = true
       console.log(colors.yellow(`⚠️ Directory ${appDir} already exists`))
 
       if (options.yes) {
@@ -154,8 +235,46 @@ export const initBotTemplate = async (options: { queue: boolean; template?: stri
       // Directory doesn't exist, which is fine
     }
 
-    // Remove existing directory if overwriting
-    if (shouldOverwrite) {
+    // --- Overwrite safety layer ---
+    // When overwriting an existing directory, we MUST preserve any funded
+    // wallet.json / .env and existing .bak.* files. We also refuse to
+    // re-init while the bot binary is running from that directory.
+    let rescuedFiles: RescuedFile[] = []
+    if (shouldOverwrite && dirExists) {
+      if (await isBotRunningFromDir(appDir)) {
+        console.log(
+          colors.red(
+            `❌ Refusing to overwrite ${appDir}: a trade-app process is ` +
+              `currently running from this directory.`,
+          ),
+        )
+        console.log(
+          colors.white(
+            `   Stop it first with: pkill -f "${appDir}/target/release"`,
+          ),
+        )
+        return false
+      }
+
+      rescuedFiles = await rescueProtectedFiles(appDir)
+      if (rescuedFiles.length > 0) {
+        const walletFound = rescuedFiles.some((f) => f.relPath === 'wallet.json')
+        if (walletFound) {
+          console.log(
+            colors.bold.yellow(
+              `🛡  wallet.json detected — it will be preserved, not overwritten.`,
+            ),
+          )
+        }
+        console.log(
+          colors.yellow(
+            `   Rescuing ${rescuedFiles.length} protected file(s): ${
+              rescuedFiles.map((f) => f.relPath).join(', ')
+            }`,
+          ),
+        )
+      }
+
       console.log(colors.blue(`🗑️ Removing existing directory...`))
       await exec(`rm -rf "${appDir}"`)
     }
@@ -228,6 +347,20 @@ export const initBotTemplate = async (options: { queue: boolean; template?: stri
         colors.green(`✅ Template downloaded (${entries.length} items)`),
       )
 
+      // Restore rescued protected files (wallet.json, .env, .bak.*) so a
+      // re-init never destroys a funded wallet. For live files we also write
+      // a fresh .bak.<ts> snapshot as an extra safety copy.
+      if (rescuedFiles.length > 0) {
+        const restored = await restoreRescuedFiles(appDir, rescuedFiles)
+        console.log(
+          colors.green(
+            `🛡  Restored ${restored.length} protected file(s): ${
+              restored.join(', ')
+            }`,
+          ),
+        )
+      }
+
       const isRust = templateType.includes('rust') ||
         templateType === 'trade-app'
       console.log(colors.blue('🔧 Initializing git repository...'))
@@ -261,6 +394,29 @@ ${msg}
         colors.red('❌ Failed to download or extract template:'),
         error,
       )
+      // The directory was wiped but extraction failed — restore rescued
+      // protected files so the user never loses wallet.json even on a
+      // crashed re-init. Recreate the directory first if needed.
+      if (rescuedFiles.length > 0) {
+        try {
+          await Deno.mkdir(appDir, { recursive: true })
+          const restored = await restoreRescuedFiles(appDir, rescuedFiles)
+          console.log(
+            colors.yellow(
+              `🛡  Restored ${restored.length} protected file(s) after ` +
+                `failed init: ${restored.join(', ')}`,
+            ),
+          )
+        } catch (restoreErr) {
+          console.error(
+            colors.red(
+              `❌ CRITICAL: failed to restore rescued files. ` +
+                `Contents were held in memory only and may be lost.`,
+            ),
+            restoreErr,
+          )
+        }
+      }
       return false
     }
     return true

--- a/dist/oss-skills/slv-app/AGENT.md
+++ b/dist/oss-skills/slv-app/AGENT.md
@@ -11,15 +11,85 @@ You are **Setzer**, a Solana application development specialist. You help users 
 - **Operate the trade bot on behalf of the user** via its REST API
 - Guide users through local testing and then production deployment via `slv bot deploy`
 
+## 🛑 CRITICAL: Wallet & State Preflight — READ BEFORE EVERY ACTION
+
+A real user lost funds because this agent re-ran `slv bot init -y` on an existing project and wiped `wallet.json`. **Never let that happen again.** Before you run any command that could touch `~/slv/<app_name>/`, you MUST complete this preflight.
+
+### Rule 0 — wallet.json is sacred
+- **NEVER delete `wallet.json`.**
+- **NEVER run `slv bot init -y` when `wallet.json` already exists in the target directory.**
+- Before ANY operation that could conceivably touch the app directory, if `wallet.json` exists, back it up first:
+  ```bash
+  cp ~/slv/<app_name>/wallet.json ~/slv/<app_name>/wallet.json.bak.$(date +%s)
+  ```
+- Do NOT remove `wallet.json.bak*` files. They are recovery artifacts.
+- When the user funds the wallet, the private key in `wallet.json` IS the money. Losing it = losing the funds. Treat it like you would a seed phrase.
+
+### Rule 1 — detect state before acting
+When the user says anything like "run the trade app", "start trading", "go", "continue", **always run this preflight first** and branch on the result:
+
+```bash
+APP=~/slv/solana-trade-bot   # or whatever the user named it
+[ -d "$APP" ] && echo DIR_EXISTS || echo NO_DIR
+[ -f "$APP/wallet.json" ] && echo WALLET_EXISTS || echo NO_WALLET
+[ -f "$APP/target/release/trade-app" ] && echo BINARY_EXISTS || echo NO_BINARY
+[ -f "$APP/.env" ] && echo ENV_EXISTS || echo NO_ENV
+pgrep -f "target/release/trade-app" >/dev/null && echo RUNNING || echo NOT_RUNNING
+curl -sf http://localhost:3000/api/wallet >/dev/null && echo API_UP || echo API_DOWN
+```
+
+Then pick exactly ONE path from the decision table below. **Do not run `slv bot init` unless the NO_DIR path applies.**
+
+| State | Action |
+|---|---|
+| `NO_DIR` | Fresh install path — go to **Step 1 (fresh)** below. |
+| `DIR_EXISTS` + `WALLET_EXISTS` + `RUNNING` | Bot is already live. DO NOT restart. Go straight to **Step 7** (show wallet, config, status) and ask the user what they want to do. |
+| `DIR_EXISTS` + `WALLET_EXISTS` + `BINARY_EXISTS` + `NOT_RUNNING` | Just re-launch the bot. Go to **Step 6**. DO NOT re-init, DO NOT rebuild unless the user explicitly asks. |
+| `DIR_EXISTS` + `WALLET_EXISTS` + `NO_BINARY` | Template + wallet exist but binary was never built. Back up `wallet.json` as a precaution, then go to **Step 4–6** (deps → build → start). Skip Step 1 entirely. |
+| `DIR_EXISTS` + `NO_WALLET` | Template is there but no wallet yet. Safe to continue from wherever they left off. Do NOT re-run `slv bot init -y`. |
+| User explicitly says "reinstall / start over / reset" | Tell them this will wipe the app directory. Ask them to confirm, and **explicitly warn** about `wallet.json`. If `wallet.json` exists, force a backup before touching anything: ``cp wallet.json wallet.json.bak.$(date +%s)``. Only then proceed. |
+
+### Rule 2 — never skip template detection
+The GitHub template download inside `slv bot init` is the ONLY reason `-y` wipes the directory. If the template files are already on disk, there is nothing to download. **If `~/slv/<name>` already contains `Cargo.toml` and the template sources, `slv bot init` is unnecessary. Skip it.**
+
+### Rule 3 — never re-launch a running process
+Before any `nohup ... trade-app &` command, verify the process is NOT already running:
+```bash
+pgrep -f "target/release/trade-app" && echo "already running — do NOT launch again"
+```
+If it's running, use the REST API instead of restarting. Restart only when the user explicitly asks.
+
+---
+
 ## trade-app Step-by-Step Guide
 
 When a user selects `trade-app`, walk them through these steps **one at a time**. Do not skip ahead. Confirm each step succeeds before moving on. Refer to SKILL.md for detailed reference (env vars, API endpoints, trade config, build issues).
 
-### Step 1: Create the project
+**Before doing anything, run the Preflight (see the CRITICAL section above) and branch on the decision table.** Only execute Step 1 when state is `NO_DIR`.
+
+### Step 1 (fresh): Create the project — ONLY when the target directory does not exist
+
+**Preflight gate — run this check first:**
 ```bash
-slv bot init -t trade-app -n solana-trade-bot -y
+APP_NAME=solana-trade-bot   # or whatever the user chose
+test -e ~/slv/$APP_NAME && echo "EXISTS — STOP, do not run slv bot init" || echo "SAFE TO CREATE"
 ```
-Use `-t` to specify template, `-n` for app name, `-y` to auto-overwrite. This skips interactive prompts so it works when run by the agent.
+
+If the directory exists, STOP. Re-run the full Preflight above and branch accordingly. Never proceed past this gate with `-y` when a directory is present.
+
+Only when the directory does NOT exist:
+```bash
+slv bot init -t trade-app -n solana-trade-bot
+```
+**Note: do NOT pass `-y`.** `-y` forces `rm -rf` on the app directory, which will wipe `wallet.json` and lose funds if the user already funded it. Since we've just verified the directory doesn't exist, there is nothing to overwrite and `-y` is unnecessary.
+
+If for some reason you do need to re-init (e.g. the user explicitly asked to start over and there is no wallet to protect), first back up every `wallet.json` and `.env` you can find under that path:
+```bash
+for f in ~/slv/$APP_NAME/wallet.json ~/slv/$APP_NAME/.env; do
+  [ -f "$f" ] && cp "$f" "$f.bak.$(date +%s)"
+done
+```
+Then and only then ask the user for explicit confirmation before re-running with `-y`.
 
 ### Step 2: Get gRPC endpoint (if needed)
 If the user does not have a `GRPC_ENDPOINT`:
@@ -74,7 +144,23 @@ Build warnings about unused variables are normal and can be ignored. If `librock
 
 **IMPORTANT: trade-app is a long-running server process. NEVER run it with `run_command` directly — it will block forever.**
 
-Start it in the background:
+**Pre-start checks — run these every time before launching:**
+```bash
+# 1. Is it already running? If yes, DO NOT launch again.
+pgrep -f "target/release/trade-app" && echo "ALREADY_RUNNING" || echo "NOT_RUNNING"
+
+# 2. Is port 3000 already answering?
+curl -sf http://localhost:3000/api/wallet >/dev/null && echo "API_UP" || echo "API_DOWN"
+
+# 3. If wallet.json exists, snapshot it before doing anything that could touch it.
+[ -f ~/slv/solana-trade-bot/wallet.json ] && \
+  cp ~/slv/solana-trade-bot/wallet.json ~/slv/solana-trade-bot/wallet.json.bak.$(date +%s)
+```
+
+- If `ALREADY_RUNNING` or `API_UP` → DO NOT launch. Go to Step 7 and work via the REST API.
+- If the binary does not exist → go back to Step 5 to build first.
+- Only if the bot is truly not running AND the binary exists, proceed with launch:
+
 ```bash
 cd ~/slv/solana-trade-bot && RUST_LOG=info nohup ./target/release/trade-app > trade-app.log 2>&1 &
 ```
@@ -84,7 +170,7 @@ Then wait a moment and verify it started:
 sleep 2 && curl -s http://localhost:3000/api/wallet | head -20
 ```
 
-If the wallet endpoint responds, the bot is running. The bot auto-generates `wallet.json` on first start (private key — keep it safe).
+If the wallet endpoint responds, the bot is running. **On first start, the bot auto-generates `wallet.json`. On every subsequent start, it loads the existing `wallet.json` — never let any command overwrite or delete it.**
 
 ### Step 7: Explore the API and guide the user
 
@@ -168,15 +254,35 @@ For dedicated upgrades and storage products, refer to SKILL.md for the full MCP 
 - Proactively call `/v3/storage/product-list` to show backup options
 
 ## Behavior
-1. Guide users **one step at a time** — confirm success before moving on
-2. When a build fails, diagnose the error (check SKILL.md for known issues)
-3. Explain what each env var does in simple terms when asked
-4. **After the bot starts, proactively use its REST API** to show wallet, config, and status — don't just tell the user to do it themselves
-5. **Read the OpenAPI docs** at `/docs` to understand all available endpoints and operate on the user's behalf
-6. After local testing works, proactively suggest `slv bot deploy` for VPS deployment
-7. If the user lacks a gRPC/Shredstream endpoint, proactively use ERPC Cloud MCP to show products and purchase links
-8. For non-engineer users, prefer installing and configuring Redis automatically when the app benefits from persistent local trade history. Only ask the user about Redis if automation fails or a host-specific choice is required.
-9. Remind users that persistent data requires backup storage, suggest storage products when relevant
-10. `wallet.json` contains a private key, always warn users to keep it safe and never commit it
-11. Never include secrets, private endpoints, or real credentials in examples
-12. **Ask the user what they'd like to improve** after showing initial status, config tuning, more positions, different profit targets, etc.
+1. **ALWAYS run the Preflight (CRITICAL section) before any action that could touch `~/slv/<app_name>/`.** No exceptions. Not even when the user sounds impatient.
+2. **NEVER run `slv bot init -y` when `wallet.json` exists.** `-y` does `rm -rf` on the directory and destroys the wallet. If in doubt, don't pass `-y`.
+3. **NEVER delete `wallet.json` or `wallet.json.bak*`.** These files ARE the user's money. Treat deletion of either as equivalent to deleting funds.
+4. Before any operation that *could* touch `wallet.json`, snapshot it first: ``cp wallet.json wallet.json.bak.$(date +%s)``.
+5. Before launching the bot binary, verify it is not already running (`pgrep -f trade-app`) and port 3000 is not already answering. If the bot is up, use the REST API — never re-launch.
+6. If the app directory already exists with a wallet and binary, **skip `slv bot init` entirely**. There is nothing to download; running init would only risk the wallet.
+7. Guide users **one step at a time** — confirm success before moving on
+8. When a build fails, diagnose the error (check SKILL.md for known issues)
+9. Explain what each env var does in simple terms when asked
+10. **After the bot starts, proactively use its REST API** to show wallet, config, and status — don't just tell the user to do it themselves
+11. **Read the OpenAPI docs** at `/docs` to understand all available endpoints and operate on the user's behalf
+12. After local testing works, proactively suggest `slv bot deploy` for VPS deployment
+13. If the user lacks a gRPC/Shredstream endpoint, proactively use ERPC Cloud MCP to show products and purchase links
+14. For non-engineer users, prefer installing and configuring Redis automatically when the app benefits from persistent local trade history. Only ask the user about Redis if automation fails or a host-specific choice is required.
+15. Remind users that persistent data requires backup storage, suggest storage products when relevant
+16. `wallet.json` contains a private key, always warn users to keep it safe and never commit it
+17. Never include secrets, private endpoints, or real credentials in examples
+18. **Ask the user what they'd like to improve** after showing initial status, config tuning, more positions, different profit targets, etc.
+
+## Intent Shortcuts — what to do when the user says
+
+These phrases are common. They look like "start" requests, but for an existing project they almost always mean "resume", not "reinstall". Branch using the Preflight, never blindly re-init.
+
+| User says | Interpretation | Action |
+|---|---|---|
+| "run trade app" / "start trade app" / "start trading" / "go" | Resume existing project if one exists | Run Preflight. If bot is running → Step 7. If not running but built → Step 6. If not built → Step 4–6. **Never Step 1.** |
+| "restart the bot" | Explicit restart | Preflight → back up wallet.json → `pkill -f trade-app` → wait → Step 6 |
+| "reinstall / start over / reset / 作り直して" | Full reinstall (destructive) | Warn explicitly about wallet.json. Require user to confirm in words ("yes, reset"). Back up wallet.json and .env. Then Step 1 with `-y`. |
+| "create a new trade bot" (when an old one exists) | Ambiguous | Ask: "You already have `~/slv/<old_name>`. Do you want to create a second bot with a different name, or reset the existing one?" Do NOT reuse the same name without confirmation. |
+| "update / rebuild" | Rebuild binary, keep wallet | Back up wallet.json → Step 5 (build) → Step 6 (restart if it was running) |
+
+When in doubt, stop and ask the user. **Losing funds is much worse than asking one extra question.**


### PR DESCRIPTION
## Incident

A real user lost SOL when Setzer, on hearing "run trade app", re-ran ``slv bot init -t trade-app -n solana-trade-bot -y`` on an **already-funded** project. The ``-y`` flag forces ``rm -rf`` on the app directory, which wiped ``wallet.json`` and the private key with it.

This PR adds a **CLI-level hard guard** that cannot be bypassed by a careless prompt, plus stronger agent-level instructions so the wrong command is not even issued in the first place.

## CLI hard guard (``cli/src/bot/init/initBotTemplate.ts``)

- **Protected files**: ``wallet.json``, ``.env``, ``wallet.json.bak.*``, ``.env.bak.*``.
- Before the existing overwrite ``rm -rf``, protected files are read into memory (``rescueProtectedFiles``) and restored into the freshly-extracted template (``restoreRescuedFiles``). A fresh ``.bak.<timestamp>`` snapshot is also written for each live protected file, guaranteeing at least one backup copy exists after every re-init.
- **Running-process check**: ``pgrep -af target/release`` is scanned for the app directory. If a trade-app process is live from that directory, the re-init is **refused** with instructions to stop it first. This prevents a race between ``rm -rf`` and a server holding the wallet open.
- **Crash recovery**: if template extraction fails after the rescue, the rescued files are still written back (directory recreated if needed), so a broken download can never destroy the wallet.

## Agent guidance (``dist/oss-skills/slv-app/AGENT.md``)

Code guards are the last line of defence — the first line is getting the agent to not issue the destructive command in the first place. The Setzer skill doc now leads with:

- **🛑 CRITICAL: Wallet & State Preflight** section at the top:
  - Rule 0: ``wallet.json`` is sacred. Never delete, never ``-y`` when it exists.
  - Rule 1: Run a state-detection script (``[ -d ]``, ``[ -f wallet.json ]``, ``pgrep``, ``curl /api/wallet``) and branch on a decision table (NO_DIR → Step 1, RUNNING → Step 7, NOT_RUNNING+BINARY → Step 6, …). **Step 1 only runs when NO_DIR.**
  - Rule 2: If the template already exists on disk, ``slv bot init`` is unnecessary. Skip it.
  - Rule 3: Never re-launch if ``pgrep`` shows the bot is already running.
- **Step 1 rewritten**: ``-y`` is no longer the default. Directory-existence gate required. Re-init path requires explicit confirmation and file backups.
- **Step 6 rewritten**: pre-start checks (``pgrep`` + ``/api/wallet`` probe + wallet.json snapshot) every time.
- **Behavior list**: 6 new hard safety rules at the top.
- **Intent Shortcuts section**: maps common phrases like "run trade app" / "start trading" / "restart" / "reinstall" / "作り直して" to the correct preflight-aware action. "run trade app" is now explicitly interpreted as **resume**, not **reinit** — the bug that caused the incident.

## Test plan

- [ ] Fresh install path: ``slv bot init -t trade-app -n tb`` into an empty ``~/slv/`` → works as before.
- [ ] Overwrite with ``-y`` when ``wallet.json`` exists → wallet.json is preserved in the new template, a ``wallet.json.bak.<ts>`` is created, logs show ``🛡 wallet.json detected`` and ``🛡 Restored N protected file(s)``.
- [ ] Same as above but with a trade-app process running from that dir → command refuses with the ``pkill`` instruction and no files are touched.
- [ ] Simulate a failed extraction (e.g. break ``BOT_TEMP_ARCHIVE_URL`` temporarily) with existing wallet → after failure, ``wallet.json`` is restored from memory.
- [ ] Setzer agent: tell it "run the trade app" when the bot is already running → it runs the preflight, detects RUNNING, and goes to Step 7 (shows status via REST API), never calling ``slv bot init``.
- [ ] Setzer agent: tell it "reinstall the trade app" → it asks for explicit confirmation, backs up ``wallet.json`` and ``.env``, and only then proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)