### PR TITLE
feat(skills): add slv skills sync and wire into slv upgrade

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy'
 import denoJson from '/deno.json' with { type: 'json' }
 import { botCmd } from '@/bot/index.ts'
+import { skillsCmd } from '@/skills/index.ts'
 import { appCmd } from '@/app/index.ts'
 import { validatorCmd } from '@/validator/index.ts'
 import { rpcCmd } from '@/rpc/index.ts'
@@ -59,6 +60,9 @@ program
 program
   .command('bot', botCmd)
   .alias('b')
+
+program
+  .command('skills', skillsCmd)
 
 program
   .command('app', appCmd)

--- a/cli/src/skills/index.ts
+++ b/cli/src/skills/index.ts
@@ -1,0 +1,65 @@
+import { Command } from '@cliffy'
+import { colors } from '@cliffy/colors'
+import { SKILL_NAMES, syncSkills } from '@/skills/syncSkills.ts'
+
+export const skillsCmd = new Command()
+  .description(`🧠 Manage AI agent skills (~/.slv/skills)
+
+Skills are the per-agent instruction files (AGENT.md, SKILL.md) that the
+AI console loads when delegating to a specialist agent. They live in
+~/.slv/skills/ and are downloaded from GitHub on first install.
+
+Run \`slv skills sync\` after pulling new CLI versions to make sure your
+local skills match the latest instructions. \`slv upgrade\` also runs a
+sync automatically.
+`)
+  .action(() => {
+    skillsCmd.showHelp()
+  })
+
+skillsCmd
+  .command('sync')
+  .description('Re-download AI agent skills from GitHub')
+  .option('-f, --force', 'Re-write files even if already up to date', {
+    default: false,
+  })
+  .option(
+    '-s, --skill <name:string>',
+    `Only sync a specific skill (repeatable). Known: ${SKILL_NAMES.join(', ')}`,
+    { collect: true },
+  )
+  .action(async (options: { force?: boolean; skill?: string[] }) => {
+    try {
+      const result = await syncSkills({
+        force: options.force ?? false,
+        only: options.skill,
+      })
+      if (result.failed > 0) {
+        console.log(
+          colors.yellow(
+            `\nSome files failed to download. Check your network and retry with --force.`,
+          ),
+        )
+        Deno.exit(1)
+      }
+    } catch (err) {
+      console.error(
+        colors.red(`Failed to sync skills: ${(err as Error).message}`),
+      )
+      Deno.exit(1)
+    }
+  })
+
+skillsCmd
+  .command('list')
+  .alias('ls')
+  .description('List known AI agent skills')
+  .action(() => {
+    console.log(colors.bold('Known AI agent skills:'))
+    for (const name of SKILL_NAMES) {
+      console.log(`  - ${name}`)
+    }
+    console.log(
+      colors.gray(`\nRun \`slv skills sync\` to fetch the latest versions.`),
+    )
+  })

--- a/cli/src/skills/syncSkills.ts
+++ b/cli/src/skills/syncSkills.ts
@@ -1,0 +1,219 @@
+import { colors } from '@cliffy/colors'
+import { dirname, join } from '@std/path'
+
+// Mirror of sh/install's install_skills(). Kept in lockstep so that
+// `slv skills sync` and `slv upgrade` produce the same result.
+export const SKILL_NAMES = [
+  'slv-validator',
+  'slv-rpc',
+  'slv-grpc-geyser',
+  'slv-benchmark',
+  'slv-app',
+  'slv-server-procurement',
+] as const
+
+// Top-level files fetched for every skill. These are the files the AI console
+// actually reads at runtime (AGENT.md for sub-agent prompts, SKILL.md for the
+// capability doc, skill.json for metadata). README.md is included for parity
+// with the bash installer.
+const TOP_LEVEL_FILES = ['AGENT.md', 'SKILL.md', 'README.md', 'skill.json']
+
+// Auxiliary files fetched per skill. Path is relative to the skill root.
+const AUX_FILES = ['scripts/setup.sh']
+
+const BASE_URL =
+  'https://raw.githubusercontent.com/ValidatorsDAO/slv/main/dist/oss-skills'
+
+type SyncOptions = {
+  // Re-download files even if the local copy already matches the remote hash.
+  force?: boolean
+  // Restrict sync to this subset of skill names.
+  only?: readonly string[]
+  // Silence informational logs (errors are still printed).
+  quiet?: boolean
+}
+
+export type SyncResult = {
+  updated: number
+  unchanged: number
+  added: number
+  failed: number
+  failedFiles: string[]
+}
+
+const home = (): string => {
+  const h = Deno.env.get('HOME')
+  if (!h) throw new Error('HOME environment variable is not set')
+  return h
+}
+
+const skillsDir = (): string => `${home()}/.slv/skills`
+
+// Fetch a single file with a short timeout and return its body, or null if
+// the file is missing upstream. Network errors throw so the caller can decide
+// whether to keep going.
+const fetchRemote = async (url: string): Promise<Uint8Array | null> => {
+  const res = await fetch(url, {
+    signal: AbortSignal.timeout(30_000),
+  })
+  if (res.status === 404) return null
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`)
+  }
+  const buf = new Uint8Array(await res.arrayBuffer())
+  return buf
+}
+
+const bytesEqual = (a: Uint8Array, b: Uint8Array): boolean => {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+const readIfExists = async (path: string): Promise<Uint8Array | null> => {
+  try {
+    return await Deno.readFile(path)
+  } catch {
+    return null
+  }
+}
+
+const writeFile = async (path: string, data: Uint8Array): Promise<void> => {
+  await Deno.mkdir(dirname(path), { recursive: true })
+  await Deno.writeFile(path, data)
+}
+
+type FileStatus = 'updated' | 'unchanged' | 'added' | 'missing-remote' | 'failed'
+
+const syncOneFile = async (
+  skill: string,
+  relPath: string,
+  options: SyncOptions,
+): Promise<FileStatus> => {
+  const url = `${BASE_URL}/${skill}/${relPath}`
+  const localPath = join(skillsDir(), skill, relPath)
+
+  let remote: Uint8Array | null
+  try {
+    remote = await fetchRemote(url)
+  } catch (err) {
+    if (!options.quiet) {
+      console.log(
+        colors.red(`  ✖ ${skill}/${relPath} — ${(err as Error).message}`),
+      )
+    }
+    return 'failed'
+  }
+
+  if (remote === null) return 'missing-remote'
+
+  const local = await readIfExists(localPath)
+  if (local && !options.force && bytesEqual(local, remote)) {
+    return 'unchanged'
+  }
+  const wasAdded = local === null
+  await writeFile(localPath, remote)
+  return wasAdded ? 'added' : 'updated'
+}
+
+export const syncSkills = async (
+  options: SyncOptions = {},
+): Promise<SyncResult> => {
+  const targets = options.only && options.only.length > 0
+    ? SKILL_NAMES.filter((s) => options.only!.includes(s))
+    : SKILL_NAMES
+
+  if (targets.length === 0) {
+    throw new Error('No matching skills to sync')
+  }
+
+  const result: SyncResult = {
+    updated: 0,
+    unchanged: 0,
+    added: 0,
+    failed: 0,
+    failedFiles: [],
+  }
+
+  if (!options.quiet) {
+    console.log(
+      colors.bold.rgb24(
+        `Syncing AI agent skills from ${BASE_URL}`,
+        0x14f195,
+      ),
+    )
+  }
+
+  for (const skill of targets) {
+    const files = [...TOP_LEVEL_FILES, ...AUX_FILES]
+    const perSkill = { updated: 0, unchanged: 0, added: 0, failed: 0 }
+    for (const rel of files) {
+      const status = await syncOneFile(skill, rel, options)
+      switch (status) {
+        case 'updated':
+          result.updated++
+          perSkill.updated++
+          break
+        case 'added':
+          result.added++
+          perSkill.added++
+          break
+        case 'unchanged':
+          result.unchanged++
+          perSkill.unchanged++
+          break
+        case 'failed':
+          result.failed++
+          perSkill.failed++
+          result.failedFiles.push(`${skill}/${rel}`)
+          break
+        case 'missing-remote':
+          // Silent — some skills don't ship every aux file (e.g. skills
+          // without scripts/setup.sh). This is expected.
+          break
+      }
+    }
+
+    if (!options.quiet) {
+      const parts: string[] = []
+      if (perSkill.added > 0) {
+        parts.push(colors.green(`${perSkill.added} added`))
+      }
+      if (perSkill.updated > 0) {
+        parts.push(colors.yellow(`${perSkill.updated} updated`))
+      }
+      if (perSkill.unchanged > 0) {
+        parts.push(colors.gray(`${perSkill.unchanged} unchanged`))
+      }
+      if (perSkill.failed > 0) {
+        parts.push(colors.red(`${perSkill.failed} failed`))
+      }
+      const summary = parts.length > 0 ? parts.join(', ') : colors.gray('no files')
+      console.log(`  ${colors.bold(skill)}  ${summary}`)
+    }
+  }
+
+  if (!options.quiet) {
+    const touched = result.added + result.updated
+    if (touched === 0 && result.failed === 0) {
+      console.log(colors.green('\n✔ All skills are already up to date.'))
+    } else if (result.failed === 0) {
+      console.log(
+        colors.green(
+          `\n✔ Skills synced: ${result.added} added, ${result.updated} updated, ${result.unchanged} unchanged.`,
+        ),
+      )
+    } else {
+      console.log(
+        colors.yellow(
+          `\n⚠ Skills synced with ${result.failed} failure(s): ${result.added} added, ${result.updated} updated, ${result.unchanged} unchanged.`,
+        ),
+      )
+    }
+    console.log(colors.gray(`  Installed to: ${skillsDir()}/`))
+  }
+
+  return result
+}

--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -1,3 +1,6 @@
+import { colors } from '@cliffy/colors'
+import { syncSkills } from '@/skills/syncSkills.ts'
+
 const upgrade = async () => {
   const script = await (await fetch('https://storage.slv.dev/slv/install'))
     .text()
@@ -10,6 +13,28 @@ const upgrade = async () => {
   await writer.write(new TextEncoder().encode(script))
   await writer.close()
   const { code } = await process.status
+
+  // After the shell installer runs, re-sync skills via the Deno native path.
+  // The installer already downloads skills, but it uses `curl ... || true`
+  // which silently ignores failures. Running syncSkills() here surfaces any
+  // missed files and guarantees existing users pick up agent-instruction
+  // fixes (e.g. wallet.json protection in AGENT.md) on every upgrade.
+  if (code === 0) {
+    console.log()
+    try {
+      await syncSkills({ force: false })
+    } catch (err) {
+      console.log(
+        colors.yellow(
+          `⚠ Skills sync after upgrade failed: ${(err as Error).message}`,
+        ),
+      )
+      console.log(
+        colors.gray(`  Retry manually with: slv skills sync`),
+      )
+    }
+  }
+
   Deno.exit(code)
 }
 


### PR DESCRIPTION
## Why

Existing ``slv`` installs keep a stale copy of ``~/.slv/skills/<name>/AGENT.md``. These files are downloaded once by the shell installer (``sh/install``) and then never refreshed — they're not bundled into the compiled binary, so simply shipping a new CLI release does nothing for existing users. After the wallet-protection fixes in PR #275 (slv-app AGENT.md), every funded user on the old instructions is still exposed until they somehow re-run the full installer.

This PR gives existing users a fast, predictable way to pull agent-instruction updates.

## Changes

**New module** ``cli/src/skills/syncSkills.ts``
- Deno port of ``sh/install``'s ``install_skills()``.
- Fetches ``AGENT.md``, ``SKILL.md``, ``README.md``, ``skill.json`` and ``scripts/setup.sh`` for each known skill from ``raw.githubusercontent.com/.../dist/oss-skills/<name>/`` on ``main``.
- Byte-compares against the local copy and only writes when content actually changed.
- Reports per-skill ``added / updated / unchanged / failed`` counts.
- Supports ``force`` (re-write regardless) and ``only`` (subset of skills).

**New subcommand** ``slv skills``
- ``slv skills sync [-f] [-s <name>...]`` — re-download one or more skills.
- ``slv skills list`` — print the known skill names.

**Wire into upgrade** ``cli/src/upgrade.ts``
- After the shell installer exits with code 0, call ``syncSkills()`` as a safety net. The installer already curls the files, but uses ``|| true`` so any silent failure (network blip, CDN cache) goes unnoticed — running the Deno sync on top surfaces those gaps and guarantees fresh instructions after every ``slv upgrade``.

## Test plan

- [ ] ``slv skills list`` prints all 6 known skill names
- [ ] ``slv skills sync`` on a fresh machine downloads every skill and reports ``N added``
- [ ] ``slv skills sync`` on an up-to-date machine reports ``unchanged`` across the board
- [ ] Edit a local skill file, then ``slv skills sync`` — the edit is overwritten with the GitHub version (that's the intended behavior)
- [ ] ``slv skills sync -s slv-app`` restricts to that one skill
- [ ] ``slv skills sync -f`` re-writes even matching files
- [ ] ``slv upgrade`` completes, then prints the sync summary block
- [ ] After merging PR #275 to main, an existing user running ``slv skills sync`` gets the new wallet-protection AGENT.md locally without a full reinstall

## Follow-ups (not in this PR)

- Consider also fetching the ``ansible/`` and ``jinja/`` trees for ``slv-validator``, ``slv-rpc``, ``slv-grpc-geyser``. The bash installer doesn't either — those are runtime assets for playbook execution, not prompt context — so parity is preserved for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)