### PR TITLE
fix(upgrade): stop running syncSkills after the shell installer

### DIFF
--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -1,6 +1,3 @@
-import { colors } from '@cliffy/colors'
-import { syncSkills } from '@/skills/syncSkills.ts'
-
 const upgrade = async () => {
   const script = await (await fetch('https://storage.slv.dev/slv/install'))
     .text()
@@ -13,28 +10,11 @@ const upgrade = async () => {
   await writer.write(new TextEncoder().encode(script))
   await writer.close()
   const { code } = await process.status
-
-  // After the shell installer runs, re-sync skills via the Deno native path.
-  // The installer already downloads skills, but it uses `curl ... || true`
-  // which silently ignores failures. Running syncSkills() here surfaces any
-  // missed files and guarantees existing users pick up agent-instruction
-  // fixes (e.g. wallet.json protection in AGENT.md) on every upgrade.
-  if (code === 0) {
-    console.log()
-    try {
-      await syncSkills({ force: false })
-    } catch (err) {
-      console.log(
-        colors.yellow(
-          `⚠ Skills sync after upgrade failed: ${(err as Error).message}`,
-        ),
-      )
-      console.log(
-        colors.gray(`  Retry manually with: slv skills sync`),
-      )
-    }
-  }
-
+  // NOTE: skills are re-synced inside the shell installer via
+  // `install_skills()` in sh/install. Do not run syncSkills() here — it
+  // appends noisy "N unchanged" output after the welcome banner/ASCII
+  // art and buries the quick-start message. Users who want to force a
+  // skill refresh can run `slv skills sync` directly.
   Deno.exit(code)
 }
 


### PR DESCRIPTION
## Problem

\`slv upgrade\` was printing the Deno \`syncSkills()\` summary **after** the installer's welcome banner and ASCII art, burying the quick-start message users are supposed to see:

\`\`\`
(…ASCII art + "Welcome to SLV vX.Y.Z" + quick-start hints…)
Syncing AI agent skills from https://raw.githubusercontent.com/ValidatorsDAO/slv/main/dist/oss-skills
  slv-validator  5 unchanged
  slv-rpc  5 unchanged
  …
✔ All skills are already up to date.
\`\`\`

## Why it was there

PR #276 added the Deno \`syncSkills()\` call as a safety net because the shell installer's \`install_skills()\` uses \`curl ... || true\` and silently ignores individual file failures. In practice the installer always succeeds on healthy networks, so the extra sync just produces a noisy "N unchanged" block that drowns out the nice welcome banner.

## Fix

Remove the post-install \`syncSkills()\` call from \`cli/src/upgrade.ts\`. The shell installer already covers the normal path. Users who suspect a missed file can still force a resync with \`slv skills sync\` directly.

## Test plan

- [ ] \`slv upgrade\` now ends with the installer's ASCII art + quick-start banner as the last visible output
- [ ] \`slv skills sync\` still works as an explicit command
- [ ] Skills are still delivered on upgrade (via the shell installer's \`install_skills()\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)