### PR TITLE
feat(console): user profile detection, /focus command, backup reminders

### DIFF
--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -1306,12 +1306,15 @@ RULES:
     }
 
     // /focus <role> — switch the main agent's routing bias. Persisted to
-    // ~/.slv/agent/focus so it carries across sessions. `/focus auto` clears
-    // the override and returns to heuristic detection.
-    if (input.startsWith('/focus')) {
-      const arg = input.slice('/focus'.length).trim().toLowerCase()
+    // ~/.slv/agent/focus.txt so it carries across sessions. `/focus auto`
+    // clears the override and returns to heuristic detection.
+    // Exact-token match so `/focuses`, `/focusapp`, etc. fall through to the
+    // shell-command path below instead of silently being interpreted.
+    const firstToken = input.split(/\s+/)[0]
+    if (firstToken === '/focus') {
+      const rest = input.slice(firstToken.length).trim().toLowerCase()
       const valid: PrimaryFocus[] = ['validator', 'rpc', 'app', 'mixed']
-      if (!arg) {
+      if (!rest) {
         const profile = await detectProfile()
         chatLog.addSystem(
           `  Current focus: ${profile.primary}${
@@ -1324,24 +1327,45 @@ RULES:
         tui.requestRender()
         return
       }
-      if (arg === 'auto' || arg === 'clear' || arg === 'reset') {
-        await clearFocusOverride()
-        const profile = await detectProfile()
+
+      let handled = false
+      if (rest === 'auto' || rest === 'clear' || rest === 'reset') {
+        try {
+          await clearFocusOverride()
+          chatLog.addSystem('  ◇ Focus override cleared.')
+          handled = true
+        } catch (err) {
+          chatLog.addSystem(
+            `  ⚠ Failed to clear focus override: ${(err as Error).message}`,
+          )
+          tui.requestRender()
+          return
+        }
+      } else if ((valid as string[]).includes(rest)) {
+        try {
+          await writeFocusOverride(rest as PrimaryFocus)
+          chatLog.addSystem(`  ◇ Focus set to: ${rest}`)
+          handled = true
+        } catch (err) {
+          chatLog.addSystem(
+            `  ⚠ Failed to set focus: ${(err as Error).message}`,
+          )
+          tui.requestRender()
+          return
+        }
+      }
+
+      if (!handled) {
         chatLog.addSystem(
-          `  ◇ Focus override cleared. Auto-detected: ${profile.primary}.`,
-        )
-      } else if ((valid as string[]).includes(arg)) {
-        await writeFocusOverride(arg as PrimaryFocus)
-        chatLog.addSystem(`  ◇ Focus set to: ${arg}`)
-      } else {
-        chatLog.addSystem(
-          `  Unknown focus "${arg}". Use: validator | rpc | app | mixed | auto`,
+          `  Unknown focus "${rest}". Use: validator | rpc | app | mixed | auto`,
         )
         tui.requestRender()
         return
       }
+
       // Rebuild the system prompt so the new profile takes effect on the
-      // next user message without requiring a /clear.
+      // next user message without requiring a /clear. Single detectProfile
+      // call — describeProfile is the only user-facing summary we show.
       currentSystemPrompt = await buildSystemPrompt()
       provider.setSystemPrompt(currentSystemPrompt)
       const refreshed = await detectProfile()
@@ -1354,7 +1378,7 @@ RULES:
     if (
       input.startsWith('/') &&
       !['/exit', '/quit', '/clear', '/update', '/help', '/focus'].includes(
-        input.split(' ')[0],
+        firstToken,
       )
     ) {
       const shellCommand = input.slice(1).trim()

--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -1314,13 +1314,22 @@ RULES:
     if (firstToken === '/focus') {
       const rest = input.slice(firstToken.length).trim().toLowerCase()
       const valid: PrimaryFocus[] = ['validator', 'rpc', 'app', 'mixed']
+
+      // /focus with no argument — show current state and usage. detectProfile
+      // failures are logged but never crash the input loop.
       if (!rest) {
-        const profile = await detectProfile()
-        chatLog.addSystem(
-          `  Current focus: ${profile.primary}${
-            profile.overridden ? ' (manual override)' : ' (auto)'
-          }`,
-        )
+        try {
+          const profile = await detectProfile()
+          chatLog.addSystem(
+            `  Current focus: ${profile.primary}${
+              profile.overridden ? ' (manual override)' : ' (auto)'
+            }`,
+          )
+        } catch (err) {
+          chatLog.addSystem(
+            `  ⚠ Could not detect current focus: ${(err as Error).message}`,
+          )
+        }
         chatLog.addSystem(
           '  Usage: /focus validator | rpc | app | mixed | auto',
         )
@@ -1364,12 +1373,18 @@ RULES:
       }
 
       // Rebuild the system prompt so the new profile takes effect on the
-      // next user message without requiring a /clear. Single detectProfile
-      // call — describeProfile is the only user-facing summary we show.
-      currentSystemPrompt = await buildSystemPrompt()
-      provider.setSystemPrompt(currentSystemPrompt)
-      const refreshed = await detectProfile()
-      chatLog.addSystem(`  ${describeProfile(refreshed)}`)
+      // next user message without requiring a /clear. Wrap in try/catch so
+      // a best-effort profile refresh failure doesn't crash the input loop.
+      try {
+        currentSystemPrompt = await buildSystemPrompt()
+        provider.setSystemPrompt(currentSystemPrompt)
+        const refreshed = await detectProfile()
+        chatLog.addSystem(`  ${describeProfile(refreshed)}`)
+      } catch (err) {
+        chatLog.addSystem(
+          `  ⚠ Profile refresh failed: ${(err as Error).message}`,
+        )
+      }
       tui.requestRender()
       return
     }

--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -15,6 +15,13 @@ import {
 import chalk from 'chalk'
 import { readAiConfig } from '@/ai/config.ts'
 import { initI18n, t } from '@/ai/i18n/index.ts'
+import {
+  clearFocusOverride,
+  describeProfile,
+  detectProfile,
+  type PrimaryFocus,
+  writeFocusOverride,
+} from '@/ai/console/profile.ts'
 import { OpenAIProvider } from '@/ai/console/providers/openai.ts'
 import { AnthropicProvider } from '@/ai/console/providers/anthropic.ts'
 import { SLVProvider } from '@/ai/console/providers/slv.ts'
@@ -273,9 +280,17 @@ async function buildLocalGreeting(home: string): Promise<string> {
     crewSection = ' '
   }
 
+  // Append a one-line profile hint so the user sees we've detected their
+  // primary focus. Failures are non-fatal — the greeting still works.
+  let profileLine = ''
+  try {
+    const profile = await detectProfile()
+    profileLine = `\n\n${describeProfile(profile)}`
+  } catch { /* profile detection is best-effort */ }
+
   return `${greetLine}\n\n${introLine}${crewSection}${
     t('What would you like to work on today?')
-  }`
+  }${profileLine}`
 }
 
 async function checkDependencies(): Promise<string[]> {
@@ -1280,6 +1295,9 @@ RULES:
       chatLog.addSystem('  /clear — Clear conversation')
       chatLog.addSystem('  /update — Apply pending version updates')
       chatLog.addSystem(
+        '  /focus <validator|rpc|app|mixed|auto> — Switch or reset the main agent\'s primary focus',
+      )
+      chatLog.addSystem(
         '  /<command> — Execute shell command directly (e.g. /slv ai usage)',
       )
       chatLog.addSystem('  /help — Show this help')
@@ -1287,10 +1305,55 @@ RULES:
       return
     }
 
+    // /focus <role> — switch the main agent's routing bias. Persisted to
+    // ~/.slv/agent/focus so it carries across sessions. `/focus auto` clears
+    // the override and returns to heuristic detection.
+    if (input.startsWith('/focus')) {
+      const arg = input.slice('/focus'.length).trim().toLowerCase()
+      const valid: PrimaryFocus[] = ['validator', 'rpc', 'app', 'mixed']
+      if (!arg) {
+        const profile = await detectProfile()
+        chatLog.addSystem(
+          `  Current focus: ${profile.primary}${
+            profile.overridden ? ' (manual override)' : ' (auto)'
+          }`,
+        )
+        chatLog.addSystem(
+          '  Usage: /focus validator | rpc | app | mixed | auto',
+        )
+        tui.requestRender()
+        return
+      }
+      if (arg === 'auto' || arg === 'clear' || arg === 'reset') {
+        await clearFocusOverride()
+        const profile = await detectProfile()
+        chatLog.addSystem(
+          `  ◇ Focus override cleared. Auto-detected: ${profile.primary}.`,
+        )
+      } else if ((valid as string[]).includes(arg)) {
+        await writeFocusOverride(arg as PrimaryFocus)
+        chatLog.addSystem(`  ◇ Focus set to: ${arg}`)
+      } else {
+        chatLog.addSystem(
+          `  Unknown focus "${arg}". Use: validator | rpc | app | mixed | auto`,
+        )
+        tui.requestRender()
+        return
+      }
+      // Rebuild the system prompt so the new profile takes effect on the
+      // next user message without requiring a /clear.
+      currentSystemPrompt = await buildSystemPrompt()
+      provider.setSystemPrompt(currentSystemPrompt)
+      const refreshed = await detectProfile()
+      chatLog.addSystem(`  ${describeProfile(refreshed)}`)
+      tui.requestRender()
+      return
+    }
+
     // Direct CLI execution: input starting with / (but not a known command) runs as shell command
     if (
       input.startsWith('/') &&
-      !['/exit', '/quit', '/clear', '/update', '/help'].includes(
+      !['/exit', '/quit', '/clear', '/update', '/help', '/focus'].includes(
         input.split(' ')[0],
       )
     ) {

--- a/cli/src/ai/console/profile.ts
+++ b/cli/src/ai/console/profile.ts
@@ -1,0 +1,229 @@
+import { parse } from '@std/yaml'
+
+// Three primary user archetypes the main agent tailors its behaviour for.
+// `mixed` is the fallback when signals point in several directions at once
+// (e.g. a user with both a validator and a trade-bot).
+export type PrimaryFocus = 'validator' | 'rpc' | 'app' | 'mixed'
+
+export type TradeAppInventory = {
+  name: string
+  hasBinary: boolean
+  hasWallet: boolean
+}
+
+export type UserProfile = {
+  primary: PrimaryFocus
+  // One or two short lines of evidence used to explain the classification to
+  // the user in the opening greeting.
+  signals: string[]
+  // Present trade-app style projects under ~/slv/. Used to bias the greeting
+  // and system prompt toward Setzer when non-empty.
+  apps: TradeAppInventory[]
+  // True when the user manually set focus via `/focus <role>` this session or
+  // a previous one. Manual overrides beat heuristics.
+  overridden: boolean
+}
+
+const FOCUS_FILE = '.slv/agent/focus'
+
+const home = (): string => Deno.env.get('HOME') || ''
+
+const readFocusOverride = async (): Promise<PrimaryFocus | null> => {
+  try {
+    const raw = await Deno.readTextFile(`${home()}/${FOCUS_FILE}`)
+    const v = raw.trim().toLowerCase()
+    if (v === 'validator' || v === 'rpc' || v === 'app' || v === 'mixed') {
+      return v
+    }
+  } catch { /* absent */ }
+  return null
+}
+
+export const writeFocusOverride = async (
+  focus: PrimaryFocus,
+): Promise<void> => {
+  const path = `${home()}/${FOCUS_FILE}`
+  await Deno.mkdir(path.replace(/\/focus$/, ''), { recursive: true }).catch(
+    () => {},
+  )
+  await Deno.writeTextFile(path, focus + '\n')
+}
+
+export const clearFocusOverride = async (): Promise<void> => {
+  try {
+    await Deno.remove(`${home()}/${FOCUS_FILE}`)
+  } catch { /* absent */ }
+}
+
+const scanTradeApps = async (): Promise<TradeAppInventory[]> => {
+  const slvRoot = `${home()}/slv`
+  const apps: TradeAppInventory[] = []
+  try {
+    for await (const entry of Deno.readDir(slvRoot)) {
+      if (!entry.isDirectory || entry.name.startsWith('.')) continue
+      const dir = `${slvRoot}/${entry.name}`
+      let hasBinary = false
+      let hasWallet = false
+      try {
+        await Deno.stat(`${dir}/target/release/trade-app`)
+        hasBinary = true
+      } catch { /* no binary */ }
+      try {
+        await Deno.stat(`${dir}/wallet.json`)
+        hasWallet = true
+      } catch { /* no wallet */ }
+      apps.push({ name: entry.name, hasBinary, hasWallet })
+    }
+  } catch { /* ~/slv doesn't exist */ }
+  return apps
+}
+
+type ConfigSkill = { name: string; enabled: boolean; agent?: string }
+
+const readEnabledSkills = async (): Promise<ConfigSkill[]> => {
+  try {
+    const raw = await Deno.readTextFile(
+      `${home()}/.slv/agent/config.yml`,
+    )
+    const cfg = parse(raw) as { skills?: ConfigSkill[] } | null
+    return (cfg?.skills || []).filter((s) => s && s.enabled)
+  } catch { /* not configured */ }
+  return []
+}
+
+// Classify the user into one of the three primary roles.
+//
+// Priority (highest to lowest):
+//   1. Manual override via `/focus <role>` (persisted in ~/.slv/agent/focus)
+//   2. Live trade apps under ~/slv/ — if the user has a real trade-bot with
+//      binary+wallet, they're clearly in app-dev mode regardless of what they
+//      picked during onboard.
+//   3. Enabled skills in ~/.slv/agent/config.yml.
+//   4. Default to `validator` (the original SLV focus).
+//
+// Multiple strong signals across different roles → `mixed`.
+export const detectProfile = async (): Promise<UserProfile> => {
+  const override = await readFocusOverride()
+  const apps = await scanTradeApps()
+  const enabled = await readEnabledSkills()
+
+  if (override) {
+    return {
+      primary: override,
+      overridden: true,
+      apps,
+      signals: [
+        `Manual focus override: ${override} (set via /focus)`,
+      ],
+    }
+  }
+
+  const signals: string[] = []
+
+  const hasLiveTradeApp = apps.some((a) => a.hasBinary || a.hasWallet)
+  if (hasLiveTradeApp) {
+    signals.push(
+      `Trade app(s) in ~/slv: ${
+        apps.filter((a) => a.hasBinary || a.hasWallet).map((a) => a.name).join(', ')
+      }`,
+    )
+  }
+
+  const enabledNames = new Set(enabled.map((s) => s.name))
+  const hasValidatorSkill = enabledNames.has('slv-validator')
+  const hasRpcSkill = enabledNames.has('slv-rpc') ||
+    enabledNames.has('slv-grpc-geyser')
+  const hasAppSkill = enabledNames.has('slv-app')
+
+  const roleScore = {
+    validator: 0,
+    rpc: 0,
+    app: 0,
+  }
+
+  if (hasLiveTradeApp) roleScore.app += 3
+  if (hasAppSkill) roleScore.app += 1
+  if (hasValidatorSkill) roleScore.validator += 1
+  if (hasRpcSkill) roleScore.rpc += 1
+
+  if (hasValidatorSkill) signals.push('Validator skill enabled')
+  if (hasRpcSkill) signals.push('RPC / gRPC skill enabled')
+  if (hasAppSkill && !hasLiveTradeApp) signals.push('App skill enabled')
+
+  const max = Math.max(roleScore.validator, roleScore.rpc, roleScore.app)
+
+  let primary: PrimaryFocus
+  if (max === 0) {
+    primary = 'validator' // fallback — original SLV focus
+    signals.push('No strong signal — defaulting to validator')
+  } else {
+    const leaders = (Object.entries(roleScore) as [PrimaryFocus, number][])
+      .filter(([k, v]) => k !== 'mixed' && v === max)
+      .map(([k]) => k)
+    if (leaders.length === 1) {
+      primary = leaders[0]
+    } else {
+      primary = 'mixed'
+      signals.push(`Multiple strong signals: ${leaders.join(', ')}`)
+    }
+  }
+
+  return { primary, overridden: false, apps, signals }
+}
+
+// Short human-readable summary for the opening greeting. One line only.
+export const describeProfile = (profile: UserProfile): string => {
+  const { primary, apps } = profile
+  const appCount = apps.filter((a) => a.hasBinary || a.hasWallet).length
+
+  switch (primary) {
+    case 'app': {
+      if (appCount === 0) {
+        return "Focused on Solana App Development. Say 'new trade bot' when you're ready."
+      }
+      if (appCount === 1) {
+        const a = apps.find((x) => x.hasBinary || x.hasWallet)!
+        return `Focused on App Development. You have 1 trade app: ${a.name}.`
+      }
+      return `Focused on App Development. You have ${appCount} trade apps in ~/slv/.`
+    }
+    case 'validator':
+      return 'Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades.'
+    case 'rpc':
+      return 'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.'
+    case 'mixed':
+      return 'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.'
+  }
+}
+
+// Human-readable prompt-context block inserted into the main system prompt.
+// Kept short to avoid bloating every turn.
+export const profilePromptBlock = (profile: UserProfile): string => {
+  const { primary, apps, signals, overridden } = profile
+  const appCount = apps.filter((a) => a.hasBinary || a.hasWallet).length
+  const appList = apps
+    .filter((a) => a.hasBinary || a.hasWallet)
+    .map((a) => `- ${a.name} (binary=${a.hasBinary}, wallet=${a.hasWallet})`)
+    .join('\n')
+
+  const roleGuidance: Record<PrimaryFocus, string> = {
+    validator:
+      'Bias proactive suggestions toward validator operations: health checks, upgrades, restart flows, backup schedule. Delegate unfamiliar app/RPC work to the right specialist but do not push it.',
+    rpc:
+      'Bias proactive suggestions toward RPC / gRPC / Geyser operations: endpoint lifecycle, IP registration, slot lag, geyser plugin health. Do not push validator or app topics.',
+    app:
+      'Bias proactive suggestions toward trade-app work: status, live config tuning via REST API, profit/loss, wallet protection, Discord notifications. Delegate unfamiliar validator/RPC work only when the user asks.',
+    mixed:
+      'The user spans multiple roles. Listen for intent before proactively suggesting anything; offer options rather than picking one role.',
+  }
+
+  return `## User Profile
+
+- **Primary focus:** ${primary}${overridden ? ' (manual /focus override)' : ''}
+- **Signals:** ${signals.join('; ') || 'none'}
+${appCount > 0 ? `- **Trade apps in ~/slv:** ${appCount}\n${appList}\n` : ''}
+### Routing preference
+${roleGuidance[primary]}
+
+The user can override this at any time with \`/focus validator\`, \`/focus rpc\`, \`/focus app\`, or \`/focus mixed\`. Always honor an explicit intent over the profile — the profile is a prior, not a gate.`
+}

--- a/cli/src/ai/console/profile.ts
+++ b/cli/src/ai/console/profile.ts
@@ -56,23 +56,46 @@ const parseFocusValue = (raw: string): PrimaryFocus | null => {
   return null
 }
 
-const readFocusOverride = async (): Promise<PrimaryFocus | null> => {
+// Discriminated result from readFocusOverride so detectProfile can tell the
+// difference between "no override file" (ignore silently) and "override file
+// exists but contents are garbage" (mention it in signals so the user can
+// spot their typo).
+type FocusReadResult =
+  | { kind: 'none' }
+  | { kind: 'valid'; focus: PrimaryFocus }
+  | { kind: 'invalid'; raw: string; path: string }
+
+const tryReadFocusFile = async (
+  path: string,
+): Promise<string | null> => {
   try {
-    const raw = await Deno.readTextFile(focusFilePath())
-    return parseFocusValue(raw)
+    return await Deno.readTextFile(path)
   } catch (err) {
-    if (!(err instanceof Deno.errors.NotFound)) throw err
+    if (err instanceof Deno.errors.NotFound) return null
+    throw err
+  }
+}
+
+const readFocusOverride = async (): Promise<FocusReadResult> => {
+  const primary = await tryReadFocusFile(focusFilePath())
+  if (primary !== null) {
+    const parsed = parseFocusValue(primary)
+    if (parsed) return { kind: 'valid', focus: parsed }
+    return { kind: 'invalid', raw: primary.trim(), path: focusFilePath() }
   }
   // Fall back to the legacy location so existing users don't lose their
-  // override after this release. We do not auto-migrate here — writeFocusOverride
-  // handles that on the next set.
-  try {
-    const raw = await Deno.readTextFile(legacyFocusFilePath())
-    return parseFocusValue(raw)
-  } catch (err) {
-    if (!(err instanceof Deno.errors.NotFound)) throw err
+  // override after this release. writeFocusOverride migrates on next set.
+  const legacy = await tryReadFocusFile(legacyFocusFilePath())
+  if (legacy !== null) {
+    const parsed = parseFocusValue(legacy)
+    if (parsed) return { kind: 'valid', focus: parsed }
+    return {
+      kind: 'invalid',
+      raw: legacy.trim(),
+      path: legacyFocusFilePath(),
+    }
   }
-  return null
+  return { kind: 'none' }
 }
 
 export const writeFocusOverride = async (
@@ -103,6 +126,10 @@ export const clearFocusOverride = async (): Promise<void> => {
 }
 
 const scanTradeApps = async (): Promise<TradeAppInventory[]> => {
+  // NOTE: `~/slv/` holds user-scaffolded bot projects (created by
+  // `slv bot init`). It is NOT the same as `~/.slv/`, which holds the SLV
+  // CLI config (agent/, skills/, api.yml, …). The two are adjacent in the
+  // home dir and the name similarity is a trap for future maintainers.
   const slvRoot = join(requireHome(), 'slv')
   const apps: TradeAppInventory[] = []
   try {
@@ -144,10 +171,17 @@ const readEnabledSkills = async (): Promise<ConfigSkill[]> => {
   return []
 }
 
+// `mixed` is a derived classification — never a direct signal source — so
+// the scoring map only holds the three concrete roles.
+type ScoredRole = Exclude<PrimaryFocus, 'mixed'>
+const SCORED_ROLES: readonly ScoredRole[] = ['validator', 'rpc', 'app']
+
 // Classify the user into one of the three primary roles.
 //
 // Priority (highest to lowest):
-//   1. Manual override via `/focus <role>` (persisted in ~/.slv/agent/focus)
+//   1. Manual override via `/focus <role>` (persisted in
+//      ~/.slv/agent/focus.txt). An invalid file is ignored but surfaced in
+//      signals so the user can spot their typo.
 //   2. Live trade apps under ~/slv/ — if the user has a real trade-bot with
 //      binary+wallet, they're clearly in app-dev mode regardless of what they
 //      picked during onboard.
@@ -156,29 +190,39 @@ const readEnabledSkills = async (): Promise<ConfigSkill[]> => {
 //
 // Multiple strong signals across different roles → `mixed`.
 export const detectProfile = async (): Promise<UserProfile> => {
-  const override = await readFocusOverride()
+  const overrideResult = await readFocusOverride()
   const apps = await scanTradeApps()
   const enabled = await readEnabledSkills()
 
-  if (override) {
+  if (overrideResult.kind === 'valid') {
     return {
-      primary: override,
+      primary: overrideResult.focus,
       overridden: true,
       apps,
       signals: [
-        `Manual focus override: ${override} (set via /focus)`,
+        `Manual focus override: ${overrideResult.focus} (set via /focus)`,
       ],
     }
   }
 
   const signals: string[] = []
 
-  const hasLiveTradeApp = apps.some((a) => a.hasBinary || a.hasWallet)
+  // If the override file exists but has a garbage value, surface it so the
+  // user can spot the typo and fix it — but continue to auto-detection so
+  // the session isn't blocked by a bad edit.
+  if (overrideResult.kind === 'invalid') {
+    signals.push(
+      `Invalid focus override in ${overrideResult.path}: ${
+        JSON.stringify(overrideResult.raw)
+      } — expected one of validator / rpc / app / mixed. Ignoring.`,
+    )
+  }
+
+  const liveApps = apps.filter((a) => a.hasBinary || a.hasWallet)
+  const hasLiveTradeApp = liveApps.length > 0
   if (hasLiveTradeApp) {
     signals.push(
-      `Trade app(s) in ~/slv: ${
-        apps.filter((a) => a.hasBinary || a.hasWallet).map((a) => a.name).join(', ')
-      }`,
+      `Trade app(s) in ~/slv: ${liveApps.map((a) => a.name).join(', ')}`,
     )
   }
 
@@ -188,7 +232,7 @@ export const detectProfile = async (): Promise<UserProfile> => {
     enabledNames.has('slv-grpc-geyser')
   const hasAppSkill = enabledNames.has('slv-app')
 
-  const roleScore = {
+  const roleScore: Record<ScoredRole, number> = {
     validator: 0,
     rpc: 0,
     app: 0,
@@ -203,16 +247,14 @@ export const detectProfile = async (): Promise<UserProfile> => {
   if (hasRpcSkill) signals.push('RPC / gRPC skill enabled')
   if (hasAppSkill && !hasLiveTradeApp) signals.push('App skill enabled')
 
-  const max = Math.max(roleScore.validator, roleScore.rpc, roleScore.app)
+  const max = Math.max(...SCORED_ROLES.map((r) => roleScore[r]))
 
   let primary: PrimaryFocus
   if (max === 0) {
     primary = 'validator' // fallback — original SLV focus
     signals.push('No strong signal — defaulting to validator')
   } else {
-    const leaders = (Object.entries(roleScore) as [PrimaryFocus, number][])
-      .filter(([k, v]) => k !== 'mixed' && v === max)
-      .map(([k]) => k)
+    const leaders = SCORED_ROLES.filter((r) => roleScore[r] === max)
     if (leaders.length === 1) {
       primary = leaders[0]
     } else {

--- a/cli/src/ai/console/profile.ts
+++ b/cli/src/ai/console/profile.ts
@@ -1,4 +1,6 @@
 import { parse } from '@std/yaml'
+import { dirname, join } from '@std/path'
+import { t } from '@/ai/i18n/index.ts'
 
 // Three primary user archetypes the main agent tailors its behaviour for.
 // `mixed` is the fallback when signals point in several directions at once
@@ -24,57 +26,106 @@ export type UserProfile = {
   overridden: boolean
 }
 
-const FOCUS_FILE = '.slv/agent/focus'
+// Location of the manual /focus override, relative to $HOME.
+// `focus.txt` is explicit about being a plain-text single-value marker and
+// sits alongside the other agent files (SOUL.md, USER.md, MEMORY.md,
+// config.yml). The older location `focus` (no extension) is still read for
+// one release so users mid-session don't lose their override after upgrade.
+const FOCUS_FILE_REL = '.slv/agent/focus.txt'
+const LEGACY_FOCUS_FILE_REL = '.slv/agent/focus'
 
-const home = (): string => Deno.env.get('HOME') || ''
+const requireHome = (): string => {
+  const h = Deno.env.get('HOME')
+  if (!h) {
+    throw new Error(
+      'HOME environment variable is not set — cannot locate ~/.slv',
+    )
+  }
+  return h
+}
+
+const focusFilePath = (): string => join(requireHome(), FOCUS_FILE_REL)
+const legacyFocusFilePath = (): string =>
+  join(requireHome(), LEGACY_FOCUS_FILE_REL)
+
+const parseFocusValue = (raw: string): PrimaryFocus | null => {
+  const v = raw.trim().toLowerCase()
+  if (v === 'validator' || v === 'rpc' || v === 'app' || v === 'mixed') {
+    return v
+  }
+  return null
+}
 
 const readFocusOverride = async (): Promise<PrimaryFocus | null> => {
   try {
-    const raw = await Deno.readTextFile(`${home()}/${FOCUS_FILE}`)
-    const v = raw.trim().toLowerCase()
-    if (v === 'validator' || v === 'rpc' || v === 'app' || v === 'mixed') {
-      return v
-    }
-  } catch { /* absent */ }
+    const raw = await Deno.readTextFile(focusFilePath())
+    return parseFocusValue(raw)
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err
+  }
+  // Fall back to the legacy location so existing users don't lose their
+  // override after this release. We do not auto-migrate here — writeFocusOverride
+  // handles that on the next set.
+  try {
+    const raw = await Deno.readTextFile(legacyFocusFilePath())
+    return parseFocusValue(raw)
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err
+  }
   return null
 }
 
 export const writeFocusOverride = async (
   focus: PrimaryFocus,
 ): Promise<void> => {
-  const path = `${home()}/${FOCUS_FILE}`
-  await Deno.mkdir(path.replace(/\/focus$/, ''), { recursive: true }).catch(
-    () => {},
-  )
+  const path = focusFilePath()
+  await Deno.mkdir(dirname(path), { recursive: true })
   await Deno.writeTextFile(path, focus + '\n')
+  // Remove the legacy location so readFocusOverride's fallback never wins
+  // after a successful migration. Missing is fine; anything else bubbles.
+  try {
+    await Deno.remove(legacyFocusFilePath())
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err
+  }
 }
 
 export const clearFocusOverride = async (): Promise<void> => {
-  try {
-    await Deno.remove(`${home()}/${FOCUS_FILE}`)
-  } catch { /* absent */ }
+  for (const p of [focusFilePath(), legacyFocusFilePath()]) {
+    try {
+      await Deno.remove(p)
+    } catch (err) {
+      // Only swallow NotFound — permission errors or other issues should
+      // surface so the caller knows the override is still in place.
+      if (!(err instanceof Deno.errors.NotFound)) throw err
+    }
+  }
 }
 
 const scanTradeApps = async (): Promise<TradeAppInventory[]> => {
-  const slvRoot = `${home()}/slv`
+  const slvRoot = join(requireHome(), 'slv')
   const apps: TradeAppInventory[] = []
   try {
     for await (const entry of Deno.readDir(slvRoot)) {
       if (!entry.isDirectory || entry.name.startsWith('.')) continue
-      const dir = `${slvRoot}/${entry.name}`
+      const dir = join(slvRoot, entry.name)
       let hasBinary = false
       let hasWallet = false
       try {
-        await Deno.stat(`${dir}/target/release/trade-app`)
+        await Deno.stat(join(dir, 'target/release/trade-app'))
         hasBinary = true
       } catch { /* no binary */ }
       try {
-        await Deno.stat(`${dir}/wallet.json`)
+        await Deno.stat(join(dir, 'wallet.json'))
         hasWallet = true
       } catch { /* no wallet */ }
       apps.push({ name: entry.name, hasBinary, hasWallet })
     }
-  } catch { /* ~/slv doesn't exist */ }
+  } catch (err) {
+    // Only swallow NotFound — other errors (permission, etc.) should bubble
+    // so the top-level catch in detectProfile() can log them cleanly.
+    if (!(err instanceof Deno.errors.NotFound)) throw err
+  }
   return apps
 }
 
@@ -83,11 +134,13 @@ type ConfigSkill = { name: string; enabled: boolean; agent?: string }
 const readEnabledSkills = async (): Promise<ConfigSkill[]> => {
   try {
     const raw = await Deno.readTextFile(
-      `${home()}/.slv/agent/config.yml`,
+      join(requireHome(), '.slv/agent/config.yml'),
     )
     const cfg = parse(raw) as { skills?: ConfigSkill[] } | null
     return (cfg?.skills || []).filter((s) => s && s.enabled)
-  } catch { /* not configured */ }
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err
+  }
   return []
 }
 
@@ -172,37 +225,52 @@ export const detectProfile = async (): Promise<UserProfile> => {
 }
 
 // Short human-readable summary for the opening greeting. One line only.
+// Uses the i18n dictionary so non-English users see this in their language.
+// The translations for each key live in cli/src/ai/i18n/messages/<lang>.ts.
 export const describeProfile = (profile: UserProfile): string => {
   const { primary, apps } = profile
-  const appCount = apps.filter((a) => a.hasBinary || a.hasWallet).length
+  const liveApps = apps.filter((a) => a.hasBinary || a.hasWallet)
+  const appCount = liveApps.length
 
   switch (primary) {
     case 'app': {
       if (appCount === 0) {
-        return "Focused on Solana App Development. Say 'new trade bot' when you're ready."
+        return t(
+          "Focused on Solana App Development. Say 'new trade bot' when you're ready.",
+        )
       }
       if (appCount === 1) {
-        const a = apps.find((x) => x.hasBinary || x.hasWallet)!
-        return `Focused on App Development. You have 1 trade app: ${a.name}.`
+        return t('Focused on App Development. You have 1 trade app: {name}.')
+          .replace('{name}', liveApps[0].name)
       }
-      return `Focused on App Development. You have ${appCount} trade apps in ~/slv/.`
+      return t(
+        'Focused on App Development. You have {count} trade apps in ~/slv/.',
+      ).replace('{count}', String(appCount))
     }
     case 'validator':
-      return 'Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades.'
+      return t(
+        'Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades.',
+      )
     case 'rpc':
-      return 'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.'
+      return t(
+        'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.',
+      )
     case 'mixed':
-      return 'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.'
+      return t(
+        'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.',
+      )
   }
 }
 
 // Human-readable prompt-context block inserted into the main system prompt.
-// Kept short to avoid bloating every turn.
+// Kept short to avoid bloating every turn. The content is English regardless
+// of `lang` because the model reasons in English internally — translation is
+// only applied to user-facing output.
 export const profilePromptBlock = (profile: UserProfile): string => {
   const { primary, apps, signals, overridden } = profile
-  const appCount = apps.filter((a) => a.hasBinary || a.hasWallet).length
-  const appList = apps
-    .filter((a) => a.hasBinary || a.hasWallet)
+  const liveApps = apps.filter((a) => a.hasBinary || a.hasWallet)
+  const appCount = liveApps.length
+  const appList = liveApps
     .map((a) => `- ${a.name} (binary=${a.hasBinary}, wallet=${a.hasWallet})`)
     .join('\n')
 
@@ -217,13 +285,24 @@ export const profilePromptBlock = (profile: UserProfile): string => {
       'The user spans multiple roles. Listen for intent before proactively suggesting anything; offer options rather than picking one role.',
   }
 
-  return `## User Profile
-
-- **Primary focus:** ${primary}${overridden ? ' (manual /focus override)' : ''}
-- **Signals:** ${signals.join('; ') || 'none'}
-${appCount > 0 ? `- **Trade apps in ~/slv:** ${appCount}\n${appList}\n` : ''}
-### Routing preference
-${roleGuidance[primary]}
-
-The user can override this at any time with \`/focus validator\`, \`/focus rpc\`, \`/focus app\`, or \`/focus mixed\`. Always honor an explicit intent over the profile — the profile is a prior, not a gate.`
+  const lines: string[] = [
+    '## User Profile',
+    '',
+    `- **Primary focus:** ${primary}${
+      overridden ? ' (manual /focus override)' : ''
+    }`,
+    `- **Signals:** ${signals.join('; ') || 'none'}`,
+  ]
+  if (appCount > 0) {
+    lines.push(`- **Trade apps in ~/slv:** ${appCount}`)
+    lines.push(appList)
+  }
+  lines.push('')
+  lines.push('### Routing preference')
+  lines.push(roleGuidance[primary])
+  lines.push('')
+  lines.push(
+    "The user can override this at any time with `/focus validator`, `/focus rpc`, `/focus app`, or `/focus mixed`. Always honor an explicit intent over the profile — the profile is a prior, not a gate.",
+  )
+  return lines.join('\n')
 }

--- a/cli/src/ai/console/profile.ts
+++ b/cli/src/ai/console/profile.ts
@@ -126,10 +126,18 @@ export const clearFocusOverride = async (): Promise<void> => {
 }
 
 const scanTradeApps = async (): Promise<TradeAppInventory[]> => {
-  // NOTE: `~/slv/` holds user-scaffolded bot projects (created by
-  // `slv bot init`). It is NOT the same as `~/.slv/`, which holds the SLV
-  // CLI config (agent/, skills/, api.yml, …). The two are adjacent in the
-  // home dir and the name similarity is a trap for future maintainers.
+  // NOTE: Do NOT confuse `~/slv/` and `~/.slv/` — they have completely
+  // different purposes even though the names look alike.
+  //
+  //   ~/slv/   → user application development code. Each subdirectory is
+  //              a bot / app project scaffolded by `slv bot init` (source
+  //              tree, Cargo.toml, wallet.json, target/, .env, …). These
+  //              are what this function enumerates.
+  //
+  //   ~/.slv/  → SLV CLI infrastructure: agent/ (SOUL.md, USER.md, config.yml,
+  //              MEMORY.md, focus.txt), skills/ (AGENT.md / SKILL.md per skill),
+  //              templates, api.yml, keys, logs, and other SLV-owned state.
+  //              Never scanned here.
   const slvRoot = join(requireHome(), 'slv')
   const apps: TradeAppInventory[] = []
   try {

--- a/cli/src/ai/console/systemPrompt.ts
+++ b/cli/src/ai/console/systemPrompt.ts
@@ -3,6 +3,7 @@ import { resolveHome } from '/lib/getApiKeyFromYml.ts'
 import { VERSION } from '@cmn/constants/version.ts'
 import { DISCORD_LINK } from '@cmn/constants/url.ts'
 import { readLang } from '@/ai/config.ts'
+import { detectProfile, profilePromptBlock } from '@/ai/console/profile.ts'
 
 // --- Context module state management ---
 
@@ -335,6 +336,12 @@ async function buildCorePrompt(userContext?: string): Promise<string> {
     )
   } catch { /* skill not synced yet — Core Rules line still applies */ }
 
+  // Detect the user's primary focus (validator / rpc / app / mixed) so the
+  // main agent can bias its proactive suggestions. See profile.ts for the
+  // exact signal hierarchy.
+  const userProfile = await detectProfile().catch(() => null)
+  const profileBlock = userProfile ? profilePromptBlock(userProfile) : ''
+
   // Read config to get enabled skills and mode
   let configYml: Record<string, unknown> = { skills: [] }
   try {
@@ -467,7 +474,7 @@ ${soulMd ? `## Identity\n${soulMd}\n` : ''}
 ${userMd ? `## User\n${userMd}\n` : ''}
 ${memoryMd ? `## Memory\n${memoryMd}\n` : ''}
 ${modeSection}
-
+${profileBlock ? `\n${profileBlock}\n` : ''}
 ## Core Rules
 - Keep replies short, practical, and natural.
 - Ask one question at a time.
@@ -475,6 +482,7 @@ ${modeSection}
 - Use bullet points instead of markdown tables.
 - Show payment or purchase links as the full URL on its own line.
 - Warn before destructive actions.
+- **Proactive backup reminders**: periodically remind the user about \`slv backup create --upload -y -r <region>\` — especially (a) at the end of a successful deployment, config change, or validator upgrade, (b) when they tell you they're about to make a risky change, (c) when they open a new session and you see no recent backup-related chatter in MEMORY.md. Never run it for them silently; always phrase it as a suggestion the user can accept or decline.
 - **Non-interactive CLI only**: \`run_command\` has no TTY, so any \`slv\` subcommand that falls into a cliffy \`Input\`/\`Select\`/\`Confirm\` prompt hangs the console forever. For \`slv backup\` and \`slv storage\` especially, **always pass explicit arguments and \`-y\` where applicable** (e.g. \`slv backup create --upload -y -r eu\`, \`slv storage delete <path> -y -r eu\`). Never call these subcommands with missing positional args hoping the CLI will ask — ask the user in chat instead. See the "Backup & Storage" section below for the full non-interactive reference.
 ${languageRule}
 ${

--- a/cli/src/ai/i18n/messages/en.ts
+++ b/cli/src/ai/i18n/messages/en.ts
@@ -112,4 +112,18 @@ export const messages: Record<string, string> = {
     'Find optimized Solana server resources',
   'Benchmarks & connectivity testing': 'Benchmarks & connectivity testing',
   'Goodbye!': 'Goodbye!',
+
+  // --- User profile (role detection) ---
+  "Focused on Solana App Development. Say 'new trade bot' when you're ready.":
+    "Focused on Solana App Development. Say 'new trade bot' when you're ready.",
+  'Focused on App Development. You have 1 trade app: {name}.':
+    'Focused on App Development. You have 1 trade app: {name}.',
+  'Focused on App Development. You have {count} trade apps in ~/slv/.':
+    'Focused on App Development. You have {count} trade apps in ~/slv/.',
+  'Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades.':
+    'Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades.',
+  'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.':
+    'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.',
+  'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
+    'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.',
 }

--- a/cli/src/ai/i18n/messages/ja.ts
+++ b/cli/src/ai/i18n/messages/ja.ts
@@ -106,4 +106,17 @@ export const messages: Record<string, string> = {
     '最適な Solana サーバーリソースの調達',
   'Benchmarks & connectivity testing': 'ベンチマークと接続性テスト',
   'Goodbye!': 'さようなら！',
+
+  "Focused on Solana App Development. Say 'new trade bot' when you're ready.":
+    'Solana アプリ開発にフォーカス中。準備ができたら「new trade bot」と言ってください。',
+  'Focused on App Development. You have 1 trade app: {name}.':
+    'アプリ開発にフォーカス中。トレードアプリが 1 つあります: {name}。',
+  'Focused on App Development. You have {count} trade apps in ~/slv/.':
+    'アプリ開発にフォーカス中。~/slv/ にトレードアプリが {count} 個あります。',
+  'Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades.':
+    'Solana バリデータ運用にフォーカス中。デプロイ、ヘルスチェック、アップグレードなどご相談ください。',
+  'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.':
+    'RPC / gRPC ノード運用にフォーカス中。エンドポイント設定、ヘルス、チューニングなどご相談ください。',
+  'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
+    '複数の役割にフォーカス中 — validator + app / rpc。`/focus <validator|rpc|app>` で絞り込めます。',
 }

--- a/cli/src/ai/i18n/messages/ru.ts
+++ b/cli/src/ai/i18n/messages/ru.ts
@@ -107,4 +107,17 @@ export const messages: Record<string, string> = {
   'Benchmarks & connectivity testing':
     'Бенчмарки и тестирование соединения',
   'Goodbye!': 'До свидания!',
+
+  "Focused on Solana App Development. Say 'new trade bot' when you're ready.":
+    'Фокус на разработке Solana-приложений. Скажите "new trade bot", когда будете готовы.',
+  'Focused on App Development. You have 1 trade app: {name}.':
+    'Фокус на разработке приложений. У вас 1 торговое приложение: {name}.',
+  'Focused on App Development. You have {count} trade apps in ~/slv/.':
+    'Фокус на разработке приложений. В ~/slv/ находится {count} торговых приложений.',
+  'Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades.':
+    'Фокус на эксплуатации Solana-валидаторов. Спрашивайте о развёртываниях, здоровье и обновлениях.',
+  'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.':
+    'Фокус на эксплуатации RPC / gRPC узлов. Спрашивайте о настройке эндпоинтов, здоровье и тюнинге.',
+  'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
+    'Смешанный фокус — validator + app / rpc. Используйте `/focus <validator|rpc|app>`, чтобы сузить.',
 }

--- a/cli/src/ai/i18n/messages/vi.ts
+++ b/cli/src/ai/i18n/messages/vi.ts
@@ -107,4 +107,17 @@ export const messages: Record<string, string> = {
   'Benchmarks & connectivity testing':
     'Kiểm thử hiệu năng & kết nối',
   'Goodbye!': 'Tạm biệt!',
+
+  "Focused on Solana App Development. Say 'new trade bot' when you're ready.":
+    'Đang tập trung vào phát triển ứng dụng Solana. Nói "new trade bot" khi bạn đã sẵn sàng.',
+  'Focused on App Development. You have 1 trade app: {name}.':
+    'Đang tập trung vào phát triển ứng dụng. Bạn có 1 trade app: {name}.',
+  'Focused on App Development. You have {count} trade apps in ~/slv/.':
+    'Đang tập trung vào phát triển ứng dụng. Bạn có {count} trade app trong ~/slv/.',
+  'Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades.':
+    'Đang tập trung vào vận hành Solana Validator. Hỏi tôi về triển khai, health hoặc upgrade.',
+  'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.':
+    'Đang tập trung vào vận hành node RPC / gRPC. Hỏi tôi về cấu hình endpoint, health hoặc tinh chỉnh.',
+  'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
+    'Focus hỗn hợp — validator + app / rpc. Dùng `/focus <validator|rpc|app>` để thu hẹp.',
 }

--- a/cli/src/ai/i18n/messages/zh.ts
+++ b/cli/src/ai/i18n/messages/zh.ts
@@ -102,4 +102,17 @@ export const messages: Record<string, string> = {
     '寻找最优 Solana 服务器资源',
   'Benchmarks & connectivity testing': '基准测试与连通性测试',
   'Goodbye!': '再见！',
+
+  "Focused on Solana App Development. Say 'new trade bot' when you're ready.":
+    '专注于 Solana 应用开发。准备好后请说 "new trade bot"。',
+  'Focused on App Development. You have 1 trade app: {name}.':
+    '专注于应用开发。您有 1 个交易应用: {name}。',
+  'Focused on App Development. You have {count} trade apps in ~/slv/.':
+    '专注于应用开发。~/slv/ 中共有 {count} 个交易应用。',
+  'Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades.':
+    '专注于 Solana 验证者运维。可询问部署、健康检查或升级。',
+  'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.':
+    '专注于 RPC / gRPC 节点运维。可询问端点配置、健康或调优。',
+  'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
+    '混合焦点 — validator + app / rpc。使用 `/focus <validator|rpc|app>` 进行细分。',
 }

--- a/cli/src/ai/onboard/onboardAction.ts
+++ b/cli/src/ai/onboard/onboardAction.ts
@@ -397,6 +397,11 @@ export const onboardAction = async () => {
     if (existing.enabledOps) return existing.enabledOps.includes(op)
     return firstRunDefault
   }
+  // First-run defaults: only the top option is pre-checked. This narrows the
+  // implied primary focus to Validator Operations (SLV's original flagship
+  // use-case) and stops the onboarding flow from dumping the user into a
+  // "you do everything" state. The user can still tick more with Space.
+  // Second-run: defaults come from the existing config (`existing.enabledOps`).
   const selectedOps: string[] = await Checkbox.prompt({
     message: t('What will you be doing? (↑↓ move, Space toggle, Enter confirm)'),
     options: [
@@ -408,17 +413,17 @@ export const onboardAction = async () => {
       {
         name: 'Index RPC Node Operations',
         value: 'Index RPC Node Operations',
-        checked: isChecked('Index RPC Node Operations', true),
+        checked: isChecked('Index RPC Node Operations', false),
       },
       {
         name: 'gRPC Geyser Streaming',
         value: 'gRPC Geyser Streaming',
-        checked: isChecked('gRPC Geyser Streaming', true),
+        checked: isChecked('gRPC Geyser Streaming', false),
       },
       {
         name: 'Benchmark & Connectivity Testing',
         value: 'Benchmark & Connectivity Testing',
-        checked: isChecked('Benchmark & Connectivity Testing', true),
+        checked: isChecked('Benchmark & Connectivity Testing', false),
       },
       {
         name: 'Solana App Development (Trade Bot)',
@@ -428,7 +433,7 @@ export const onboardAction = async () => {
       {
         name: 'Server Procurement',
         value: 'Server Procurement',
-        checked: isChecked('Server Procurement', true),
+        checked: isChecked('Server Procurement', false),
       },
     ],
   })

--- a/dist/oss-skills/slv-backup/SKILL.md
+++ b/dist/oss-skills/slv-backup/SKILL.md
@@ -157,6 +157,44 @@ positional quantity — passing nothing hangs on `Input.prompt`.
 If you catch yourself about to run any of the above, **stop and ask the
 user** instead.
 
+## When to proactively suggest a backup
+
+The main agent should not wait for the user to ask. `slv backup create` is
+cheap, non-destructive, and the single biggest insurance policy against the
+kind of disasters a validator / RPC / trade-app operator actually
+experiences (disk failure, bad config push, accidental `rm`). Offer a
+backup — **as a suggestion, not a silent action** — at these moments:
+
+- **After a successful validator deployment or upgrade**: "Now's a good
+  time to snapshot this box with `slv backup create --upload -y -r <region>
+  --retention 7`. Want me to run it?"
+- **Before a risky change** the user just described: a restart, a config
+  rewrite, a package upgrade, a kernel reboot. "Before we do that, want me
+  to take a backup? It's a one-liner and saves you if something breaks."
+- **At the start of a session** when MEMORY.md shows no recent
+  backup-related activity and the host has clearly been in production (has
+  a validator or RPC or trade-app). "Quick check — when did you last back
+  this box up? Happy to run `slv backup create` now."
+- **After the user asks "how do I protect against X?"** — almost any
+  answer includes backup.
+- **Periodically during long sessions**: once per session is plenty. Don't
+  nag; once the user declines, drop it for the session.
+
+Do NOT run `slv backup create` silently. Always phrase it as a suggestion,
+show the exact command you would run, and wait for explicit consent. The
+user decides. If they decline, respect it and move on.
+
+When the user agrees, use the non-interactive form from the reference
+above:
+
+```bash
+slv backup create --upload -y -r <region> --retention 7
+```
+
+Substitute `<region>` with the user's preferred region if known (check
+`SLV_STORAGE_REGION` env or their onboard config); otherwise ask once in
+chat before running.
+
 ## Env var shortcuts
 
 - `SLV_STORAGE_REGION` — default region for `slv storage` subcommands when `-r` is omitted.


### PR DESCRIPTION
## Why

Solana operators cluster into three archetypes — **validator runners**, **RPC / Geyser operators**, and **trade-app developers** — and each wants very different proactive help from the main agent. Until now the assistant treated everyone the same and pushed every skill at every user. This PR teaches the console to read a few strong signals, classify the user into a primary role, and bias its behaviour accordingly. Manual override stays trivial.

This is **PR A** of a two-part improvement. PR B will fix the remaining TTY-hang points in ``slv backup`` / ``slv storage`` (storage upgrade Input prompt, restore file selector, etc.).

## What it does

### 1. ``cli/src/ai/console/profile.ts`` (new)

- ``detectProfile()`` reads ``~/.slv/agent/config.yml`` enabled skills and scans ``~/slv/*`` for trade-app projects (``target/release/trade-app`` binary + ``wallet.json``), then classifies the user as ``validator``, ``rpc``, ``app``, or ``mixed``.
- Priority chain: **manual /focus override > live trade apps > enabled skills > default validator**. A real trade-bot with a wallet beats whatever the user ticked during onboard — the user's activity is more informative than their original intent.
- ``writeFocusOverride`` / ``clearFocusOverride`` persist a ``/focus`` choice to ``~/.slv/agent/focus`` so it survives sessions.
- ``profilePromptBlock()`` renders a compact ``## User Profile`` system-prompt section with role-specific routing guidance.
- ``describeProfile()`` renders a one-line hint for the console greeting.

### 2. System prompt (``cli/src/ai/console/systemPrompt.ts``)

- ``buildCorePrompt`` now inlines the profile block above Core Rules, so every turn carries the user's focus as context.
- New **Core Rule**: proactively suggest ``slv backup create --upload -y -r <region> --retention 7`` at natural moments — after deploys, before risky changes, at session start when MEMORY.md shows no recent backup activity. Always a suggestion (never a silent action), always phrased so the user can decline.

### 3. Console (``cli/src/ai/console/consoleAction.ts``)

- ``buildLocalGreeting`` appends the one-line profile hint so the user immediately sees what the console detected (e.g. "Focused on App Development. You have 1 trade app: solana-trade-bot.").
- New ``/focus <validator|rpc|app|mixed|auto>`` slash command.
  - Any role value persists to the override file.
  - ``/focus auto`` clears the override and falls back to heuristic detection.
  - System prompt is rebuilt immediately after a change, so the next user turn reflects the new focus without requiring ``/clear``.
- ``/help`` now lists ``/focus``.

### 4. Onboard (``cli/src/ai/onboard/onboardAction.ts``)

- "What will you be doing?" Checkbox now defaults to **only the first option** (Solana Validator Operations). Users who do more still tick more with Space — the behaviour is unchanged — but the default no longer dumps a fresh user into an "everything at once" state. Second-run defaults still come from the existing config, so returning users are unaffected.

### 5. Skill doc (``dist/oss-skills/slv-backup/SKILL.md``)

- New **"When to proactively suggest a backup"** section with concrete trigger scenarios (post-deploy, pre-risky-change, session start, user asks "how do I protect against X"). Explicit rule: suggest, don't silently run; respect a decline for the rest of the session.

## Test plan

- [ ] Fresh install, no ``~/slv``, no enabled skills → greeting shows "Focused on Solana Validator Operations. Ask me about deploys, health, or upgrades."
- [ ] Run ``slv bot init -t trade-app -n demo`` and restart ``slv c`` → greeting switches to "Focused on App Development. You have 1 trade app: demo."
- [ ] ``/focus rpc`` → system prompt rebuilds, next turn biases toward RPC suggestions. Restart ``slv c`` → focus still ``rpc`` (persisted).
- [ ] ``/focus auto`` → override cleared, detection returns to heuristic.
- [ ] ``/focus`` with no arg → prints current focus + usage.
- [ ] ``/help`` shows the new ``/focus`` entry.
- [ ] First-time ``slv onboard`` → Checkbox only Validator pre-checked. Second run → previously-enabled skills remain pre-checked.
- [ ] After a successful validator deploy in the same session, the main agent spontaneously suggests ``slv backup create ...``.

## Non-goals (follow-up PR)

- Actually running ``slv backup create`` non-interactively is already covered by PR #277's slv-backup skill. **Remaining TTY hang points** in ``slv backup import`` (Select file selector, line 77), ``slv storage upgrade`` (Input capacity, line 52) are the target of PR B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)