### PR TITLE
fix(backup,storage): close remaining TTY hang points

### DIFF
--- a/cli/src/backup/importAction.ts
+++ b/cli/src/backup/importAction.ts
@@ -144,8 +144,12 @@ export const importAction = async (
     return
   }
 
-  // If no argument provided and restic is available, offer choice between restic and tar
-  if (!file && await hasRestic()) {
+  // If no argument provided and restic is available, offer choice between
+  // restic and tar. Under --yes (non-interactive / agent-driven), skip the
+  // Select and default to tar — the same path a machine without restic
+  // installed would take. Agents that explicitly want restic should pass
+  // a snapshot id as the positional argument.
+  if (!file && await hasRestic() && !options.yes) {
     try {
       const mode = await Select.prompt({
         message: 'Restore from:',
@@ -201,8 +205,24 @@ export const importAction = async (
     if (file) {
       // Treat as remote path
       remotePath = file.startsWith('backups/') ? file : `backups/${file}`
+    } else if (options.yes) {
+      // Non-interactive mode with no file specified — refuse rather than
+      // falling into the interactive Select, which would hang run_command.
+      // Agents must pass an explicit filename (use `slv backup list` to
+      // discover it first).
+      console.log(
+        colors.red(
+          '\n❌ --yes was passed but no backup file was specified.',
+        ),
+      )
+      console.log(
+        colors.white(
+          '   Run `slv backup list` first, then `slv backup restore <filename> -y`.\n',
+        ),
+      )
+      return
     } else {
-      // Interactive selection
+      // Interactive selection (TTY users only)
       remotePath = await selectRemoteBackup(apiKey, region)
     }
 

--- a/cli/src/storage/index.ts
+++ b/cli/src/storage/index.ts
@@ -112,8 +112,9 @@ export const storageCmd = new Command()
   })
   .command('upgrade', 'Change storage capacity (upgrade or downgrade)')
   .arguments('[quantity:number]')
-  .action(async (_options, quantity?: number) => {
-    await upgradeAction(quantity)
+  .option('-y, --yes', 'Skip confirmation prompts (non-interactive)')
+  .action(async (options, quantity?: number) => {
+    await upgradeAction(quantity, { yes: options.yes })
   })
   .command('sync', 'Reconcile storage usage with actual cloud data')
   .option('-r, --region <region:string>', 'Storage region')

--- a/cli/src/storage/upgrade/upgradeAction.ts
+++ b/cli/src/storage/upgrade/upgradeAction.ts
@@ -10,7 +10,10 @@ import {
 import { formatBytes } from '/src/storage/upload/uploadAction.ts'
 import Kia from 'https://deno.land/x/kia@0.4.1/mod.ts'
 
-export const upgradeAction = async (quantity?: number) => {
+export const upgradeAction = async (
+  quantity?: number,
+  options: { yes?: boolean } = {},
+) => {
   const apiKey = await getApiKeyFromYml()
 
   const spinner = new Kia(colors.cyan('Fetching current storage info...'))
@@ -48,6 +51,20 @@ export const upgradeAction = async (quantity?: number) => {
     let newGB: number
     if (quantity !== undefined) {
       newGB = quantity
+    } else if (options.yes) {
+      // Non-interactive mode — refuse rather than falling into Input.prompt,
+      // which would hang run_command. Agents must pass the quantity.
+      console.log(
+        colors.red(
+          '\n❌ --yes was passed but no capacity was specified.',
+        ),
+      )
+      console.log(
+        colors.white(
+          `   Usage: slv storage upgrade <GB> -y   (multiples of ${GB_PER_UNIT})\n`,
+        ),
+      )
+      return false
     } else {
       const input = await Input.prompt({
         message: `New storage capacity in GB (multiples of ${GB_PER_UNIT}, e.g. 5, 10, 15)`,
@@ -90,15 +107,27 @@ export const upgradeAction = async (quantity?: number) => {
       ),
     )
 
-    // Confirm
-    const confirmed = await Confirm.prompt({
-      message: `Proceed with ${action}?`,
-      default: true,
-    })
+    // Confirm (skipped under --yes so agents can run this end-to-end).
+    if (!options.yes) {
+      const confirmed = await Confirm.prompt({
+        message: `Proceed with ${action}?`,
+        default: true,
+      })
 
-    if (!confirmed) {
-      console.log(colors.yellow(`\n${action.charAt(0).toUpperCase() + action.slice(1)} cancelled.`))
-      return false
+      if (!confirmed) {
+        console.log(
+          colors.yellow(
+            `\n${action.charAt(0).toUpperCase() + action.slice(1)} cancelled.`,
+          ),
+        )
+        return false
+      }
+    } else {
+      console.log(
+        colors.yellow(
+          `   --yes provided — proceeding with ${action} without confirmation.`,
+        ),
+      )
     }
 
     const upgradeSpinner = new Kia(colors.cyan('Updating storage plan...'))

--- a/dist/oss-skills/slv-backup/SKILL.md
+++ b/dist/oss-skills/slv-backup/SKILL.md
@@ -54,14 +54,20 @@ Both are fully non-interactive. No `-y` needed.
 ```bash
 slv backup restore <remote-file-or-snapshot-id> -y -r eu
 ```
-- The positional `<file>` is **required**. If you do not pass it, the
-  command enters an interactive file selector and hangs. Ask the user
-  for the exact filename (`slv backup list` first) before restoring.
+- The positional `<file>` is **required under `-y`**. Without a file and
+  with `-y`, the CLI now refuses with
+  `❌ --yes was passed but no backup file was specified` — it no longer
+  drops into a `Select` prompt that hangs the agent. Always run
+  `slv backup list -r <region>` first, show the user the options, and
+  ask them to pick a filename before invoking restore.
 - `-y` is **required** for agents. It prints the root-filesystem warning
   banner and proceeds without a TTY confirmation. Since this extracts tar
   over `/` and requires a reboot, **always show the user the target file
   name in chat and ask them to confirm in words** before you execute.
 - `-r <region>` — region where the backup lives.
+- When both `-y` and restic are available, the CLI defaults to the tar
+  path. To restore from a restic snapshot, pass the snapshot id
+  explicitly as the positional argument.
 
 ### Schedule a cron backup
 ```bash
@@ -119,7 +125,7 @@ Alias: `slv storage rm`.
 slv storage usage                # all regions with data
 slv storage usage -r eu          # single region
 slv storage product              # show available storage products
-slv storage upgrade 5            # buy 5 GB more (positional arg required)
+slv storage upgrade 5 -y         # upgrade to 5 GB (positional arg + -y required)
 slv storage sync -r eu           # reconcile local usage cache with cloud
 ```
 `product`, `usage`, `sync` have no prompts. `upgrade` **requires** the
@@ -140,7 +146,7 @@ positional quantity — passing nothing hangs on `Input.prompt`.
 | "delete file X from storage" | Confirm in chat → `slv storage delete X -y -r <region>` |
 | "clean up old backups" | Confirm prefix in chat → `slv storage delete -p <prefix> -y -r <region>` |
 | "how much storage am I using" | `slv storage usage` |
-| "buy more storage" | Ask quantity in chat → `slv storage upgrade <n>` |
+| "buy more storage" | Ask quantity in chat → `slv storage upgrade <n> -y` |
 
 ## Forbidden patterns (will hang the console)
 
@@ -151,7 +157,7 @@ positional quantity — passing nothing hangs on `Input.prompt`.
 - `slv storage download` without a positional remote path
 - `slv storage delete` without `-y`
 - `slv storage delete -p <prefix>` without `-y`
-- `slv storage upgrade` without a quantity
+- `slv storage upgrade` without a quantity, or without `-y`
 - Any subcommand with an ambiguous region when the user has not chosen one — ask in chat first, do not let the CLI prompt.
 
 If you catch yourself about to run any of the above, **stop and ask the


### PR DESCRIPTION
## Why

After PR #277 and the slv-backup skill doc (PR #277, #282), four interactive prompts in ``slv backup restore`` and ``slv storage upgrade`` could still hang the AI console because they were not gated by ``--yes``. This PR closes all four so agents can run the full backup-and-storage lifecycle end-to-end without ever falling into a TTY prompt that ``run_command`` cannot answer.

This is **PR B** of the plan I outlined when #282 was merged.

## What was still broken

| File:Line | Prompt | Impact |
|---|---|---|
| ``backup/importAction.ts:~77`` | ``Select.prompt`` — cloud-backup file selector | Calling ``slv backup restore -y`` without a filename dropped into a selector and hung the agent. |
| ``backup/importAction.ts:~150`` | ``Select.prompt`` — tar vs restic mode | Boxes with restic installed had this fire even with ``-y``. Agents never got past it. |
| ``storage/upgrade/upgradeAction.ts:~52`` | ``Input.prompt`` — capacity in GB | Without a positional quantity, agents hung on input. |
| ``storage/upgrade/upgradeAction.ts:~94`` | ``Confirm.prompt`` — upgrade/downgrade | No ``-y`` bypass existed; agents could never reach the actual API call. |

## Fixes

### ``cli/src/backup/importAction.ts``

- **Tar vs restic Select** now gated on ``!options.yes``. Under ``--yes``, the Select is skipped and the command falls through to the tar path (same behaviour a box without restic would take). Agents that specifically want restic must pass a snapshot id as the positional argument — explicit intent, no guessing.
- **Cloud-backup file selector**: the caller refuses early when ``--yes`` is passed with no file:

  > ❌ --yes was passed but no backup file was specified.
  > Run ``slv backup list`` first, then ``slv backup restore <filename> -y``.

  The interactive ``selectRemoteBackup`` Select is only reached when ``--yes`` is NOT set, so TTY users keep the picker.

### ``cli/src/storage/upgrade/upgradeAction.ts``

- New second parameter ``options: { yes?: boolean } = {}``.
- **Capacity Input.prompt**: under ``--yes`` with no quantity, refuses with
  ``❌ --yes was passed but no capacity was specified`` + usage hint, instead of hanging.
- **Final Confirm.prompt**: gated on ``!options.yes``. Under ``--yes`` prints a "proceeding without confirmation" line and continues.

### ``cli/src/storage/index.ts``

- ``slv storage upgrade`` now accepts ``-y, --yes``, forwarded to ``upgradeAction``. The flag lives alongside the positional ``[quantity]``, matching ``slv storage delete -y`` and ``slv backup create -y``.

### ``dist/oss-skills/slv-backup/SKILL.md``

- Restore section rewritten to reflect the new ``--yes`` refusal on missing filenames and the new tar-default behaviour.
- ``slv storage upgrade`` example now shows ``-y``.
- "Forbidden patterns" updated so the main agent will not try ``slv storage upgrade <n>`` without ``-y``.

## Test plan

- [ ] ``slv backup restore -y`` (no filename) → prints the refusal message and exits cleanly. Does NOT hang.
- [ ] ``slv backup restore -y`` (no filename, TTY user, no ``-y``) → still shows the interactive Select picker as before.
- [ ] ``slv backup restore -y`` on a box with restic installed → falls through to tar path without prompting for tar-vs-restic.
- [ ] ``slv backup restore <snapshot-id> -y`` (restic id, restic installed) → still takes the restic path.
- [ ] ``slv storage upgrade -y`` (no quantity) → prints the refusal message and exits cleanly.
- [ ] ``slv storage upgrade 5 -y`` → runs end-to-end, prints "--yes provided — proceeding with upgrade", calls the API.
- [ ] ``slv storage upgrade 5`` (TTY, no ``-y``) → still shows the Confirm prompt.
- [ ] Main agent under ``slv c`` can ask "restore the latest backup" and get a list → user confirms filename → agent runs the restore end-to-end without hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)