### PR TITLE
feat(console): inject TRADE_APP_LANG from api.yml lang on spawn

### DIFF
--- a/cli/src/ai/console/tools.ts
+++ b/cli/src/ai/console/tools.ts
@@ -2,7 +2,7 @@ import { resolveHome } from '/lib/getApiKeyFromYml.ts'
 import { Confirm } from '@cliffy/prompt'
 import Anthropic from '@anthropic-ai/sdk'
 import OpenAI from 'openai'
-import { DEFAULT_MAX_TOKENS, readAiConfig } from '@/ai/config.ts'
+import { DEFAULT_MAX_TOKENS, readAiConfig, readLang } from '@/ai/config.ts'
 import { parse } from '@std/yaml'
 import type { TUI } from '@mariozechner/pi-tui'
 import {
@@ -447,6 +447,7 @@ async function executeRunCommand(command: string): Promise<string> {
       ANSIBLE_STDOUT_CALLBACK: 'default',
       ANSIBLE_DISPLAY_ARGS_TO_STDOUT: 'False',
       PYTHONUNBUFFERED: '1',
+      TRADE_APP_LANG: await readLang(),
     }
     const proc = new Deno.Command('bash', {
       args: ['-c', command],


### PR DESCRIPTION
## Summary
- Read `lang` from `~/.slv/api.yml` via `readLang()` inside `executeRunCommand` and inject it as `TRADE_APP_LANG` on every spawned shell command.
- Lets trade-app (launched via `cargo run` from `slv onboard` / the AI console) automatically pick up the user's configured language for the new 5-language i18n notification templates (en / ja / zh / ru / vi) with no extra setup.
- `executeRunCommand` is the single chokepoint for AI-driven shell spawns, so this covers every launch path; non-trade-app commands ignore the variable harmlessly. Defaults to `en` when `lang` is unset.

## Test plan
- [ ] `deno check cli/src/ai/console/tools.ts` passes
- [ ] With `lang: ja` in `~/.slv/api.yml`, run `slv onboard` → trade-app → confirm Discord notifications render in Japanese
- [ ] With `lang` unset, confirm `TRADE_APP_LANG=en` behavior (default)
- [ ] Verify unrelated shell commands spawned from the console still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)