### PR TITLE
fix(console): hard-guard wallet.json and ~/.slv against rm in run_command

### DIFF
--- a/cli/src/ai/console/tools.ts
+++ b/cli/src/ai/console/tools.ts
@@ -408,7 +408,56 @@ export async function executeSubAgentTool(
   return await executeTool(name, args)
 }
 
+// Hard guard against destructive operations on wallet.json, ~/.slv, and
+// ~/slv/<bot> project directories. This runs before any confirmation or spawn,
+// so it cannot be bypassed by auto-execute mode or by the agent rephrasing a
+// confirm dialog. Returns a reason string if the command must be blocked, or
+// null if it is allowed through.
+function checkWalletGuard(command: string): string | null {
+  const home = '(~|\\$HOME|/Users/[^/\\s\'"]+|/home/[^/\\s\'"]+)'
+  const rmFlags = '\\s+-[a-zA-Z]*[rRfF][a-zA-Z]*'
+  const patterns: { re: RegExp; reason: string }[] = [
+    {
+      re: /\brm\b[^\n]*\bwallet\.json\b/,
+      reason:
+        'refusing to delete wallet.json (contains the trading wallet private key)',
+    },
+    {
+      re: />\s*wallet\.json\b/,
+      reason: 'refusing to truncate or overwrite wallet.json via shell redirect',
+    },
+    {
+      re: new RegExp(`\\brm${rmFlags}\\s+[^\\n]*${home}/\\.slv(/|\\s|$|['"])`),
+      reason:
+        'refusing rm -rf on ~/.slv (holds api.yml, agent config, and credentials)',
+    },
+    {
+      re: new RegExp(
+        `\\brm${rmFlags}\\s+[^\\n]*${home}/slv(/[^\\s'"]+)?(\\s|$|['"])`,
+      ),
+      reason:
+        'refusing rm -rf on ~/slv or a ~/slv/<bot> directory (bot projects contain wallet.json). Delegate bot cleanup to Setzer, or use `slv bot init` which has a built-in wallet rescue layer.',
+    },
+  ]
+  for (const { re, reason } of patterns) {
+    if (re.test(command)) return reason
+  }
+  return null
+}
+
 async function executeRunCommand(command: string): Promise<string> {
+  const guardReason = checkWalletGuard(command)
+  if (guardReason !== null) {
+    const msg =
+      `Command blocked by wallet safety guard: ${guardReason}\n\n` +
+      `Command: ${command}\n\n` +
+      `This is a hard guard that runs before confirmation to protect wallet.json and ~/.slv from accidental deletion. Do not retry with a rephrased command — either delegate to the Setzer sub-agent (agent='Setzer') for bot/app work, or ask the user to run the command manually if they truly intend it.`
+    if (!tuiInstance) {
+      console.log(`  ✗ ${msg}`)
+    }
+    return msg
+  }
+
   let confirmed = true
 
   if (autoExecuteCommands) {


### PR DESCRIPTION
## Summary
Adds a hard pre-execution guard inside `executeRunCommand` (`cli/src/ai/console/tools.ts`) that refuses destructive shell commands targeting the trading wallet and SLV config directories — **regardless of which agent issued them**. This is the last-resort defense so that even if the main agent bypasses delegation to Setzer, the catastrophic paths are blocked.

### What it blocks
- `rm … wallet.json` (any flags, any path form)
- Shell redirect `> wallet.json` (truncate/overwrite)
- `rm -rf` on `~/.slv`, `\$HOME/.slv`, `/Users/*/.slv`, `/home/*/.slv`
- `rm -rf` on `~/slv` or any `~/slv/<bot>` project directory (they contain `wallet.json`)

### How it works
- Runs at the very top of `executeRunCommand`, **before** the confirm dialog and before the `Deno.Command` spawn.
- Cannot be bypassed by auto-execute mode or by the agent answering a confirm prompt.
- Returns an error string to the model telling it to delegate to Setzer instead of retrying.

### Motivation
Recurring incident: the main agent deleted `wallet.json` while operating on trade-app directly instead of delegating to the Setzer sub-agent. The existing `rescueProtectedFiles` layer in `initBotTemplate.ts` only protects the `slv bot init` path and was bypassed by raw bash (`rm -rf ~/slv/<name>`).

This is defense **A** of a three-layer plan. Defenses **B** (force delegation for `app_builder` intent by removing `run_command`/`write_file` from main agent) and **C** (promote wallet rules to CRITICAL section of main agent system prompt) will follow in separate PRs after UX review.

### Pattern validation
17 positive/negative test cases validated locally:

| case | expected | result |
|---|---|---|
| `rm wallet.json` | BLOCK | ✓ |
| `rm -rf wallet.json` | BLOCK | ✓ |
| `rm -f /tmp/wallet.json` | BLOCK | ✓ |
| `cat /dev/null > wallet.json` | BLOCK | ✓ |
| `echo "" > wallet.json` | BLOCK | ✓ |
| `rm -rf ~/.slv` | BLOCK | ✓ |
| `rm -rf ~/.slv/foo` | BLOCK | ✓ |
| `rm -rf /Users/fumi/.slv` | BLOCK | ✓ |
| `rm -rf ~/slv` | BLOCK | ✓ |
| `rm -rf ~/slv/myapp` | BLOCK | ✓ |
| `rm -rf /Users/fumi/slv/myapp` | BLOCK | ✓ |
| `rm -rf ~/slv/myapp && mkdir ~/slv/myapp` | BLOCK | ✓ |
| `rm -rf ~/slv-backup` | pass | ✓ |
| `ls ~/slv` | pass | ✓ |
| `cat ~/.slv/api.yml` | pass | ✓ |
| `cargo run --bin notify-test` | pass | ✓ |
| `cd ~/slv/myapp && cargo build` | pass | ✓ |

## Test plan
- [ ] `deno check cli/src/ai/console/tools.ts` passes
- [ ] In `slv c`, ask the agent to run `rm -rf ~/slv/test-bot` and confirm it is blocked with the guard message (not executed, not even prompted)
- [ ] Confirm benign commands (`cd ~/slv/myapp && cargo build`, `cat ~/.slv/api.yml`) still run normally
- [ ] Confirm Setzer sub-agent is unaffected for legitimate `slv bot init` flows (the guard only blocks raw destructive patterns, not the init command itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)