### PR TITLE
feat(ai): centralize agent config loading + SLV provider sub-agent delegation

### DIFF
--- a/cli/src/ai/agentConfig/loader.ts
+++ b/cli/src/ai/agentConfig/loader.ts
@@ -1,0 +1,301 @@
+import { parse as parseYaml } from '@std/yaml'
+import { resolveHome } from '/lib/getApiKeyFromYml.ts'
+import {
+  resolveAgentConfigPath,
+  resolveApiYmlPath,
+  resolveMemoryMdPath,
+  resolveSkillMdPath,
+  resolveSkillsDir,
+  resolveSoulMdPath,
+  resolveUserMdPath,
+} from '@/ai/agentConfig/paths.ts'
+import {
+  type AgentConfig,
+  AgentConfigSchema,
+  type ApiConfig,
+  ApiConfigSchema,
+  type DeploymentMode,
+  type SkillEntry,
+} from '@/ai/agentConfig/schema.ts'
+import {
+  AGENT_REGISTRY,
+  type AgentId,
+  ALL_AGENT_IDS,
+  isKnownAgentId,
+  listAgentsByOrder,
+} from '@/ai/agentConfig/registry.ts'
+import {
+  parseAgentProfile,
+  type ParsedAgentProfile,
+  parseUserProfile,
+  type ParsedUserProfile,
+} from '@/ai/agentConfig/markdown.ts'
+
+export type ConfigWarningSource =
+  | 'config.yml'
+  | 'api.yml'
+  | 'SOUL.md'
+  | 'USER.md'
+  | 'MEMORY.md'
+  | 'skills'
+
+export interface ConfigWarning {
+  source: ConfigWarningSource
+  message: string
+  path?: string
+}
+
+export interface AgentContext {
+  home: string
+  skillsDir: string
+  raw: {
+    config: AgentConfig
+    api: ApiConfig
+  }
+  soul: ParsedAgentProfile | null
+  user: ParsedUserProfile | null
+  memory: { raw: string } | null
+  /** Specialist agents to expose in this session, with Figaro auto-merge
+   *  already applied and unknown/duplicate ids filtered out. Ordered by
+   *  registry order for display use. */
+  enabledAgents: AgentId[]
+  /** Skills grouped by agent, including registry-declared extraSkills. The
+   *  values are skill names (not paths). Use `resolveSkillMdPath(name)` to
+   *  resolve a specific file. */
+  skillSourcesByAgent: Record<AgentId, string[]>
+  mode: DeploymentMode
+  autoExecute: boolean
+  discordWebhookConfigured: boolean
+  warnings: ConfigWarning[]
+}
+
+interface LoadOptions {
+  force?: boolean
+  /** Override home for tests. */
+  home?: string
+}
+
+let cached: Promise<AgentContext> | null = null
+let cachedHome: string | null = null
+
+const safeReadText = async (
+  path: string,
+): Promise<string | null> => {
+  try {
+    return await Deno.readTextFile(path)
+  } catch {
+    return null
+  }
+}
+
+const safeStat = async (path: string): Promise<boolean> => {
+  try {
+    await Deno.stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const parseYamlSafe = (
+  raw: string,
+  source: ConfigWarningSource,
+  path: string,
+  warnings: ConfigWarning[],
+): unknown => {
+  try {
+    return parseYaml(raw)
+  } catch (err) {
+    warnings.push({
+      source,
+      path,
+      message: `Failed to parse YAML: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    })
+    return null
+  }
+}
+
+const loadAgentConfig = async (
+  path: string,
+  warnings: ConfigWarning[],
+): Promise<AgentConfig> => {
+  const raw = await safeReadText(path)
+  if (raw === null) return AgentConfigSchema.parse({})
+  const parsed = parseYamlSafe(raw, 'config.yml', path, warnings)
+  if (parsed === null) return AgentConfigSchema.parse({})
+  const result = AgentConfigSchema.safeParse(parsed)
+  if (result.success) return result.data
+  warnings.push({
+    source: 'config.yml',
+    path,
+    message: `Schema validation failed: ${
+      result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(
+        '; ',
+      )
+    }`,
+  })
+  return AgentConfigSchema.parse({})
+}
+
+const loadApiConfig = async (
+  path: string,
+  warnings: ConfigWarning[],
+): Promise<ApiConfig> => {
+  const raw = await safeReadText(path)
+  if (raw === null) return ApiConfigSchema.parse({})
+  const parsed = parseYamlSafe(raw, 'api.yml', path, warnings)
+  if (parsed === null) return ApiConfigSchema.parse({})
+  const result = ApiConfigSchema.safeParse(parsed)
+  if (result.success) return result.data
+  warnings.push({
+    source: 'api.yml',
+    path,
+    message: `Schema validation failed: ${
+      result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(
+        '; ',
+      )
+    }`,
+  })
+  return ApiConfigSchema.parse({})
+}
+
+/** Resolve the enabled agent set from config.yml skills plus registry-driven
+ *  auto-enable rules (e.g. Figaro when slv-server-procurement skill exists). */
+const resolveEnabledAgents = async (
+  config: AgentConfig,
+  home: string,
+  warnings: ConfigWarning[],
+): Promise<{ agents: AgentId[]; sources: Record<AgentId, string[]> }> => {
+  const configuredEnabled = new Map<AgentId, SkillEntry[]>()
+  const configuredDisabled = new Set<AgentId>()
+
+  for (const skill of config.skills) {
+    if (!isKnownAgentId(skill.agent)) {
+      warnings.push({
+        source: 'config.yml',
+        message:
+          `Unknown agent "${skill.agent}" for skill "${skill.name}" — ignoring`,
+      })
+      continue
+    }
+    if (skill.enabled) {
+      const list = configuredEnabled.get(skill.agent) ?? []
+      list.push(skill)
+      configuredEnabled.set(skill.agent, list)
+    } else {
+      configuredDisabled.add(skill.agent)
+    }
+  }
+
+  // Apply registry auto-enable rules. Explicit disable wins.
+  for (const id of ALL_AGENT_IDS) {
+    const meta = AGENT_REGISTRY[id]
+    if (!meta.autoEnableIfSkillPresent) continue
+    if (configuredEnabled.has(id)) continue
+    if (configuredDisabled.has(id)) continue
+    const path = resolveSkillMdPath(meta.autoEnableIfSkillPresent, home)
+    if (await safeStat(path)) {
+      configuredEnabled.set(id, [
+        { name: meta.autoEnableIfSkillPresent, enabled: true, agent: id },
+      ])
+    }
+  }
+
+  // Warn if explicitly enabled but skill file missing.
+  for (const [id, skills] of configuredEnabled) {
+    for (const skill of skills) {
+      const present = await safeStat(resolveSkillMdPath(skill.name, home))
+      if (!present) {
+        warnings.push({
+          source: 'skills',
+          message: `Agent ${id} enabled via skill "${skill.name}" but ${
+            resolveSkillMdPath(skill.name, home)
+          } is missing`,
+        })
+      }
+    }
+  }
+
+  const sources = {} as Record<AgentId, string[]>
+  for (const id of ALL_AGENT_IDS) sources[id] = []
+  for (const [id, skills] of configuredEnabled) {
+    const set = new Set<string>(skills.map((s) => s.name))
+    for (const extra of AGENT_REGISTRY[id].extraSkills ?? []) set.add(extra)
+    sources[id] = [...set]
+  }
+
+  const agents = listAgentsByOrder([...configuredEnabled.keys()]).map((m) =>
+    m.id
+  )
+  return { agents, sources }
+}
+
+const detectDiscordWebhook = (
+  agentConfig: AgentConfig,
+  apiConfig: ApiConfig,
+): boolean => {
+  const hook = apiConfig.notifications?.discord_webhook ??
+    agentConfig.notifications?.discord_webhook
+  return typeof hook === 'string' && hook.trim().length > 0
+}
+
+const buildContext = async (
+  home: string,
+): Promise<AgentContext> => {
+  const warnings: ConfigWarning[] = []
+
+  const configPath = resolveAgentConfigPath(home)
+  const apiPath = resolveApiYmlPath(home)
+  const soulPath = resolveSoulMdPath(home)
+  const userPath = resolveUserMdPath(home)
+  const memoryPath = resolveMemoryMdPath(home)
+
+  const [config, api, soulRaw, userRaw, memoryRaw] = await Promise.all([
+    loadAgentConfig(configPath, warnings),
+    loadApiConfig(apiPath, warnings),
+    safeReadText(soulPath),
+    safeReadText(userPath),
+    safeReadText(memoryPath),
+  ])
+
+  const { agents, sources } = await resolveEnabledAgents(
+    config,
+    home,
+    warnings,
+  )
+
+  return {
+    home,
+    skillsDir: resolveSkillsDir(home),
+    raw: { config, api },
+    soul: soulRaw !== null ? parseAgentProfile(soulRaw) : null,
+    user: userRaw !== null ? parseUserProfile(userRaw) : null,
+    memory: memoryRaw !== null ? { raw: memoryRaw } : null,
+    enabledAgents: agents,
+    skillSourcesByAgent: sources,
+    mode: config.mode,
+    autoExecute: config.auto_execute,
+    discordWebhookConfigured: detectDiscordWebhook(config, api),
+    warnings,
+  }
+}
+
+/** Load and memoize the agent context. Subsequent calls in the same session
+ *  return the cached result. Pass `{ force: true }` to re-read files, or
+ *  call `invalidateAgentContext()` after writing to any config file. */
+export const loadAgentContext = (
+  opts: LoadOptions = {},
+): Promise<AgentContext> => {
+  const home = opts.home ?? resolveHome()
+  if (!opts.force && cached && cachedHome === home) return cached
+  cached = buildContext(home)
+  cachedHome = home
+  return cached
+}
+
+export const invalidateAgentContext = (): void => {
+  cached = null
+  cachedHome = null
+}

--- a/cli/src/ai/agentConfig/markdown.ts
+++ b/cli/src/ai/agentConfig/markdown.ts
@@ -1,0 +1,143 @@
+import { parse as parseYaml } from '@std/yaml'
+import {
+  AgentProfileFrontmatterSchema,
+  UserProfileFrontmatterSchema,
+} from '@/ai/agentConfig/schema.ts'
+
+/**
+ * Markdown profile parsing for SOUL.md and USER.md.
+ *
+ * Supports two formats:
+ *
+ *   1. YAML frontmatter (preferred for new files)
+ *      ---
+ *      name: EL
+ *      role: Commander
+ *      ---
+ *      # Free-form markdown below…
+ *
+ *   2. Bullet-list style (the format used by the current onboarding template)
+ *      - **Name:** EL
+ *      - **Call me:** K
+ *
+ * The fallback regex strips optional list markers (`- `/`* `), markdown
+ * emphasis (`**`), and tolerates both ASCII `:` and full-width `：` colons.
+ * It fixes two bugs that existed in the previous inline regex:
+ *   - `**Name:** EL` used to capture `** EL` (asterisks leaked into value).
+ *   - USER.md only matched `preferred_name:`; real files use `Call me:`,
+ *     so `preferredName` was always empty.
+ */
+
+export interface ParsedAgentProfile {
+  name?: string
+  role?: string
+  /** Original file contents (for embedding into the system prompt). */
+  raw: string
+}
+
+export interface ParsedUserProfile {
+  name?: string
+  preferredName?: string
+  raw: string
+}
+
+const FRONTMATTER_OPEN = '---\n'
+
+const extractFrontmatter = (raw: string): Record<string, unknown> | null => {
+  if (!raw.startsWith(FRONTMATTER_OPEN)) return null
+  const rest = raw.slice(FRONTMATTER_OPEN.length)
+  // Accept both '\n---\n' and trailing '\n---' (no newline at EOF).
+  const endIdx = rest.search(/\n---(?:\n|$)/)
+  if (endIdx === -1) return null
+  const yamlBlock = rest.slice(0, endIdx)
+  try {
+    const parsed = parseYaml(yamlBlock)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    // fall through to bullet-list parsing
+  }
+  return null
+}
+
+// Bullet-list field matcher. Captures (key) and (value), stripping:
+//   - leading "- " or "* " bullet marker (optional)
+//   - surrounding `**` markdown emphasis on both key and value
+//   - leading/trailing whitespace (handled by .trim() post-match)
+const BULLET_FIELD = new RegExp(
+  [
+    '^\\s*[-*]?\\s*', // optional bullet marker
+    '\\*{0,2}', // opening emphasis on key
+    '([\\w][\\w\\s\\-/]*?)', // key (1): word/hyphen/slash/space
+    '\\*{0,2}', // closing emphasis on key
+    '\\s*[:：]\\s*', // ASCII or full-width colon
+    '\\*{0,2}', // opening emphasis on value
+    '(.+?)', // value (2), non-greedy
+    '\\*{0,2}', // closing emphasis on value
+    '\\s*$',
+  ].join(''),
+  'gm',
+)
+
+const normalizeKey = (key: string): string =>
+  key.toLowerCase().replace(/[\s_-]+/g, ' ').trim()
+
+const parseBulletList = (raw: string): Record<string, string> => {
+  const out: Record<string, string> = {}
+  BULLET_FIELD.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = BULLET_FIELD.exec(raw)) !== null) {
+    const key = normalizeKey(match[1])
+    const value = match[2].trim().replace(/^\*+|\*+$/g, '').trim()
+    if (!key || !value) continue
+    if (out[key] !== undefined) continue // first match wins
+    out[key] = value
+  }
+  return out
+}
+
+export const parseAgentProfile = (raw: string): ParsedAgentProfile => {
+  const result: ParsedAgentProfile = { raw }
+  if (!raw.trim()) return result
+
+  const fm = extractFrontmatter(raw)
+  if (fm) {
+    const parsed = AgentProfileFrontmatterSchema.safeParse(fm)
+    if (parsed.success) {
+      if (parsed.data.name) result.name = parsed.data.name
+      if (parsed.data.role) result.role = parsed.data.role
+      return result
+    }
+  }
+
+  const bullets = parseBulletList(raw)
+  const name = bullets['name']
+  const role = bullets['role']
+  if (name) result.name = name
+  if (role) result.role = role
+  return result
+}
+
+export const parseUserProfile = (raw: string): ParsedUserProfile => {
+  const result: ParsedUserProfile = { raw }
+  if (!raw.trim()) return result
+
+  const fm = extractFrontmatter(raw)
+  if (fm) {
+    const parsed = UserProfileFrontmatterSchema.safeParse(fm)
+    if (parsed.success) {
+      if (parsed.data.name) result.name = parsed.data.name
+      const pref = parsed.data.preferred_name ?? parsed.data.call_me
+      if (pref) result.preferredName = pref
+      return result
+    }
+  }
+
+  const bullets = parseBulletList(raw)
+  if (bullets['name']) result.name = bullets['name']
+  const pref = bullets['call me'] ?? bullets['preferred name'] ??
+    bullets['preferred_name']
+  if (pref) result.preferredName = pref
+  return result
+}

--- a/cli/src/ai/agentConfig/mod.ts
+++ b/cli/src/ai/agentConfig/mod.ts
@@ -1,0 +1,5 @@
+export * from '@/ai/agentConfig/schema.ts'
+export * from '@/ai/agentConfig/registry.ts'
+export * from '@/ai/agentConfig/paths.ts'
+export * from '@/ai/agentConfig/markdown.ts'
+export * from '@/ai/agentConfig/loader.ts'

--- a/cli/src/ai/agentConfig/paths.ts
+++ b/cli/src/ai/agentConfig/paths.ts
@@ -1,0 +1,37 @@
+import { resolveHome } from '/lib/getApiKeyFromYml.ts'
+
+/**
+ * Centralized filesystem path helpers for agent configuration.
+ * All callers should go through these helpers rather than string-building
+ * `${home}/.slv/...` inline, so paths can be overridden for tests and
+ * stay consistent with `resolveHome()` (which handles sudo-invoked shells).
+ */
+
+export const resolveSlvDir = (home: string = resolveHome()): string =>
+  `${home}/.slv`
+
+export const resolveAgentDir = (home: string = resolveHome()): string =>
+  `${resolveSlvDir(home)}/agent`
+
+export const resolveSkillsDir = (home: string = resolveHome()): string =>
+  `${resolveSlvDir(home)}/skills`
+
+export const resolveApiYmlPath = (home: string = resolveHome()): string =>
+  `${resolveSlvDir(home)}/api.yml`
+
+export const resolveAgentConfigPath = (home: string = resolveHome()): string =>
+  `${resolveAgentDir(home)}/config.yml`
+
+export const resolveSoulMdPath = (home: string = resolveHome()): string =>
+  `${resolveAgentDir(home)}/SOUL.md`
+
+export const resolveUserMdPath = (home: string = resolveHome()): string =>
+  `${resolveAgentDir(home)}/USER.md`
+
+export const resolveMemoryMdPath = (home: string = resolveHome()): string =>
+  `${resolveAgentDir(home)}/MEMORY.md`
+
+export const resolveSkillMdPath = (
+  skillName: string,
+  home: string = resolveHome(),
+): string => `${resolveSkillsDir(home)}/${skillName}/SKILL.md`

--- a/cli/src/ai/agentConfig/registry.ts
+++ b/cli/src/ai/agentConfig/registry.ts
@@ -1,0 +1,103 @@
+import { t } from '@/ai/i18n/index.ts'
+import type { SpecialistAgent } from '@/ai/console/intentClassifier.ts'
+
+/**
+ * Central registry of specialist agent metadata.
+ *
+ * This replaces the three hardcoded tables that previously lived in:
+ *  - consoleAction.ts  (agentDescriptions + preferredOrder — greeting)
+ *  - systemPrompt.ts   (agentLabels — team summary)
+ *  - systemPrompt.ts   (Tina/Cid extra gRPC Geyser skill registration)
+ *
+ * Descriptions are lazy (`() => t('…')`) so i18n resolution happens after
+ * `initI18n()` has settled, not at module import time.
+ */
+
+export type AgentId = SpecialistAgent
+
+export interface AgentMeta {
+  id: AgentId
+  /** Routing tag used in system prompts and intent classifier. */
+  label: string
+  /** Human-facing description for greeting / team list. */
+  description: () => string
+  /** Display order (lower = earlier). */
+  order: number
+  /** Additional skill SKILL.md files to inject for this agent beyond the
+   *  one paired with it in config.yml. */
+  extraSkills?: string[]
+  /** When set, the agent is auto-enabled if the named skill directory
+   *  exists and config.yml does not explicitly list the agent. Explicit
+   *  `enabled: false` in config.yml always wins over auto-enable. */
+  autoEnableIfSkillPresent?: string
+}
+
+export const AGENT_REGISTRY: Record<AgentId, AgentMeta> = {
+  Cecil: {
+    id: 'Cecil',
+    label: 'validator',
+    description: () => t('Solana Validator deployments & management'),
+    order: 1,
+  },
+  Tina: {
+    id: 'Tina',
+    label: 'rpc',
+    description: () => t('RPC nodes (Index RPC, gRPC Geyser, combos)'),
+    order: 2,
+    extraSkills: ['slv-grpc-geyser'],
+  },
+  Setzer: {
+    id: 'Setzer',
+    label: 'app',
+    description: () => t('Trading bots & Solana apps'),
+    order: 3,
+  },
+  Figaro: {
+    id: 'Figaro',
+    label: 'server-procurement',
+    description: () => t('Find optimized Solana server resources'),
+    order: 4,
+    autoEnableIfSkillPresent: 'slv-server-procurement',
+  },
+  Cid: {
+    id: 'Cid',
+    label: 'benchmark',
+    description: () => t('Benchmarks & connectivity testing'),
+    order: 5,
+    extraSkills: ['slv-grpc-geyser'],
+  },
+}
+
+export const ALL_AGENT_IDS: AgentId[] = Object.keys(
+  AGENT_REGISTRY,
+) as AgentId[]
+
+export const isKnownAgentId = (id: string): id is AgentId =>
+  Object.prototype.hasOwnProperty.call(AGENT_REGISTRY, id)
+
+/** Order agent ids by registry `order`, ignoring unknown ids silently. */
+export const listAgentsByOrder = (ids: readonly string[]): AgentMeta[] => {
+  const seen = new Set<AgentId>()
+  const known: AgentMeta[] = []
+  for (const id of ids) {
+    if (!isKnownAgentId(id)) continue
+    if (seen.has(id)) continue
+    seen.add(id)
+    known.push(AGENT_REGISTRY[id])
+  }
+  known.sort((a, b) => a.order - b.order)
+  return known
+}
+
+/** Flat list of all SKILL.md paths that should be registered for an agent,
+ *  given the skill names pulled from config.yml that were paired with this
+ *  agent. Handles deduplication of extraSkills. */
+export const collectSkillNamesForAgent = (
+  agent: AgentId,
+  configPaired: readonly string[],
+): string[] => {
+  const meta = AGENT_REGISTRY[agent]
+  const set = new Set<string>(configPaired)
+  for (const extra of meta.extraSkills ?? []) set.add(extra)
+  return [...set]
+}

--- a/cli/src/ai/agentConfig/schema.ts
+++ b/cli/src/ai/agentConfig/schema.ts
@@ -1,0 +1,69 @@
+import { z } from '@hono/zod-openapi'
+
+/**
+ * Zod schemas for all agent-configuration files under ~/.slv/.
+ *
+ * Design notes:
+ *  - Every field uses `.default()` or `.optional()` so missing/empty configs
+ *    parse successfully (schema-driven defaults replace the scattered try/catch
+ *    fallbacks that existed before).
+ *  - All object schemas use `.passthrough()` so unknown/new fields survive
+ *    round-trips and future additions stay backward-compatible.
+ *  - Invalid field types never throw — the loader uses `.safeParse()` and
+ *    surfaces errors through the warnings channel, then falls back to defaults.
+ */
+
+export const DeploymentModeSchema = z.enum(['remote', 'local'])
+export type DeploymentMode = z.infer<typeof DeploymentModeSchema>
+
+export const SkillEntrySchema = z.object({
+  name: z.string().min(1),
+  enabled: z.boolean().default(true),
+  agent: z.string().min(1),
+}).passthrough()
+export type SkillEntry = z.infer<typeof SkillEntrySchema>
+
+export const AgentConfigSchema = z.object({
+  skills: z.array(SkillEntrySchema).default([]),
+  auto_execute: z.boolean().default(true),
+  mode: DeploymentModeSchema.default('remote'),
+  notifications: z.object({
+    discord_webhook: z.string().optional(),
+  }).partial().passthrough().optional(),
+}).passthrough()
+export type AgentConfig = z.infer<typeof AgentConfigSchema>
+
+export const AiProviderSchema = z.enum(['openai', 'anthropic', 'slv'])
+export type AiProvider = z.infer<typeof AiProviderSchema>
+
+export const AiConfigSchema = z.object({
+  provider: AiProviderSchema,
+  api_key: z.string().default(''),
+  model: z.string(),
+}).passthrough()
+export type AiConfig = z.infer<typeof AiConfigSchema>
+
+export const ApiConfigSchema = z.object({
+  slv: z.object({
+    api_key: z.string().nullable().default(null),
+  }).passthrough().default({ api_key: null }),
+  ai: AiConfigSchema.optional(),
+  lang: z.string().optional(),
+  agreed_slv_init_bot: z.boolean().optional(),
+  notifications: z.object({
+    discord_webhook: z.string().optional(),
+  }).partial().passthrough().optional(),
+}).passthrough()
+export type ApiConfig = z.infer<typeof ApiConfigSchema>
+
+/** Frontmatter shape for SOUL.md / USER.md when authors opt-in to YAML. */
+export const AgentProfileFrontmatterSchema = z.object({
+  name: z.string().optional(),
+  role: z.string().optional(),
+}).passthrough()
+
+export const UserProfileFrontmatterSchema = z.object({
+  name: z.string().optional(),
+  preferred_name: z.string().optional(),
+  call_me: z.string().optional(),
+}).passthrough()

--- a/cli/src/ai/config.ts
+++ b/cli/src/ai/config.ts
@@ -2,6 +2,12 @@ import { parse, stringify } from '@std/yaml'
 import { dirname } from '@std/path'
 import { colors } from '@cliffy/colors'
 
+import {
+  invalidateAgentContext,
+  loadAgentContext,
+} from '@/ai/agentConfig/loader.ts'
+import { resolveApiYmlPath } from '@/ai/agentConfig/paths.ts'
+
 export type AiProvider = 'openai' | 'anthropic' | 'slv'
 
 export type AiConfig = {
@@ -18,15 +24,19 @@ type ApiYml = {
 }
 
 const getApiYmlPath = (): string => {
-  const home = Deno.env.get('HOME')
-  if (!home) {
+  try {
+    return resolveApiYmlPath()
+  } catch {
     console.log(colors.red('HOME environment variable not found'))
     Deno.exit(1)
   }
-  return home + '/.slv/api.yml'
 }
 
-const readApiYml = async (): Promise<ApiYml> => {
+// Read side delegates to loadAgentContext so we parse api.yml once per session.
+// Write side reads+stringifies directly (the loader is read-only) and then
+// invalidates the cache so subsequent loads see the updated values.
+
+const readApiYmlForWrite = async (): Promise<ApiYml> => {
   const path = getApiYmlPath()
   try {
     await Deno.stat(path)
@@ -37,28 +47,34 @@ const readApiYml = async (): Promise<ApiYml> => {
   try {
     return parse(content) as ApiYml
   } catch {
-    console.warn(colors.yellow('Warning: Failed to parse api.yml, using defaults'))
+    console.warn(
+      colors.yellow('Warning: Failed to parse api.yml, using defaults'),
+    )
     return { slv: { api_key: null } }
   }
 }
 
 export const readAiConfig = async (): Promise<AiConfig | null> => {
-  const yml = await readApiYml()
-  if (!yml.ai) return null
+  const ctx = await loadAgentContext()
+  const ai = ctx.raw.api.ai
+  if (!ai) return null
   // Ensure api_key is always a string (may be omitted for provider: slv)
-  return { ...yml.ai, api_key: yml.ai.api_key ?? '' }
+  return {
+    provider: ai.provider,
+    api_key: ai.api_key ?? '',
+    model: ai.model,
+  }
 }
 
 export const writeAiConfig = async (config: AiConfig): Promise<void> => {
   const path = getApiYmlPath()
   await Deno.mkdir(dirname(path), { recursive: true })
-  const yml = await readApiYml()
+  const yml = await readApiYmlForWrite()
 
   // When provider is 'slv', omit api_key from the YAML (slv.api_key is used instead)
   if (config.provider === 'slv') {
     const { api_key: _unused, ...rest } = config
     yml.ai = { ...rest, api_key: '' } as AiConfig
-    // Write YAML without the ai.api_key field
     const ymlObj = yml as Record<string, unknown>
     const aiObj = ymlObj.ai as Record<string, unknown>
     delete aiObj.api_key
@@ -68,39 +84,44 @@ export const writeAiConfig = async (config: AiConfig): Promise<void> => {
     await Deno.writeTextFile(path, stringify(yml as Record<string, unknown>))
   }
   await Deno.chmod(path, 0o600)
+  invalidateAgentContext()
 }
 
 export const readLang = async (): Promise<string> => {
-  const yml = await readApiYml()
-  return yml.lang && yml.lang.trim().length > 0 ? yml.lang.trim() : 'en'
+  const ctx = await loadAgentContext()
+  const lang = ctx.raw.api.lang
+  return lang && lang.trim().length > 0 ? lang.trim() : 'en'
 }
 
 export const hasLangSet = async (): Promise<boolean> => {
-  const yml = await readApiYml()
-  return typeof yml.lang === 'string' && yml.lang.trim().length > 0
+  const ctx = await loadAgentContext()
+  const lang = ctx.raw.api.lang
+  return typeof lang === 'string' && lang.trim().length > 0
 }
 
 export const writeLang = async (lang: string): Promise<void> => {
   const path = getApiYmlPath()
   await Deno.mkdir(dirname(path), { recursive: true })
-  const yml = await readApiYml()
+  const yml = await readApiYmlForWrite()
   yml.lang = lang
   await Deno.writeTextFile(path, stringify(yml as Record<string, unknown>))
   await Deno.chmod(path, 0o600)
+  invalidateAgentContext()
 }
 
 export const readBotAgreement = async (): Promise<boolean> => {
-  const yml = await readApiYml()
-  return yml.agreed_slv_init_bot === true
+  const ctx = await loadAgentContext()
+  return ctx.raw.api.agreed_slv_init_bot === true
 }
 
 export const writeBotAgreement = async (agreed: boolean): Promise<void> => {
   const path = getApiYmlPath()
   await Deno.mkdir(dirname(path), { recursive: true })
-  const yml = await readApiYml()
+  const yml = await readApiYmlForWrite()
   yml.agreed_slv_init_bot = agreed
   await Deno.writeTextFile(path, stringify(yml as Record<string, unknown>))
   await Deno.chmod(path, 0o600)
+  invalidateAgentContext()
 }
 
 export const DEFAULT_MAX_TOKENS = 8192

--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -51,7 +51,8 @@ import {
   type UserContextKind,
 } from '@/ai/console/intentClassifier.ts'
 import { resolveHome } from '/lib/getApiKeyFromYml.ts'
-import { parse } from '@std/yaml'
+import { loadAgentContext } from '@/ai/agentConfig/loader.ts'
+import { listAgentsByOrder } from '@/ai/agentConfig/registry.ts'
 import {
   applyVersionUpdates,
   checkSolanaReleases,
@@ -215,43 +216,10 @@ class ChatLog extends Container {
 }
 
 async function buildLocalGreeting(home: string): Promise<string> {
-  const agentDir = `${home}/.slv/agent`
+  const ctx = await loadAgentContext({ home })
 
-  // Extract agent name from SOUL.md
-  let agentName = 'your SLV assistant'
-  try {
-    const soulMd = await Deno.readTextFile(`${agentDir}/SOUL.md`)
-    const nameMatch = soulMd.match(/name:\s*([^\n]+)/i)
-    if (nameMatch) agentName = nameMatch[1].trim()
-  } catch { /* not configured */ }
-
-  // Extract user's preferred name from USER.md
-  let userName = ''
-  try {
-    const userMd = await Deno.readTextFile(`${agentDir}/USER.md`)
-    const nameMatch = userMd.match(/preferred_name:\s*([^\n]+)/i)
-    if (nameMatch) userName = nameMatch[1].trim()
-  } catch { /* not configured */ }
-
-  // Read enabled agents from config.yml
-  let enabledAgents: string[] = []
-  try {
-    const raw = await Deno.readTextFile(`${agentDir}/config.yml`)
-    const agentConfig = parse(raw) as Record<string, unknown>
-    const skills = (agentConfig.skills || []) as Array<
-      { name: string; enabled: boolean; agent: string }
-    >
-    enabledAgents = skills.filter((s) => s.enabled).map((s) => s.agent)
-  } catch { /* not configured */ }
-
-  // Figaro should be visible when the skill is installed, even if older configs
-  // predate the Server Procurement toggle.
-  try {
-    await Deno.stat(`${home}/.slv/skills/slv-server-procurement/SKILL.md`)
-    enabledAgents.push('Figaro')
-  } catch {
-    // skill not installed
-  }
+  const agentName = ctx.soul?.name ?? 'your SLV assistant'
+  const userName = ctx.user?.preferredName ?? ''
 
   const greetLine = userName
     ? t('Hey {name}! 👋').replace('{name}', userName)
@@ -261,24 +229,12 @@ async function buildLocalGreeting(home: string): Promise<string> {
     ? t("I'm {agent}, your SLV commander.").replace('{agent}', agentName)
     : t("I'm your SLV assistant.")
 
-  const agentDescriptions: Record<string, string> = {
-    'Cecil': t('Solana Validator deployments & management'),
-    'Tina': t('RPC nodes (Index RPC, gRPC Geyser, combos)'),
-    'Setzer': t('Trading bots & Solana apps'),
-    'Figaro': t('Find optimized Solana server resources'),
-    'Cid': t('Benchmarks & connectivity testing'),
-  }
-
-  const preferredOrder = ['Cecil', 'Tina', 'Setzer', 'Figaro', 'Cid']
-  const crew = preferredOrder.filter((agent) => enabledAgents.includes(agent))
-  let crewSection = ''
-  if (crew.length > 0) {
-    crewSection = ` ${t("Here's my crew:")}\n\n${
-      crew.map((a) => `- ${a} — ${agentDescriptions[a]}`).join('\n')
+  const crew = listAgentsByOrder(ctx.enabledAgents)
+  const crewSection = crew.length > 0
+    ? ` ${t("Here's my crew:")}\n\n${
+      crew.map((meta) => `- ${meta.id} — ${meta.description()}`).join('\n')
     }\n\n`
-  } else {
-    crewSection = ' '
-  }
+    : ' '
 
   // Append a one-line profile hint so the user sees we've detected their
   // primary focus. Failures are non-fatal — the greeting still works.
@@ -687,14 +643,10 @@ export const consoleAction = async () => {
   })
 
   // Read auto-execute setting from agent config
-  try {
-    const agentConfigPath = `${resolveHome()}/.slv/agent/config.yml`
-    const raw = await Deno.readTextFile(agentConfigPath)
-    const agentConfig = parse(raw) as Record<string, unknown>
-    if (agentConfig.auto_execute === false) {
-      setAutoExecute(false)
-    }
-  } catch { /* default: auto-execute on */ }
+  {
+    const ctx = await loadAgentContext()
+    if (!ctx.autoExecute) setAutoExecute(false)
+  }
 
   // Provider init with callbacks
   let provider: OpenAIProvider | AnthropicProvider | SLVProvider
@@ -862,11 +814,8 @@ export const consoleAction = async () => {
     )
   } else if (config.provider === 'slv') {
     // SLV AI uses slv.api_key from ~/.slv/api.yml (not ai.api_key)
-    try {
-      const apiYmlRaw = await Deno.readTextFile(`${resolveHome()}/.slv/api.yml`)
-      const apiYml = parse(apiYmlRaw) as Record<string, any>
-      slvApiKey = apiYml?.slv?.api_key || ''
-    } catch { /* */ }
+    const ctx = await loadAgentContext()
+    slvApiKey = ctx.raw.api.slv.api_key ?? ''
     if (!slvApiKey) {
       console.log('\n  SLV API Key not found. Run `slv login` first.\n')
       return
@@ -955,21 +904,10 @@ export const consoleAction = async () => {
   const hydratedUserContextKinds = new Set<UserContextKind>()
   const hydratedUserContextBlocks = new Map<UserContextKind, string>()
 
-  try {
-    const raw = await Deno.readTextFile(
-      `${resolveHome()}/.slv/agent/config.yml`,
-    )
-    const agentConfig = parse(raw) as Record<string, unknown>
-    deploymentMode =
-      ((agentConfig.mode as string) || 'remote') as DeploymentMode
-    enabledSpecialists =
-      ((agentConfig.skills as Array<Record<string, unknown>> | undefined) || [])
-        .filter((skill) => skill?.enabled)
-        .map((skill) => String(skill.agent || ''))
-        .filter(Boolean)
-  } catch {
-    deploymentMode = 'remote'
-    enabledSpecialists = []
+  {
+    const ctx = await loadAgentContext()
+    deploymentMode = ctx.mode
+    enabledSpecialists = ctx.enabledAgents
   }
 
   const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
@@ -994,11 +932,8 @@ export const consoleAction = async () => {
       renderStage(`📚 Loading ${describeUserContextKind(kind)}…`)
       try {
         if (!slvApiKey) {
-          const apiYmlRaw = await Deno.readTextFile(
-            `${resolveHome()}/.slv/api.yml`,
-          )
-          const apiYml = parse(apiYmlRaw) as Record<string, any>
-          slvApiKey = apiYml?.slv?.api_key || ''
+          const ctx = await loadAgentContext()
+          slvApiKey = ctx.raw.api.slv.api_key ?? ''
         }
         if (slvApiKey) {
           const res = await fetch('https://mcp-slv-cloud.erpc.global/mcp', {
@@ -1250,12 +1185,8 @@ RULES:
           callbacks,
         )
       } else if (config.provider === 'slv') {
-        let slvKey = ''
-        try {
-          const raw = await Deno.readTextFile(`${resolveHome()}/.slv/api.yml`)
-          const yml = parse(raw) as Record<string, any>
-          slvKey = yml?.slv?.api_key || ''
-        } catch { /* */ }
+        const ctx = await loadAgentContext()
+        const slvKey = ctx.raw.api.slv.api_key ?? ''
         if (slvKey) {
           slvApiKey = slvKey
           provider = new SLVProvider(

--- a/cli/src/ai/console/systemPrompt.ts
+++ b/cli/src/ai/console/systemPrompt.ts
@@ -1,9 +1,17 @@
-import { parse } from '@std/yaml'
-import { resolveHome } from '/lib/getApiKeyFromYml.ts'
 import { VERSION } from '@cmn/constants/version.ts'
 import { DISCORD_LINK } from '@cmn/constants/url.ts'
 import { readLang } from '@/ai/config.ts'
 import { detectProfile, profilePromptBlock } from '@/ai/console/profile.ts'
+import { loadAgentContext } from '@/ai/agentConfig/loader.ts'
+import {
+  AGENT_REGISTRY,
+  type AgentId,
+  isKnownAgentId,
+} from '@/ai/agentConfig/registry.ts'
+import {
+  resolveApiYmlPath,
+  resolveSkillMdPath,
+} from '@/ai/agentConfig/paths.ts'
 
 // --- Context module state management ---
 
@@ -50,21 +58,19 @@ function skillSectionTitle(path: string): string {
 }
 
 async function cacheSkillDocs(
-  skillsDir: string,
-  skills: Array<{ name: string; enabled: boolean; agent: string }>,
+  home: string,
+  skillSourcesByAgent: Record<AgentId, string[]>,
 ) {
   skillDocsCache = {}
   skillDocSources = {}
 
-  for (const skill of skills) {
-    if (!skill.enabled) continue
-    registerSkillDocSource(skill.agent, `${skillsDir}/${skill.name}/SKILL.md`)
-  }
-
-  // Tina and Cid also benefit from the gRPC Geyser skill when that skill exists,
-  // but we still register it lazily instead of reading it at startup.
-  for (const agent of ['Tina', 'Cid']) {
-    registerSkillDocSource(agent, `${skillsDir}/slv-grpc-geyser/SKILL.md`)
+  // skillSourcesByAgent already merges registry-declared extraSkills (e.g.
+  // Tina/Cid → slv-grpc-geyser) with the config.yml entries and deduplicates,
+  // so each path is registered exactly once per agent.
+  for (const agent of Object.keys(skillSourcesByAgent) as AgentId[]) {
+    for (const skillName of skillSourcesByAgent[agent]) {
+      registerSkillDocSource(agent, resolveSkillMdPath(skillName, home))
+    }
   }
 }
 
@@ -295,9 +301,10 @@ You have access to the SLV Cloud MCP API via the call_mcp tool. Key tools:
 // --- Core prompt builder (small footprint, ~3KB) ---
 
 async function buildCorePrompt(userContext?: string): Promise<string> {
-  const home = resolveHome()
+  const ctx = await loadAgentContext()
+  const home = ctx.home
   const agentDir = `${home}/.slv/agent`
-  const skillsDir = `${home}/.slv/skills`
+  const skillsDir = ctx.skillsDir
 
   const osName = Deno.build.os === 'darwin'
     ? 'macOS'
@@ -312,17 +319,9 @@ async function buildCorePrompt(userContext?: string): Promise<string> {
     // ignore
   }
 
-  // Read agent files
-  let soulMd = '', userMd = '', memoryMd = ''
-  try {
-    soulMd = await Deno.readTextFile(`${agentDir}/SOUL.md`)
-  } catch { /* not configured */ }
-  try {
-    userMd = await Deno.readTextFile(`${agentDir}/USER.md`)
-  } catch { /* not configured */ }
-  try {
-    memoryMd = await Deno.readTextFile(`${agentDir}/MEMORY.md`)
-  } catch { /* not configured */ }
+  const soulMd = ctx.soul?.raw ?? ''
+  const userMd = ctx.user?.raw ?? ''
+  const memoryMd = ctx.memory?.raw ?? ''
 
   // Always-on non-interactive command reference for `slv backup` and
   // `slv storage`. Loaded directly into the main agent prompt so the
@@ -332,7 +331,7 @@ async function buildCorePrompt(userContext?: string): Promise<string> {
   let backupSkillMd = ''
   try {
     backupSkillMd = await Deno.readTextFile(
-      `${skillsDir}/slv-backup/SKILL.md`,
+      resolveSkillMdPath('slv-backup', home),
     )
   } catch { /* skill not synced yet — Core Rules line still applies */ }
 
@@ -342,35 +341,13 @@ async function buildCorePrompt(userContext?: string): Promise<string> {
   const userProfile = await detectProfile().catch(() => null)
   const profileBlock = userProfile ? profilePromptBlock(userProfile) : ''
 
-  // Read config to get enabled skills and mode
-  let configYml: Record<string, unknown> = { skills: [] }
-  try {
-    const raw = await Deno.readTextFile(`${agentDir}/config.yml`)
-    configYml = parse(raw) as Record<string, unknown>
-  } catch { /* not configured */ }
-
-  // Build sub-agent team list (keep it tiny)
-  const skills = (configYml.skills || []) as Array<
-    { name: string; enabled: boolean; agent: string }
-  >
-  const enabledAgents: string[] = []
-  for (const skill of skills) {
-    if (skill.enabled) enabledAgents.push(skill.agent)
-  }
-
-  const agentLabels: Record<string, string> = {
-    'Cecil': 'validator',
-    'Tina': 'rpc',
-    'Cid': 'benchmark',
-    'Setzer': 'app',
-    'Figaro': 'server-procurement',
-  }
-  const teamSummary = enabledAgents
-    .filter((agent, index, all) => all.indexOf(agent) === index)
-    .map((agent) => `${agent} (${agentLabels[agent] || 'specialist'})`)
+  // Agent team list — already deduplicated + ordered by the loader.
+  const teamSummary = ctx.enabledAgents
+    .filter(isKnownAgentId)
+    .map((id) => `${id} (${AGENT_REGISTRY[id].label})`)
     .join(', ')
 
-  const mode = (configYml.mode as string) || 'remote'
+  const mode = ctx.mode
 
   const inventoryFiles = [
     `${home}/.slv/inventory.testnet.validators.yml`,
@@ -382,11 +359,11 @@ async function buildCorePrompt(userContext?: string): Promise<string> {
     api: false,
     agent: false,
     inventory: false,
-    discordWebhook: false,
+    discordWebhook: ctx.discordWebhookConfigured,
   }
 
   try {
-    await Deno.stat(`${home}/.slv/api.yml`)
+    await Deno.stat(resolveApiYmlPath(home))
     configPresence.api = true
   } catch {
     // ignore
@@ -404,34 +381,6 @@ async function buildCorePrompt(userContext?: string): Promise<string> {
       await Deno.stat(inventoryFile)
       configPresence.inventory = true
       break
-    } catch {
-      // keep checking
-    }
-  }
-
-  // Detect whether a Discord webhook is configured so the main agent can
-  // proactively offer to push long outputs (payment links, benchmark
-  // summaries, deploy results) to Discord. Only the presence flag is
-  // surfaced — the URL itself never enters the prompt context.
-  // Primary location is ~/.slv/api.yml (written by `slv onboard`); the
-  // legacy ~/.slv/agent/config.yml location is also checked for older
-  // installs. Inlined here (rather than imported from tools.ts) to avoid
-  // a circular import between systemPrompt.ts and tools.ts.
-  const webhookCandidates = [
-    `${home}/.slv/api.yml`,
-    `${agentDir}/config.yml`,
-  ]
-  for (const path of webhookCandidates) {
-    try {
-      const raw = await Deno.readTextFile(path)
-      const parsed = parse(raw) as Record<string, unknown> | null
-      const notifications = parsed?.notifications as
-        | Record<string, string>
-        | undefined
-      if (notifications?.discord_webhook?.trim()) {
-        configPresence.discordWebhook = true
-        break
-      }
     } catch {
       // keep checking
     }
@@ -455,8 +404,8 @@ This user operates in REMOTE mode. Deployments target remote servers via SSH.
 `
 
   // Cache skill docs for lazy loading (not included in prompt)
-  await cacheSkillDocs(skillsDir, skills)
-  const enabledSkillSummary = skills
+  await cacheSkillDocs(home, ctx.skillSourcesByAgent)
+  const enabledSkillSummary = ctx.raw.config.skills
     .filter((s) => s.enabled)
     .map((s) => `${s.name} (${s.agent})`)
     .join(', ')

--- a/cli/src/ai/console/tools.ts
+++ b/cli/src/ai/console/tools.ts
@@ -1160,6 +1160,27 @@ When running ansible-playbook or slv commands that connect to servers:
         subSystemPrompt,
         task,
       )
+    } else if (config.provider === 'slv') {
+      const home = resolveHome()
+      let slvApiKey = ''
+      try {
+        const raw = await Deno.readTextFile(`${home}/.slv/api.yml`)
+        const yml = (await import('@std/yaml')).parse(raw) as Record<
+          string,
+          // deno-lint-ignore no-explicit-any
+          any
+        >
+        slvApiKey = yml?.slv?.api_key || ''
+      } catch { /* */ }
+      if (!slvApiKey) {
+        return 'Error: SLV API Key not found. Run `slv login` first.'
+      }
+      return await runSlvSubAgent(
+        slvApiKey,
+        config.model,
+        subSystemPrompt,
+        task,
+      )
     } else {
       return await runOpenAISubAgent(
         config.api_key,
@@ -1227,6 +1248,98 @@ async function runAnthropicSubAgent(
 
     // Execute tools
     const toolResults: Anthropic.ToolResultBlockParam[] = []
+    for (const tb of toolUseBlocks) {
+      const result = await executeSubAgentTool(tb.name, tb.input)
+      toolResults.push({
+        type: 'tool_result',
+        tool_use_id: tb.id,
+        content: result,
+      })
+    }
+    messages.push({ role: 'user', content: toolResults })
+  }
+
+  return '(sub-agent reached maximum iteration limit)'
+}
+
+// --- Sub-agent SLV AI implementation (fetch-based Anthropic proxy) ---
+const SLV_AI_CHAT_URL = 'https://user-api.erpc.global/v3/ai/chat'
+
+async function runSlvSubAgent(
+  apiKey: string,
+  model: string,
+  systemPrompt: string,
+  task: string,
+): Promise<string> {
+  const tools = SUB_AGENT_TOOL_DEFINITIONS.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.parameters,
+  }))
+
+  // deno-lint-ignore no-explicit-any
+  const messages: any[] = [{ role: 'user', content: task }]
+
+  const MAX_ITERATIONS = 20
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    const res = await fetch(SLV_AI_CHAT_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: DEFAULT_MAX_TOKENS,
+        system: systemPrompt,
+        messages,
+        tools,
+      }),
+      signal: AbortSignal.timeout(600_000),
+    })
+
+    if (!res.ok) {
+      const errText = await res.text().catch(() => '')
+      throw new Error(`SLV AI API error (${res.status}): ${errText}`)
+    }
+
+    // deno-lint-ignore no-explicit-any
+    const data = await res.json() as any
+    if (!data || !Array.isArray(data.content)) {
+      throw new Error(
+        `SLV AI returned unexpected response: ${
+          JSON.stringify(data).slice(0, 200)
+        }`,
+      )
+    }
+
+    let textContent = ''
+    const toolUseBlocks: {
+      id: string
+      name: string
+      input: Record<string, unknown>
+    }[] = []
+    for (const block of data.content) {
+      if (block.type === 'text') {
+        textContent += block.text
+      } else if (block.type === 'tool_use') {
+        toolUseBlocks.push({
+          id: block.id,
+          name: block.name,
+          input: block.input as Record<string, unknown>,
+        })
+      }
+    }
+
+    messages.push({ role: 'assistant', content: data.content })
+
+    if (toolUseBlocks.length === 0 || data.stop_reason === 'end_turn') {
+      return textContent || '(no response from sub-agent)'
+    }
+
+    // Execute tools
+    // deno-lint-ignore no-explicit-any
+    const toolResults: any[] = []
     for (const tb of toolUseBlocks) {
       const result = await executeSubAgentTool(tb.name, tb.input)
       toolResults.push({

--- a/cli/src/ai/console/tools.ts
+++ b/cli/src/ai/console/tools.ts
@@ -1165,7 +1165,7 @@ When running ansible-playbook or slv commands that connect to servers:
       let slvApiKey = ''
       try {
         const raw = await Deno.readTextFile(`${home}/.slv/api.yml`)
-        const yml = (await import('@std/yaml')).parse(raw) as Record<
+        const yml = parse(raw) as Record<
           string,
           // deno-lint-ignore no-explicit-any
           any

--- a/cli/test/unit/agentConfig_loader.test.ts
+++ b/cli/test/unit/agentConfig_loader.test.ts
@@ -1,0 +1,239 @@
+import { assert, assertEquals } from '@std/assert'
+
+import {
+  invalidateAgentContext,
+  loadAgentContext,
+} from '@/ai/agentConfig/loader.ts'
+
+interface Fixture {
+  configYml?: string
+  apiYml?: string
+  soulMd?: string
+  userMd?: string
+  memoryMd?: string
+  skills?: Record<string, string>
+}
+
+const makeHome = async (fixture: Fixture): Promise<string> => {
+  const home = await Deno.makeTempDir({ prefix: 'slv-agent-cfg-' })
+  const agentDir = `${home}/.slv/agent`
+  const skillsDir = `${home}/.slv/skills`
+  await Deno.mkdir(agentDir, { recursive: true })
+  await Deno.mkdir(skillsDir, { recursive: true })
+  if (fixture.configYml !== undefined) {
+    await Deno.writeTextFile(`${agentDir}/config.yml`, fixture.configYml)
+  }
+  if (fixture.apiYml !== undefined) {
+    await Deno.writeTextFile(`${home}/.slv/api.yml`, fixture.apiYml)
+  }
+  if (fixture.soulMd !== undefined) {
+    await Deno.writeTextFile(`${agentDir}/SOUL.md`, fixture.soulMd)
+  }
+  if (fixture.userMd !== undefined) {
+    await Deno.writeTextFile(`${agentDir}/USER.md`, fixture.userMd)
+  }
+  if (fixture.memoryMd !== undefined) {
+    await Deno.writeTextFile(`${agentDir}/MEMORY.md`, fixture.memoryMd)
+  }
+  for (const [skill, body] of Object.entries(fixture.skills ?? {})) {
+    const dir = `${skillsDir}/${skill}`
+    await Deno.mkdir(dir, { recursive: true })
+    await Deno.writeTextFile(`${dir}/SKILL.md`, body)
+  }
+  return home
+}
+
+const reset = () => invalidateAgentContext()
+
+Deno.test('loadAgentContext returns defaults when no files exist', async () => {
+  reset()
+  const home = await makeHome({})
+  const ctx = await loadAgentContext({ home, force: true })
+  assertEquals(ctx.enabledAgents, [])
+  assertEquals(ctx.mode, 'remote')
+  assertEquals(ctx.autoExecute, true)
+  assertEquals(ctx.soul, null)
+  assertEquals(ctx.user, null)
+  assertEquals(ctx.memory, null)
+  assertEquals(ctx.discordWebhookConfigured, false)
+})
+
+Deno.test('loadAgentContext parses production config and MD files', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: [
+      'skills:',
+      '  - name: slv-validator',
+      '    enabled: true',
+      '    agent: Cecil',
+      '  - name: slv-rpc',
+      '    enabled: true',
+      '    agent: Tina',
+      '  - name: slv-grpc-geyser',
+      '    enabled: true',
+      '    agent: Tina',
+      '  - name: slv-benchmark',
+      '    enabled: true',
+      '    agent: Cid',
+      'auto_execute: true',
+      'mode: remote',
+      '',
+    ].join('\n'),
+    soulMd: '- **Name:** EL\n',
+    userMd: '- **Name:** K\n- **Call me:** K\n',
+    memoryMd: 'Some notes\n',
+    skills: {
+      'slv-validator': '# validator skill',
+      'slv-rpc': '# rpc skill',
+      'slv-grpc-geyser': '# geyser skill',
+      'slv-benchmark': '# benchmark skill',
+    },
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  assertEquals(ctx.enabledAgents, ['Cecil', 'Tina', 'Cid'])
+  assertEquals(ctx.soul?.name, 'EL')
+  assertEquals(ctx.user?.preferredName, 'K')
+  assertEquals(ctx.memory?.raw, 'Some notes\n')
+  // Warnings should be clean: all skills exist.
+  assertEquals(ctx.warnings, [])
+})
+
+Deno.test('Figaro auto-enables when skill dir exists and config omits it', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: [
+      'skills:',
+      '  - name: slv-validator',
+      '    enabled: true',
+      '    agent: Cecil',
+      'auto_execute: true',
+      'mode: remote',
+    ].join('\n'),
+    skills: {
+      'slv-validator': '# validator',
+      'slv-server-procurement': '# figaro',
+    },
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  assert(ctx.enabledAgents.includes('Figaro'))
+  assert(ctx.skillSourcesByAgent.Figaro.includes('slv-server-procurement'))
+})
+
+Deno.test('Figaro stays disabled when config explicitly sets enabled: false', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: [
+      'skills:',
+      '  - name: slv-server-procurement',
+      '    enabled: false',
+      '    agent: Figaro',
+    ].join('\n'),
+    skills: {
+      'slv-server-procurement': '# figaro',
+    },
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  assertEquals(ctx.enabledAgents.includes('Figaro'), false)
+})
+
+Deno.test('Figaro enabled but skill missing emits a warning', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: [
+      'skills:',
+      '  - name: slv-server-procurement',
+      '    enabled: true',
+      '    agent: Figaro',
+    ].join('\n'),
+    // No slv-server-procurement directory created.
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  assert(ctx.enabledAgents.includes('Figaro'))
+  const hasWarning = ctx.warnings.some((w) =>
+    w.source === 'skills' &&
+    w.message.includes('slv-server-procurement')
+  )
+  assert(hasWarning, `expected skill-missing warning, got ${JSON.stringify(ctx.warnings)}`)
+})
+
+Deno.test('Broken YAML surfaces a warning and falls back to defaults', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: 'skills: [invalid yaml',
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  assertEquals(ctx.enabledAgents, [])
+  assertEquals(ctx.mode, 'remote')
+  const hasWarning = ctx.warnings.some((w) => w.source === 'config.yml')
+  assert(hasWarning)
+})
+
+Deno.test('Unknown agent ids in config.yml are skipped with a warning', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: [
+      'skills:',
+      '  - name: slv-custom',
+      '    enabled: true',
+      '    agent: Mystery',
+      '  - name: slv-validator',
+      '    enabled: true',
+      '    agent: Cecil',
+    ].join('\n'),
+    skills: { 'slv-validator': '# v' },
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  assertEquals(ctx.enabledAgents, ['Cecil'])
+  const hasWarning = ctx.warnings.some((w) =>
+    w.source === 'config.yml' && w.message.includes('Mystery')
+  )
+  assert(hasWarning)
+})
+
+Deno.test('Discord webhook in api.yml is surfaced as configured', async () => {
+  reset()
+  const home = await makeHome({
+    apiYml: [
+      'slv:',
+      '  api_key: 00000000-0000-4000-8000-000000000000',
+      'notifications:',
+      '  discord_webhook: https://discord.com/api/webhooks/abc/xyz',
+    ].join('\n'),
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  assertEquals(ctx.discordWebhookConfigured, true)
+})
+
+Deno.test('loadAgentContext memoizes until invalidated', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: 'auto_execute: true\nmode: remote\n',
+  })
+  const first = await loadAgentContext({ home })
+  const second = await loadAgentContext({ home })
+  // Same reference thanks to memoization.
+  assertEquals(first === second, true)
+
+  invalidateAgentContext()
+  const third = await loadAgentContext({ home })
+  assertEquals(first === third, false)
+})
+
+Deno.test('Tina and Cid always register the geyser extra skill', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: [
+      'skills:',
+      '  - name: slv-rpc',
+      '    enabled: true',
+      '    agent: Tina',
+      '  - name: slv-benchmark',
+      '    enabled: true',
+      '    agent: Cid',
+    ].join('\n'),
+    skills: { 'slv-rpc': '# rpc', 'slv-benchmark': '# bench' },
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  assert(ctx.skillSourcesByAgent.Tina.includes('slv-grpc-geyser'))
+  assert(ctx.skillSourcesByAgent.Cid.includes('slv-grpc-geyser'))
+})

--- a/cli/test/unit/agentConfig_markdown.test.ts
+++ b/cli/test/unit/agentConfig_markdown.test.ts
@@ -1,0 +1,80 @@
+import { assertEquals } from '@std/assert'
+
+import {
+  parseAgentProfile,
+  parseUserProfile,
+} from '@/ai/agentConfig/markdown.ts'
+
+Deno.test('parseAgentProfile strips markdown emphasis from bullet lists', () => {
+  const raw = [
+    '# SOUL.md — Main Agent',
+    '- **Name:** EL',
+    '- **Role:** Commander — routes tasks to specialists',
+    '',
+  ].join('\n')
+  const parsed = parseAgentProfile(raw)
+  // Previous buggy regex returned "** EL" — the new parser must return "EL".
+  assertEquals(parsed.name, 'EL')
+  assertEquals(parsed.role, 'Commander — routes tasks to specialists')
+})
+
+Deno.test('parseUserProfile accepts "Call me:" phrasing', () => {
+  const raw = [
+    '# USER.md',
+    '- **Name:** K',
+    '- **Call me:** K',
+    '',
+  ].join('\n')
+  const parsed = parseUserProfile(raw)
+  assertEquals(parsed.name, 'K')
+  // Previous regex only matched "preferred_name:" and returned empty string
+  // for the real production format shown above.
+  assertEquals(parsed.preferredName, 'K')
+})
+
+Deno.test('parseUserProfile still accepts legacy preferred_name key', () => {
+  const raw = 'preferred_name: bob\n'
+  const parsed = parseUserProfile(raw)
+  assertEquals(parsed.preferredName, 'bob')
+})
+
+Deno.test('parseAgentProfile handles YAML frontmatter', () => {
+  const raw = [
+    '---',
+    'name: EL',
+    'role: Commander',
+    '---',
+    '',
+    '# Rest is free-form markdown.',
+    '',
+  ].join('\n')
+  const parsed = parseAgentProfile(raw)
+  assertEquals(parsed.name, 'EL')
+  assertEquals(parsed.role, 'Commander')
+})
+
+Deno.test('parseUserProfile handles frontmatter with call_me', () => {
+  const raw = [
+    '---',
+    'name: Kenji',
+    'call_me: K',
+    '---',
+    '',
+  ].join('\n')
+  const parsed = parseUserProfile(raw)
+  assertEquals(parsed.name, 'Kenji')
+  assertEquals(parsed.preferredName, 'K')
+})
+
+Deno.test('parseAgentProfile returns empty fields for empty input', () => {
+  const parsed = parseAgentProfile('')
+  assertEquals(parsed.name, undefined)
+  assertEquals(parsed.role, undefined)
+  assertEquals(parsed.raw, '')
+})
+
+Deno.test('parseAgentProfile preserves raw content', () => {
+  const raw = '- **Name:** EL\n'
+  const parsed = parseAgentProfile(raw)
+  assertEquals(parsed.raw, raw)
+})

--- a/cli/test/unit/agentConfig_registry.test.ts
+++ b/cli/test/unit/agentConfig_registry.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from '@std/assert'
+
+import {
+  AGENT_REGISTRY,
+  ALL_AGENT_IDS,
+  collectSkillNamesForAgent,
+  isKnownAgentId,
+  listAgentsByOrder,
+} from '@/ai/agentConfig/registry.ts'
+
+Deno.test('AGENT_REGISTRY covers all five specialists', () => {
+  assertEquals(ALL_AGENT_IDS.sort(), ['Cecil', 'Cid', 'Figaro', 'Setzer', 'Tina'])
+})
+
+Deno.test('listAgentsByOrder returns registry-ordered metadata', () => {
+  const ordered = listAgentsByOrder(['Cid', 'Cecil', 'Tina', 'Figaro'])
+  assertEquals(ordered.map((m) => m.id), ['Cecil', 'Tina', 'Figaro', 'Cid'])
+})
+
+Deno.test('listAgentsByOrder silently drops unknown ids', () => {
+  const ordered = listAgentsByOrder(['Nobody', 'Cecil'])
+  assertEquals(ordered.map((m) => m.id), ['Cecil'])
+})
+
+Deno.test('listAgentsByOrder deduplicates repeated ids', () => {
+  const ordered = listAgentsByOrder(['Tina', 'Tina', 'Tina'])
+  assertEquals(ordered.length, 1)
+  assertEquals(ordered[0].id, 'Tina')
+})
+
+Deno.test('isKnownAgentId narrows strings to AgentId', () => {
+  assertEquals(isKnownAgentId('Cecil'), true)
+  assertEquals(isKnownAgentId('Nobody'), false)
+})
+
+Deno.test('collectSkillNamesForAgent merges extraSkills into configured skills', () => {
+  const skills = collectSkillNamesForAgent('Tina', ['slv-rpc'])
+  // Tina registers slv-grpc-geyser as an extra skill.
+  assertEquals(skills.sort(), ['slv-grpc-geyser', 'slv-rpc'])
+})
+
+Deno.test('collectSkillNamesForAgent deduplicates overlapping entries', () => {
+  const skills = collectSkillNamesForAgent('Cid', ['slv-grpc-geyser'])
+  assertEquals(skills, ['slv-grpc-geyser'])
+})
+
+Deno.test('Figaro registry metadata enables auto-detect via skill presence', () => {
+  assertEquals(
+    AGENT_REGISTRY.Figaro.autoEnableIfSkillPresent,
+    'slv-server-procurement',
+  )
+})

--- a/cli/test/unit/agentConfig_schema.test.ts
+++ b/cli/test/unit/agentConfig_schema.test.ts
@@ -1,0 +1,72 @@
+import { assert, assertEquals } from '@std/assert'
+
+import {
+  AgentConfigSchema,
+  ApiConfigSchema,
+  SkillEntrySchema,
+} from '@/ai/agentConfig/schema.ts'
+
+Deno.test('AgentConfigSchema applies defaults for an empty object', () => {
+  const parsed = AgentConfigSchema.parse({})
+  assertEquals(parsed.skills, [])
+  assertEquals(parsed.auto_execute, true)
+  assertEquals(parsed.mode, 'remote')
+  assertEquals(parsed.notifications, undefined)
+})
+
+Deno.test('AgentConfigSchema accepts the current production shape', () => {
+  const parsed = AgentConfigSchema.parse({
+    skills: [
+      { name: 'slv-validator', enabled: true, agent: 'Cecil' },
+      { name: 'slv-rpc', enabled: true, agent: 'Tina' },
+      { name: 'slv-grpc-geyser', enabled: false, agent: 'Tina' },
+    ],
+    auto_execute: false,
+    mode: 'local',
+  })
+  assertEquals(parsed.skills.length, 3)
+  assertEquals(parsed.auto_execute, false)
+  assertEquals(parsed.mode, 'local')
+})
+
+Deno.test('AgentConfigSchema preserves unknown keys via passthrough', () => {
+  const parsed = AgentConfigSchema.parse({
+    skills: [],
+    auto_execute: true,
+    mode: 'remote',
+    future_field: 'future_value',
+  }) as unknown as Record<string, unknown>
+  assertEquals(parsed.future_field, 'future_value')
+})
+
+Deno.test('SkillEntrySchema defaults enabled to true when omitted', () => {
+  const parsed = SkillEntrySchema.parse({ name: 'slv-app', agent: 'Setzer' })
+  assertEquals(parsed.enabled, true)
+})
+
+Deno.test('ApiConfigSchema defaults slv.api_key to null', () => {
+  const parsed = ApiConfigSchema.parse({})
+  assertEquals(parsed.slv.api_key, null)
+  assertEquals(parsed.ai, undefined)
+})
+
+Deno.test('ApiConfigSchema parses an AI config block', () => {
+  const parsed = ApiConfigSchema.parse({
+    slv: { api_key: '00000000-0000-4000-8000-000000000000' },
+    ai: {
+      provider: 'anthropic',
+      api_key: 'sk-ant-xxx',
+      model: 'claude-opus-4-6',
+    },
+    lang: 'en',
+  })
+  assert(parsed.ai)
+  assertEquals(parsed.ai.provider, 'anthropic')
+  assertEquals(parsed.ai.model, 'claude-opus-4-6')
+  assertEquals(parsed.lang, 'en')
+})
+
+Deno.test('AgentConfigSchema rejects invalid mode via safeParse', () => {
+  const result = AgentConfigSchema.safeParse({ mode: 'hybrid' })
+  assertEquals(result.success, false)
+})


### PR DESCRIPTION
## Summary
- `executeDelegateToAgent` had no `config.provider === 'slv'` branch — SLV users fell through to `runOpenAISubAgent` with an empty API key, causing every sub-agent delegation (Setzer, Cecil, etc.) to time out or fail silently.
- Adds `runSlvSubAgent`: a fetch-based agentic loop that calls the SLV AI proxy (`https://user-api.erpc.global/v3/ai/chat`) with `Authorization: Bearer` auth. The proxy returns Anthropic Messages API format, so the loop logic mirrors `runAnthropicSubAgent` exactly.
- Reads `slv.api_key` from `~/.slv/api.yml` (same pattern as `consoleAction.ts` uses for the main SLV provider).

## Root cause
```typescript
// Before: only 'anthropic' was handled, everything else → OpenAI
if (config.provider === 'anthropic') {
  return await runAnthropicSubAgent(...)
} else {
  return await runOpenAISubAgent(...)  // ← slv users landed here
}
```

The SLV provider stores its API key in `slv.api_key` (not `ai.api_key`), so `config.api_key` was `''`. The OpenAI client received an empty key and timed out on auth.

## Test plan
- [ ] `deno check cli/src/ai/console/tools.ts` passes
- [ ] With `provider: slv` in `~/.slv/api.yml`, run `slv c` and ask a question that triggers delegation to Setzer (e.g. "trade-app をセットアップして") — verify the sub-agent executes successfully instead of timing out
- [ ] With `provider: anthropic`, verify delegation still works (no regression)
- [ ] With invalid/missing SLV API key, verify a clear error message is returned instead of a hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)