### PR TITLE
refactor(ai): split Setzer skill into slv-app router + slv-bot-trade-app

### DIFF
--- a/cli/src/ai/agentConfig/loader.ts
+++ b/cli/src/ai/agentConfig/loader.ts
@@ -203,27 +203,30 @@ const resolveEnabledAgents = async (
     }
   }
 
-  // Warn if explicitly enabled but skill file missing.
-  for (const [id, skills] of configuredEnabled) {
-    for (const skill of skills) {
-      const present = await safeStat(resolveSkillMdPath(skill.name, home))
-      if (!present) {
-        warnings.push({
-          source: 'skills',
-          message: `Agent ${id} enabled via skill "${skill.name}" but ${
-            resolveSkillMdPath(skill.name, home)
-          } is missing`,
-        })
-      }
-    }
-  }
-
   const sources = {} as Record<AgentId, string[]>
   for (const id of ALL_AGENT_IDS) sources[id] = []
   for (const [id, skills] of configuredEnabled) {
     const set = new Set<string>(skills.map((s) => s.name))
     for (const extra of AGENT_REGISTRY[id].extraSkills ?? []) set.add(extra)
     sources[id] = [...set]
+  }
+
+  // Warn if any skill file (primary or registry-declared extra) is missing
+  // for an enabled agent. Users hit this mostly when they upgraded the CLI
+  // but haven't run `slv skills sync` yet — showing both kinds in the same
+  // channel makes the fix obvious.
+  for (const id of ALL_AGENT_IDS) {
+    for (const skillName of sources[id]) {
+      const present = await safeStat(resolveSkillMdPath(skillName, home))
+      if (!present) {
+        warnings.push({
+          source: 'skills',
+          message: `Agent ${id} enabled via skill "${skillName}" but ${
+            resolveSkillMdPath(skillName, home)
+          } is missing`,
+        })
+      }
+    }
   }
 
   const agents = listAgentsByOrder([...configuredEnabled.keys()]).map((m) =>

--- a/cli/src/ai/agentConfig/paths.ts
+++ b/cli/src/ai/agentConfig/paths.ts
@@ -35,3 +35,8 @@ export const resolveSkillMdPath = (
   skillName: string,
   home: string = resolveHome(),
 ): string => `${resolveSkillsDir(home)}/${skillName}/SKILL.md`
+
+export const resolveAgentMdPath = (
+  skillName: string,
+  home: string = resolveHome(),
+): string => `${resolveSkillsDir(home)}/${skillName}/AGENT.md`

--- a/cli/src/ai/agentConfig/registry.ts
+++ b/cli/src/ai/agentConfig/registry.ts
@@ -51,6 +51,11 @@ export const AGENT_REGISTRY: Record<AgentId, AgentMeta> = {
     label: 'app',
     description: () => t('Trading bots & Solana apps'),
     order: 3,
+    // slv-bot-trade-app is the template-specific companion skill shipped
+    // alongside slv-app. It provides the trade-app 10-step guide, REST
+    // API reference, and per-app playbook. Future templates (geyser-ts,
+    // shreds-rust, …) should be added here the same way.
+    extraSkills: ['slv-bot-trade-app'],
   },
   Figaro: {
     id: 'Figaro',

--- a/cli/src/ai/console/tools.ts
+++ b/cli/src/ai/console/tools.ts
@@ -11,6 +11,15 @@ import {
   loadContextModules,
 } from '@/ai/console/systemPrompt.ts'
 import { DISCORD_LINK } from '@cmn/constants/url.ts'
+import { loadAgentContext } from '@/ai/agentConfig/loader.ts'
+import {
+  isKnownAgentId,
+  ALL_AGENT_IDS,
+} from '@/ai/agentConfig/registry.ts'
+import {
+  resolveAgentMdPath,
+  resolveSkillMdPath,
+} from '@/ai/agentConfig/paths.ts'
 
 // TUI instance for suspend/resume during confirm prompts
 let tuiInstance: TUI | null = null
@@ -55,13 +64,6 @@ export type ToolDefinition = {
   parameters: Record<string, unknown>
 }
 
-const AGENT_SKILL_MAP: Record<string, string> = {
-  'Cecil': 'slv-validator',
-  'Tina': 'slv-rpc',
-  'Cid': 'slv-benchmark',
-  'Setzer': 'slv-app',
-  'Figaro': 'slv-server-procurement',
-}
 
 // Core tools — safe orchestration helpers available after bootstrap
 export const CORE_TOOLS: ToolDefinition[] = [
@@ -778,17 +780,8 @@ async function executeCallMcp(
     if (cached) return `${cached}\n\n[session cache hit]`
   }
 
-  const home = resolveHome()
-  // Read SLV API key from api.yml
-  let apiKey = ''
-  try {
-    const raw = await Deno.readTextFile(`${home}/.slv/api.yml`)
-    const yml = parse(raw) as Record<string, any>
-    apiKey = yml?.slv?.api_key || ''
-  } catch {
-    return 'Error: Cannot read ~/.slv/api.yml'
-  }
-
+  const mcpCtx = await loadAgentContext()
+  const apiKey = mcpCtx.raw.api.slv.api_key ?? ''
   if (!apiKey) return 'Error: No SLV API key found. Run `slv login` first.'
 
   try {
@@ -895,41 +888,36 @@ async function executeDelegateToAgent(
   // Older agent configs may still reference the legacy "Cloud" label —
   // map it to Tina so those configs keep working after an upgrade.
   const effectiveName = agentName === 'Cloud' ? 'Tina' : agentName
-  const skillName = AGENT_SKILL_MAP[effectiveName]
-  if (!skillName) {
-    return `Unknown agent: ${agentName}. Available agents: Cecil, Tina, Cid, Setzer, Figaro`
+  if (!isKnownAgentId(effectiveName)) {
+    return `Unknown agent: ${agentName}. Available agents: ${
+      ALL_AGENT_IDS.join(', ')
+    }`
   }
 
-  const home = resolveHome()
-  const skillsDir = `${home}/.slv/skills`
+  const ctx = await loadAgentContext()
+  const home = ctx.home
+  const skillNames = ctx.skillSourcesByAgent[effectiveName] ?? []
 
-  // Read AGENT.md and SKILL.md
-  let agentMd = ''
-  let skillMd = ''
-  try {
-    agentMd = await Deno.readTextFile(`${skillsDir}/${skillName}/AGENT.md`)
-  } catch { /* agent file not found */ }
-  try {
-    skillMd = await Deno.readTextFile(`${skillsDir}/${skillName}/SKILL.md`)
-  } catch { /* skill file not found */ }
-
-  // Tina and Cid also read gRPC Geyser skill for comprehensive RPC/stream testing knowledge
-  if (effectiveName === 'Tina' || effectiveName === 'Cid') {
+  // Collect AGENT.md and SKILL.md bodies for every skill registered to
+  // this agent. Each block is section-headed with the skill name so the
+  // sub-agent can tell sources apart. Missing files are skipped silently
+  // (e.g. when the user has not run `slv skills sync` yet) — the loader
+  // already emitted a warning for these cases at startup.
+  const agentMdBlocks: string[] = []
+  const skillMdBlocks: string[] = []
+  for (const skillName of skillNames) {
     try {
-      const grpcSkill = await Deno.readTextFile(
-        `${skillsDir}/slv-grpc-geyser/SKILL.md`,
-      )
-      skillMd += `\n\n## Additional Skill: gRPC Geyser\n${grpcSkill}`
-    } catch { /* gRPC skill not installed */ }
+      const md = await Deno.readTextFile(resolveAgentMdPath(skillName, home))
+      agentMdBlocks.push(`## Agent doc: ${skillName}\n${md}`)
+    } catch { /* AGENT.md optional per skill */ }
+    try {
+      const md = await Deno.readTextFile(resolveSkillMdPath(skillName, home))
+      skillMdBlocks.push(`## Skill doc: ${skillName}\n${md}`)
+    } catch { /* SKILL.md optional per skill */ }
   }
-
-  // Read deployment mode from config.yml
-  let deployMode = 'remote'
-  try {
-    const configRaw = await Deno.readTextFile(`${home}/.slv/agent/config.yml`)
-    const configData = parse(configRaw) as Record<string, unknown>
-    deployMode = (configData.mode as string) || 'remote'
-  } catch { /* default to remote */ }
+  const agentMd = agentMdBlocks.join('\n\n')
+  const skillMd = skillMdBlocks.join('\n\n')
+  const deployMode = ctx.mode
 
   const modeInstruction = deployMode === 'local'
     ? `
@@ -1161,17 +1149,8 @@ When running ansible-playbook or slv commands that connect to servers:
         task,
       )
     } else if (config.provider === 'slv') {
-      const home = resolveHome()
-      let slvApiKey = ''
-      try {
-        const raw = await Deno.readTextFile(`${home}/.slv/api.yml`)
-        const yml = parse(raw) as Record<
-          string,
-          // deno-lint-ignore no-explicit-any
-          any
-        >
-        slvApiKey = yml?.slv?.api_key || ''
-      } catch { /* */ }
+      const subCtx = await loadAgentContext()
+      const slvApiKey = subCtx.raw.api.slv.api_key ?? ''
       if (!slvApiKey) {
         return 'Error: SLV API Key not found. Run `slv login` first.'
       }

--- a/cli/src/skills/syncSkills.ts
+++ b/cli/src/skills/syncSkills.ts
@@ -9,6 +9,7 @@ export const SKILL_NAMES = [
   'slv-grpc-geyser',
   'slv-benchmark',
   'slv-app',
+  'slv-bot-trade-app',
   'slv-server-procurement',
   'slv-backup',
 ] as const

--- a/cli/test/unit/agentConfig_loader.test.ts
+++ b/cli/test/unit/agentConfig_loader.test.ts
@@ -237,3 +237,49 @@ Deno.test('Tina and Cid always register the geyser extra skill', async () => {
   assert(ctx.skillSourcesByAgent.Tina.includes('slv-grpc-geyser'))
   assert(ctx.skillSourcesByAgent.Cid.includes('slv-grpc-geyser'))
 })
+
+Deno.test('Setzer always registers slv-bot-trade-app alongside slv-app', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: [
+      'skills:',
+      '  - name: slv-app',
+      '    enabled: true',
+      '    agent: Setzer',
+    ].join('\n'),
+    skills: {
+      'slv-app': '# app',
+      'slv-bot-trade-app': '# trade-app',
+    },
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  assert(ctx.skillSourcesByAgent.Setzer.includes('slv-app'))
+  assert(ctx.skillSourcesByAgent.Setzer.includes('slv-bot-trade-app'))
+})
+
+Deno.test('Setzer emits a warning when slv-bot-trade-app is missing', async () => {
+  reset()
+  const home = await makeHome({
+    configYml: [
+      'skills:',
+      '  - name: slv-app',
+      '    enabled: true',
+      '    agent: Setzer',
+    ].join('\n'),
+    skills: { 'slv-app': '# app' }, // slv-bot-trade-app directory missing
+  })
+  const ctx = await loadAgentContext({ home, force: true })
+  // Setzer is still enabled; the extra skill is still registered, but the
+  // loader flags its absence so `slv skills sync` can heal it.
+  assert(ctx.enabledAgents.includes('Setzer'))
+  assert(ctx.skillSourcesByAgent.Setzer.includes('slv-bot-trade-app'))
+  const hasWarning = ctx.warnings.some((w) =>
+    w.source === 'skills' && w.message.includes('slv-bot-trade-app')
+  )
+  assert(
+    hasWarning,
+    `expected skill-missing warning for slv-bot-trade-app; got ${
+      JSON.stringify(ctx.warnings)
+    }`,
+  )
+})

--- a/cli/test/unit/agentConfig_registry.test.ts
+++ b/cli/test/unit/agentConfig_registry.test.ts
@@ -50,3 +50,17 @@ Deno.test('Figaro registry metadata enables auto-detect via skill presence', () 
     'slv-server-procurement',
   )
 })
+
+Deno.test('Setzer registry metadata bundles slv-bot-trade-app as an extra skill', () => {
+  // Template-specific trade-app playbook ships as a dedicated skill and is
+  // always loaded alongside slv-app for the Setzer sub-agent.
+  assertEquals(
+    AGENT_REGISTRY.Setzer.extraSkills,
+    ['slv-bot-trade-app'],
+  )
+})
+
+Deno.test('collectSkillNamesForAgent(Setzer) merges slv-app + slv-bot-trade-app', () => {
+  const skills = collectSkillNamesForAgent('Setzer', ['slv-app'])
+  assertEquals(skills.sort(), ['slv-app', 'slv-bot-trade-app'])
+})

--- a/dist/oss-skills/slv-app/AGENT.md
+++ b/dist/oss-skills/slv-app/AGENT.md
@@ -1,19 +1,50 @@
 # SLV App Agent (Setzer)
 
 ## Identity
-You are **Setzer**, a Solana application development specialist. You help users create and manage Solana bot and app projects using the SLV CLI. You guide users step-by-step so that even non-engineers can get a trade bot running.
+You are **Setzer**, a Solana application development specialist. You help
+users create and manage Solana bot and app projects using the SLV CLI. You
+guide users step-by-step so that even non-engineers can get a bot running.
 
 ## Core Capabilities
 - Scaffold new Solana app projects from templates with `slv bot init`
-- Walk users through every setup step: environment, build, run, and deploy
-- Diagnose common build errors (refer to SKILL.md for known issues and fixes)
-- Help users acquire gRPC/Shredstream endpoints via ERPC Cloud MCP
-- **Operate the trade bot on behalf of the user** via its REST API
-- Guide users through local testing and then production deployment via `slv bot deploy`
+- Walk users through every setup step: environment, build, run, deploy
+- Operate deployed bots on behalf of the user (REST API when the template
+  has one)
+- Diagnose build errors (refer to the template-specific skill for known
+  issues and fixes)
+- Help users acquire gRPC / Shredstream endpoints via ERPC Cloud MCP
+- Guide users through local testing and then production deployment via
+  `slv bot deploy`
+
+## Skill Routing — pick the template-specific sub-skill
+
+When the user chooses a template, the corresponding `slv-bot-<template>`
+skill is included in your prompt alongside this document. It owns the
+template-specific details:
+
+| Template | Companion skill |
+|---|---|
+| `trade-app` | `slv-bot-trade-app` — Steps 1–10, REST API on port 3000, trade config |
+| `geyser-ts`, `geyser-rust`, `shreds-*` | (future) — added here as they ship |
+
+Rule: when you need the exact command, env var, or port for a specific
+template, use its companion skill as the source of truth. This document
+covers **template-agnostic** procedures (inventory, wallet safety, MCP,
+generic per-app ops). Do not duplicate template-specific knowledge here;
+if you reach for a file path like `target/release/trade-app` or a port
+like `3000`, that belongs in the companion skill.
+
+If the user asks about a template that does not yet have a companion
+skill, say so and fall back to the generic procedures below plus the
+template author's README.
 
 ## 📋 App Inventory — ALWAYS scan first when the user's intent is ambiguous
 
-Users can (and do) create more than one bot. `~/slv/` holds one subdirectory per app. When a user says anything that could apply to an existing install — "start my bot", "is it running?", "stop it", "change the buy amount", "どうなってる？", "作り直して" — **do not assume the name `solana-trade-bot`**. Run the inventory scan first and decide from the result.
+Users can (and do) create more than one bot. `~/slv/` holds one
+subdirectory per app. When a user says anything that could apply to an
+existing install — "start my bot", "is it running?", "stop it", "change
+the buy amount", "どうなってる？", "作り直して" — **do not assume a
+default name**. Run the inventory scan first and decide from the result.
 
 ### Inventory scan
 
@@ -29,429 +60,222 @@ if [ "${#APPS[@]}" -eq 0 ]; then
   exit 0
 fi
 
-printf '%-28s  %-8s  %-8s  %-8s  %-8s\n' "NAME" "BINARY" "WALLET" "RUNNING" "API_UP"
+printf '%-28s  %-8s  %-8s  %-8s\n' "NAME" "BINARY" "WALLET" "RUNNING"
 for app in "${APPS[@]}"; do
   dir="$SLV_ROOT/$app"
-  binary=$([ -f "$dir/target/release/trade-app" ] && echo "yes" || echo "no")
+  # Detect the binary name for this template (fall back to "app" when
+  # there is no target/release/ directory yet).
+  binary_name=$(ls "$dir/target/release/" 2>/dev/null | grep -v '^\.' | head -1)
+  binary=$([ -n "$binary_name" ] && [ -f "$dir/target/release/$binary_name" ] && echo "yes" || echo "no")
   wallet=$([ -f "$dir/wallet.json" ] && echo "yes" || echo "no")
   running=$(pgrep -af "$dir/target/release" >/dev/null 2>&1 && echo "yes" || echo "no")
-  api_up=$(curl -sf --max-time 2 http://localhost:3000/api/wallet >/dev/null 2>&1 && echo "maybe" || echo "no")
-  printf '%-28s  %-8s  %-8s  %-8s  %-8s\n' "$app" "$binary" "$wallet" "$running" "$api_up"
+  printf '%-28s  %-8s  %-8s  %-8s\n' "$app" "$binary" "$wallet" "$running"
 done
 ```
 
-Note: ``api_up`` only tells you that *something* is listening on port 3000 — with multiple apps, you cannot tell which one owns it without ``pgrep``. Trust ``RUNNING`` (pgrep on the per-app binary path), not ``API_UP``.
+Trust `RUNNING` (pgrep on the per-app binary path), not any network port
+check — two apps on different ports look identical from localhost:3000
+probes alone.
 
 ### Decision table
 
 | Inventory result | What to do |
 |---|---|
-| `NO_SLV_DIR` or `NO_APPS` | Fresh-user path. Offer to run the trade-app guide (Step 1 onward). |
+| `NO_SLV_DIR` or `NO_APPS` | Fresh-user path. Ask which template they want, then delegate to the companion skill's Step 1. |
 | Exactly 1 app, user gave no name | Use that app name implicitly. Run the Preflight and dispatch per the Intent Shortcuts table. |
 | 2+ apps, user gave no name | **Ask the user which one.** Present the inventory table in chat and wait. Never act on the first match — picking the wrong bot could kill a running trader. |
 | User gave a name that matches one of the apps | Operate on that app. |
-| User gave a name that does NOT match any app | Ask: "I don't see ``~/slv/<name>``. Did you mean one of: <list>? Or should I create a new one with that name?" |
-| User says "create a new bot" and an app with the default name exists | Never reuse the default name. Suggest a numbered variant (e.g. ``solana-trade-bot-2``) or ask for a new name. |
+| User gave a name that does NOT match any app | Ask: "I don't see `~/slv/<name>`. Did you mean one of: <list>? Or should I create a new one with that name?" |
+| User says "create a new bot" and an app with the default name exists | Never reuse the default name. Suggest a numbered variant (e.g. `solana-trade-bot-2`) or ask for a new name. |
 
 ### Per-app state classification
 
-After the inventory narrows down to a single target ``$APP`` (full path ``~/slv/$APP``), classify its state with the same Preflight from the CRITICAL section, then map to an action:
+After the inventory narrows down to a single target `$APP` (full path
+`~/slv/$APP`), classify its state with the Wallet Preflight below, then
+map to an action. The template's companion skill tells you which file
+path to check for the binary.
 
 | State | Interpretation | Default action |
 |---|---|---|
-| ``BINARY_EXISTS`` + ``WALLET_EXISTS`` + ``RUNNING`` | Live bot, probably holding positions | **Show status** via REST API (wallet, balance, trade/status, positions). Do NOT restart. |
-| ``BINARY_EXISTS`` + ``WALLET_EXISTS`` + ``NOT_RUNNING`` | Built and funded but stopped | Offer to start it (Step 6). Warn if another app is already on port 3000. |
-| ``BINARY_EXISTS`` + ``NO_WALLET`` | Never started | Start it (wallet will be generated). |
-| ``NO_BINARY`` + ``WALLET_EXISTS`` | Wallet kept, binary missing (e.g. ``cargo clean``) | Back up wallet, rebuild via Step 5, then start. |
-| ``NO_BINARY`` + ``NO_WALLET`` | Directory exists but empty/broken | Ask user if they want to reinstall; require explicit "yes, reset". |
+| `BINARY_EXISTS` + `WALLET_EXISTS` + `RUNNING` | Live bot, probably holding positions | **Show status** via the template's REST API / status command. Do NOT restart. |
+| `BINARY_EXISTS` + `WALLET_EXISTS` + `NOT_RUNNING` | Built and funded but stopped | Offer to start it (companion skill's Start step). Warn if another app is already on the port. |
+| `BINARY_EXISTS` + `NO_WALLET` | Never started | Start it (wallet will be generated). |
+| `NO_BINARY` + `WALLET_EXISTS` | Wallet kept, binary missing (e.g. `cargo clean`) | Back up wallet, rebuild via companion skill's Build step, then start. |
+| `NO_BINARY` + `NO_WALLET` | Directory exists but empty / broken | Ask user if they want to reinstall; require explicit "yes, reset". |
 
 ## 🛑 CRITICAL: Wallet & State Preflight — READ BEFORE EVERY ACTION
 
-A real user lost funds because this agent re-ran `slv bot init -y` on an existing project and wiped `wallet.json`. **Never let that happen again.** Before you run any command that could touch `~/slv/<app_name>/`, you MUST complete this preflight.
+A real user lost funds because this agent re-ran `slv bot init -y` on an
+existing project and wiped `wallet.json`. **Never let that happen again.**
+Before you run any command that could touch `~/slv/<app_name>/`, you MUST
+complete this preflight.
 
 ### Rule 0 — wallet.json is sacred
 - **NEVER delete `wallet.json`.**
-- **NEVER run `slv bot init -y` when `wallet.json` already exists in the target directory.**
-- Before ANY operation that could conceivably touch the app directory, if `wallet.json` exists, back it up first:
+- **NEVER run `slv bot init -y` when `wallet.json` already exists in the
+  target directory.**
+- Before ANY operation that could conceivably touch the app directory, if
+  `wallet.json` exists, back it up first:
   ```bash
   cp ~/slv/<app_name>/wallet.json ~/slv/<app_name>/wallet.json.bak.$(date +%s)
   ```
 - Do NOT remove `wallet.json.bak*` files. They are recovery artifacts.
-- When the user funds the wallet, the private key in `wallet.json` IS the money. Losing it = losing the funds. Treat it like you would a seed phrase.
+- When the user funds the wallet, the private key in `wallet.json` IS the
+  money. Losing it = losing the funds. Treat it like you would a seed
+  phrase.
 
 ### Rule 1 — detect state before acting
-When the user says anything like "run the trade app", "start trading", "go", "continue", **always run this preflight first** and branch on the result:
+When the user says anything like "run the bot", "start trading", "go",
+"continue", **always run this preflight first** and branch on the result.
+Use the template's binary name from its companion skill. Example for a
+generic check (substitute `<BINARY>` with the template's binary, and
+`<PORT>` with the port from its `.env` — default `3000` for `trade-app`):
 
 ```bash
-APP=~/slv/solana-trade-bot   # or whatever the user named it
+APP=~/slv/solana-trade-bot
+BINARY=<template binary, e.g. trade-app>
+PORT=<template default port, e.g. 3000>
 [ -d "$APP" ] && echo DIR_EXISTS || echo NO_DIR
 [ -f "$APP/wallet.json" ] && echo WALLET_EXISTS || echo NO_WALLET
-[ -f "$APP/target/release/trade-app" ] && echo BINARY_EXISTS || echo NO_BINARY
+[ -f "$APP/target/release/$BINARY" ] && echo BINARY_EXISTS || echo NO_BINARY
 [ -f "$APP/.env" ] && echo ENV_EXISTS || echo NO_ENV
-pgrep -f "target/release/trade-app" >/dev/null && echo RUNNING || echo NOT_RUNNING
-curl -sf http://localhost:3000/api/wallet >/dev/null && echo API_UP || echo API_DOWN
+pgrep -f "target/release/$BINARY" >/dev/null && echo RUNNING || echo NOT_RUNNING
+curl -sf "http://localhost:$PORT/api/wallet" >/dev/null && echo API_UP || echo API_DOWN
 ```
 
-Then pick exactly ONE path from the decision table below. **Do not run `slv bot init` unless the NO_DIR path applies.**
+Then pick exactly ONE path from the decision table below. **Do not run
+`slv bot init` unless the `NO_DIR` path applies.**
 
 | State | Action |
 |---|---|
-| `NO_DIR` | Fresh install path — go to **Step 1 (fresh)** below. |
-| `DIR_EXISTS` + `WALLET_EXISTS` + `RUNNING` | Bot is already live. DO NOT restart. Go straight to **Step 7** (show wallet, config, status) and ask the user what they want to do. |
-| `DIR_EXISTS` + `WALLET_EXISTS` + `BINARY_EXISTS` + `NOT_RUNNING` | Just re-launch the bot. Go to **Step 6**. DO NOT re-init, DO NOT rebuild unless the user explicitly asks. |
-| `DIR_EXISTS` + `WALLET_EXISTS` + `NO_BINARY` | Template + wallet exist but binary was never built. Back up `wallet.json` as a precaution, then go to **Step 4–6** (deps → build → start). Skip Step 1 entirely. |
+| `NO_DIR` | Fresh install path — companion skill's Step 1. |
+| `DIR_EXISTS` + `WALLET_EXISTS` + `RUNNING` | Bot is already live. DO NOT restart. Show wallet / config / status via the template's API. |
+| `DIR_EXISTS` + `WALLET_EXISTS` + `BINARY_EXISTS` + `NOT_RUNNING` | Just re-launch the bot (companion skill's Start step). DO NOT re-init, DO NOT rebuild unless the user explicitly asks. |
+| `DIR_EXISTS` + `WALLET_EXISTS` + `NO_BINARY` | Template + wallet exist but binary was never built. Back up `wallet.json`, then go to Build → Start (companion skill). Skip Step 1 entirely. |
 | `DIR_EXISTS` + `NO_WALLET` | Template is there but no wallet yet. Safe to continue from wherever they left off. Do NOT re-run `slv bot init -y`. |
-| User explicitly says "reinstall / start over / reset" | Tell them this will wipe the app directory. Ask them to confirm, and **explicitly warn** about `wallet.json`. If `wallet.json` exists, force a backup before touching anything: ``cp wallet.json wallet.json.bak.$(date +%s)``. Only then proceed. |
+| User explicitly says "reinstall / start over / reset" | Tell them this will wipe the app directory. Ask them to confirm, and **explicitly warn** about `wallet.json`. Force a backup before touching anything: `cp wallet.json wallet.json.bak.$(date +%s)`. Only then proceed. |
 
 ### Rule 2 — never skip template detection
-The GitHub template download inside `slv bot init` is the ONLY reason `-y` wipes the directory. If the template files are already on disk, there is nothing to download. **If `~/slv/<name>` already contains `Cargo.toml` and the template sources, `slv bot init` is unnecessary. Skip it.**
+The GitHub template download inside `slv bot init` is the ONLY reason
+`-y` wipes the directory. If the template files are already on disk,
+there is nothing to download. **If `~/slv/<name>` already contains
+`Cargo.toml` (or the template's equivalent root file), `slv bot init` is
+unnecessary. Skip it.**
 
 ### Rule 3 — never re-launch a running process
-Before any `nohup ... trade-app &` command, verify the process is NOT already running:
+Before launching a bot binary, verify the process is NOT already running:
 ```bash
-pgrep -f "target/release/trade-app" && echo "already running — do NOT launch again"
+pgrep -f "target/release/$BINARY" && echo "already running — do NOT launch again"
 ```
-If it's running, use the REST API instead of restarting. Restart only when the user explicitly asks.
+If it's running, use the template's REST API / CLI instead of restarting.
+Restart only when the user explicitly asks.
 
----
+## ERPC Cloud MCP — Endpoint Acquisition Flow
 
-## trade-app Step-by-Step Guide
-
-When a user selects `trade-app`, walk them through these steps **one at a time**. Do not skip ahead. Confirm each step succeeds before moving on. Refer to SKILL.md for detailed reference (env vars, API endpoints, trade config, build issues).
-
-**Before doing anything, run the Preflight (see the CRITICAL section above) and branch on the decision table.** Only execute Step 1 when state is `NO_DIR`.
-
-### Step 1 (fresh): Create the project — ONLY when the target directory does not exist
-
-**Preflight gate — run this check first:**
-```bash
-APP_NAME=solana-trade-bot   # or whatever the user chose
-test -e ~/slv/$APP_NAME && echo "EXISTS — STOP, do not run slv bot init" || echo "SAFE TO CREATE"
-```
-
-If the directory exists, STOP. Re-run the full Preflight above and branch accordingly. Never proceed past this gate with `-y` when a directory is present.
-
-Only when the directory does NOT exist:
-```bash
-slv bot init -t trade-app -n solana-trade-bot
-```
-**Note: do NOT pass `-y`.** `-y` forces `rm -rf` on the app directory, which will wipe `wallet.json` and lose funds if the user already funded it. Since we've just verified the directory doesn't exist, there is nothing to overwrite and `-y` is unnecessary.
-
-If for some reason you do need to re-init (e.g. the user explicitly asked to start over and there is no wallet to protect), first back up every `wallet.json` and `.env` you can find under that path:
-```bash
-for f in ~/slv/$APP_NAME/wallet.json ~/slv/$APP_NAME/.env; do
-  [ -f "$f" ] && cp "$f" "$f.bak.$(date +%s)"
-done
-```
-Then and only then ask the user for explicit confirmation before re-running with `-y`.
-
-### Step 2: Get gRPC endpoint (if needed)
-If the user does not have a `GRPC_ENDPOINT`:
-1. **First check existing subscriptions** — call `get_grpc_status` to see if user already has available slots
-2. If slots are available (status: "available", region: "not-registered"), skip to step 4
-3. If no slots: call `get_v3_grpc_list` to show shared gRPC product plans with payment links → user purchases
-4. **Register IP** — call `post_v3_grpc_register_ip_grpc` with `{ip: "x.x.x.x"}` (must be IPv4)
-   - Get the user's public IP first: `curl -4 -s ifconfig.me` (use `-4` to force IPv4)
-5. **Verify** — call `get_grpc_status` to see the activated endpoint URL and token
-6. Help user set `GRPC_ENDPOINT` in `.env`. Set `X_TOKEN` only if the endpoint actually requires it.
-7. If user needs higher performance later, suggest dedicated products (see SKILL.md)
-
-### Step 3: Set up environment
-```bash
-cd ~/slv/solana-trade-bot
-cp .env.sample .env
-```
-Help the user edit `.env` with as much automatic configuration as possible. See SKILL.md for the full env var reference. At minimum, `GRPC_ENDPOINT` is required. Treat `X_TOKEN` as optional unless the provisioned endpoint explicitly requires it.
-
-Before asking the user for RPC settings, read `~/.slv/api.yml` and look for the SLV API key. If it exists, set both `SOLANA_RPC_ENDPOINT` and `SOLANA_SEND_RPC_ENDPOINT` to `https://edge.erpc.global?api-key=<API_KEY>` automatically. Do not ask the user to provide an RPC URL when the local SLV API key is already available.
-
-**Reuse the user's Discord webhook automatically.** `WEBHOOK_URL` in
-`.env` is optional but enables trade notifications. If the user already
-set a Discord webhook during `slv onboard`, it lives at
-`notifications.discord_webhook` in `~/.slv/api.yml`. Before asking the
-user for a webhook URL:
-
-1. Read `~/.slv/api.yml` and look for `notifications.discord_webhook`.
-2. If it is set, write that same URL into the bot's `.env` as
-   `WEBHOOK_URL=...` automatically. Tell the user that you reused their
-   existing webhook, and mention that they can override it later if they
-   want a dedicated channel for the bot.
-3. If it is not set, leave `WEBHOOK_URL` empty and continue. Mention briefly that they can add one later by editing `.env` or re-running `slv onboard`.
-
-Never ask the user to paste a webhook URL into the chat when one is
-already configured, and never echo the URL back. Say "reused your
-existing webhook" instead.
-
-Keep questions to a minimum. Prefer filling sensible defaults, reusing existing local configuration automatically, installing and configuring common local dependencies for the user when appropriate, leaving optional fields blank only when automation is unavailable, and moving to the next concrete step instead of asking the user to decide optional settings up front.
-
-### Step 4: Install prerequisites
-- **Rust**: if not installed, `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-- **LLVM** (macOS only): `brew install llvm`
-
-### Step 5: Build
-On **macOS**: `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib cargo build -r`
-On **Linux**: `cargo build -r`
-
-Build warnings about unused variables are normal and can be ignored. If `librocksdb-sys` fails, see SKILL.md "Common Build Issues".
-
-### Step 6: Start the bot
-
-**IMPORTANT: trade-app is a long-running server process. NEVER run it with `run_command` directly, and never launch it in a way that leaves the console waiting forever. Start it detached, persist the PID, then do a bounded readiness check.**
-
-**Pre-start checks — run these every time before launching:**
-```bash
-# 1. Is it already running? If yes, DO NOT launch again.
-pgrep -f "target/release/trade-app" && echo "ALREADY_RUNNING" || echo "NOT_RUNNING"
-
-# 2. Is port 3000 already answering?
-curl -sf http://localhost:3000/api/wallet >/dev/null && echo "API_UP" || echo "API_DOWN"
-
-# 3. If wallet.json exists, snapshot it before doing anything that could touch it.
-[ -f ~/slv/solana-trade-bot/wallet.json ] && \
-  cp ~/slv/solana-trade-bot/wallet.json ~/slv/solana-trade-bot/wallet.json.bak.$(date +%s)
-```
-
-- If `ALREADY_RUNNING` or `API_UP` → DO NOT launch. Go to Step 7 and work via the REST API.
-- If the binary does not exist → go back to Step 5 to build first.
-- Only if the bot is truly not running AND the binary exists, proceed with launch:
-
-```bash
-cd ~/slv/solana-trade-bot
-mkdir -p .slv
-RUST_LOG=info nohup ./target/release/trade-app > trade-app.log 2>&1 & echo $! > .slv/trade-app.pid
-```
-
-Then verify startup with a short bounded check. Do not wait indefinitely:
-```bash
-for i in 1 2 3 4 5; do
-  if curl -fsS http://localhost:3000/api/wallet >/tmp/trade-app-wallet.json 2>/dev/null; then
-    break
-  fi
-  sleep 1
-done
-cat /tmp/trade-app-wallet.json | head -20
-```
-
-If the wallet endpoint responds, the bot is running. Tell the user clearly that startup succeeded, that the API is ready at `http://localhost:3000`, and that the PID was saved to `~/slv/solana-trade-bot/.slv/trade-app.pid` so it can be stopped later. **On first start, the bot auto-generates `wallet.json`. On every subsequent start, it loads the existing `wallet.json` — never let any command overwrite or delete it.**
-
-If the readiness check does not pass, inspect `trade-app.log` and report the startup failure instead of waiting forever.
-
-### Step 6.5: Resolve the public URL (every start)
-
-`curl localhost:3000/*` is how you *probe* the API from the same host — the
-bot is running on this box so localhost always works. But `localhost` is
-**not** what you should show the user. If you send `http://localhost:3000/docs`
-in chat or to Discord, the user cannot click it from their phone or another
-machine.
-
-Capture the node's public IPv4 once and reuse it everywhere you display a
-URL:
-
-```bash
-PUBLIC_IP=$(curl -4 -fsS --max-time 5 ifconfig.me 2>/dev/null || echo "")
-if [ -z "$PUBLIC_IP" ]; then
-  # Fallback: primary interface on this box. Works for LAN-only dev machines.
-  if command -v ipconfig >/dev/null 2>&1; then
-    PUBLIC_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "")
-  fi
-fi
-[ -z "$PUBLIC_IP" ] && PUBLIC_IP="localhost"
-PUBLIC_URL="http://$PUBLIC_IP:3000"
-echo "PUBLIC_URL=$PUBLIC_URL"
-```
-
-Rules for URL display:
-- **All probes / curls run by you** → use `http://localhost:3000/...` (fast, always works from the same host).
-- **All URLs you show to the user in chat** → use `$PUBLIC_URL/...` so they are clickable from anywhere.
-- **All URLs you send to Discord** → use `$PUBLIC_URL/...`.
-- If `PUBLIC_IP` fell back to `localhost`, mention to the user that the bot is LAN-only and the docs URL only works from this machine.
-
-Also remind the user once that **port 3000 must be reachable** (open in the VPS firewall / security group) for the links to work from outside. If you detect `PUBLIC_IP` is a public address and the user is on a VPS, suggest they verify with ``curl -fsS $PUBLIC_URL/api/wallet`` from their local machine.
-
-### Step 6.6: First-start Discord notification (fresh installs only)
-
-If this was a **fresh install** (in the Preflight you observed `NO_DIR` or `DIR_EXISTS + NO_WALLET` — i.e. the bot just generated its `wallet.json` for the first time in this session) AND a Discord webhook is configured (`notifications.discord_webhook` in `~/.slv/api.yml`, as set up by `slv onboard`), send a one-time welcome notification so the user can reach the bot from their phone or another machine.
-
-Use the `send_notification` tool with a payload like:
-
-```
-🚀 Solana Trade Bot — Deployed & Running
-
-Wallet:   <pubkey from /api/wallet>
-Balance:  <SOL from /api/wallet>
-gRPC:     <GRPC_ENDPOINT from .env>
-API:      $PUBLIC_URL
-API Docs: $PUBLIC_URL/docs
-
-Next steps:
-1. Send SOL to the wallet (minimum 0.013 SOL)
-2. Start trading:  curl -X POST $PUBLIC_URL/api/trade/start
-3. Check status:   curl -s $PUBLIC_URL/api/trade/status
-4. Tune config:    GET / PUT $PUBLIC_URL/api/config
-```
-
-Then mark the notification as sent so you do not spam the user on restarts:
-
-```bash
-touch ~/slv/solana-trade-bot/.discord-init-notified
-```
-
-**Idempotency**: before sending, check `[ -f ~/slv/solana-trade-bot/.discord-init-notified ] && echo SKIP_NOTIFY`. If the marker exists, **do not send the notification again** — the user has already received it. This file must also survive re-inits because it lives inside the app directory, which means you should treat it the same way as `wallet.json` in the Preflight: if you ever re-init and the marker existed, preserve it via the same backup rule.
-
-If no Discord webhook is configured, skip this step entirely — do not ask the user for a webhook URL in chat. Mention briefly that they can set one up with `slv onboard` to get the docs URL pushed to their phone next time.
-
-### Step 7: Explore the API and guide the user
-
-Once the bot is running, **you should operate it on behalf of the user** via the REST API. Remember the rule from Step 6.5: probe via `localhost`, display via `$PUBLIC_URL`.
-
-1. **Show wallet info** — probe: `curl -s http://localhost:3000/api/wallet`
-   - Tell the user the wallet pubkey and ask them to fund it with SOL
-   - Minimum: 0.013 SOL (buy amount + ATA rent + fee reserve)
-
-2. **Show API docs link** — tell the user they can explore all endpoints at:
-   `$PUBLIC_URL/docs`  (substitute the actual resolved URL from Step 6.5)
-
-3. **Read the OpenAPI spec** to understand available endpoints:
-   ```bash
-   curl -s http://localhost:3000/docs | head -100
-   ```
-
-4. **Show current config** — probe: `curl -s http://localhost:3000/api/config`
-   - Explain the current settings (buy amount, sell multiplier, etc.)
-   - Ask if they want to adjust anything
-
-5. **Wait for funding** — ask user to confirm they've sent SOL to the wallet
-
-### Step 8: Start trading
-
-Once the wallet is funded, probe locally:
-```bash
-curl -X POST http://localhost:3000/api/trade/start
-```
-
-Then check status:
-```bash
-curl -s http://localhost:3000/api/trade/status
-```
-
-When you **show** these commands to the user in chat, substitute `$PUBLIC_URL` so they can run them from their own machine:
-
-```
-curl -X POST $PUBLIC_URL/api/trade/start
-curl -s $PUBLIC_URL/api/trade/status
-```
-
-Explain what's happening:
-- The bot is now watching for new PumpSwap pools via gRPC
-- When a matching pool is detected, it will auto-buy
-- Profit target / timeout / liquidity collapse triggers auto-sell
-- If Discord webhook is configured, notifications are sent
-
-### Step 9: Monitor and improve
-
-Keep interacting with the bot API to help the user (probe via localhost, display via `$PUBLIC_URL`):
-- `curl -s http://localhost:3000/api/trade/status` — check running state
-- `curl -s http://localhost:3000/api/logs` — view trade logs
-- `curl -s http://localhost:3000/api/trades/profit` — P&L summary
-- `curl -X PUT http://localhost:3000/api/config -H 'Content-Type: application/json' -d '{...}'` — adjust config
-
-When you hand these snippets to the user in chat, rewrite `http://localhost:3000` → `$PUBLIC_URL` so they are clickable/runnable from anywhere.
-
-**Ask the user what they'd like to improve** — e.g. buy amount, profit target, timeout, etc.
-
-### Step 10: Deploy to VPS
-Once local testing is successful:
-```bash
-slv bot deploy
-```
-This builds, uploads via SCP, creates a systemd service, and starts the bot on the remote server.
-
-### Stopping the bot locally
-Prefer the saved PID file:
-```bash
-cd ~/slv/solana-trade-bot
-kill "$(cat .slv/trade-app.pid)" && rm -f .slv/trade-app.pid
-```
-
-If the PID file is missing or stale, fall back to a process search:
-```bash
-pkill -f trade-app
-```
-
-## ERPC Cloud MCP — Guiding the User
-
-MCP Server URL: `https://mcp-slv-cloud.erpc.global/mcp` (auto-configured in `slv c`)
+MCP Server URL: `https://mcp-slv-cloud.erpc.global/mcp` (auto-configured
+in `slv c`).
 
 ### Endpoint acquisition flow
-1. **Check existing** — call `get_grpc_status` first to see if user already has available slots
-2. **If no plan** — call `get_v3_grpc_list` for product plans + payment links → user purchases
-3. **Get IPv4** — run `curl -4 -s ifconfig.me` (always use `-4` flag to force IPv4)
-4. **Register IP** — call `post_v3_grpc_register_ip_grpc` with `{ip: "x.x.x.x"}` (IPv4 required)
+1. **Check existing** — call `get_grpc_status` first to see if user
+   already has available slots
+2. **If no plan** — call `get_v3_grpc_list` for product plans + payment
+   links → user purchases
+3. **Get IPv4** — run `curl -4 -s ifconfig.me` (always use `-4` flag to
+   force IPv4)
+4. **Register IP** — call `post_v3_grpc_register_ip_grpc` with
+   `{ip: "x.x.x.x"}` (IPv4 required)
 5. **Verify** — call `get_grpc_status` to see endpoint URL and token
-6. **Remove IP** — call `post_v3_grpc_remove_ip_grpc` with `{ip: "x.x.x.x"}` when changing servers
+6. **Remove IP** — call `post_v3_grpc_remove_ip_grpc` with
+   `{ip: "x.x.x.x"}` when changing servers
 
-For dedicated upgrades and storage products, refer to SKILL.md for the full MCP endpoint reference.
+For dedicated upgrades and storage products, refer to SKILL.md for the
+full MCP endpoint reference.
 
 ### When to suggest storage
-- trade-app stores trade history and position data
+- Bots that keep trade history and position data need persistent storage
 - Without backup storage, **data is lost on restart or crash**
 - Proactively call `/v3/storage/product-list` to show backup options
 
 ## Behavior
-1. **ALWAYS run the App Inventory scan first when the request is ambiguous about *which* app.** Users can have 0, 1, or many bots in `~/slv/`. Never assume `solana-trade-bot` — you will act on the wrong bot and kill a live trader. When you find 2+ apps and the user did not name one, **stop and ask which one**.
-1a. **ALWAYS run the Preflight (CRITICAL section) before any action that could touch `~/slv/<app_name>/`.** No exceptions. Not even when the user sounds impatient.
-2. **NEVER run `slv bot init -y` when `wallet.json` exists.** `-y` does `rm -rf` on the directory and destroys the wallet. If in doubt, don't pass `-y`.
-3. **NEVER delete `wallet.json` or `wallet.json.bak*`.** These files ARE the user's money. Treat deletion of either as equivalent to deleting funds.
-4. Before any operation that *could* touch `wallet.json`, snapshot it first: ``cp wallet.json wallet.json.bak.$(date +%s)``.
-5. Before launching the bot binary, verify it is not already running (`pgrep -f trade-app`) and port 3000 is not already answering. If the bot is up, use the REST API — never re-launch.
-6. If the app directory already exists with a wallet and binary, **skip `slv bot init` entirely**. There is nothing to download; running init would only risk the wallet.
-6a. **Display URLs use `$PUBLIC_URL`, probe URLs use `localhost`.** Every URL you put in chat text, a user-facing example, or a Discord notification MUST be the node's public IP (resolved per Step 6.5). Localhost is reserved for your own `curl` probes running on the same host. The user cannot click `http://localhost:3000/*` from their phone.
-6b. **Send the first-start Discord welcome exactly once.** When a fresh `wallet.json` is generated AND `notifications.discord_webhook` is configured, call `send_notification` with the payload from Step 6.6 and create `.discord-init-notified` in the app directory. Do not notify again on restarts.
-7. Guide users **one step at a time** — confirm success before moving on
-8. When a build fails, diagnose the error (check SKILL.md for known issues)
-9. Explain what each env var does in simple terms when asked
-10. **After the bot starts, proactively use its REST API** to show wallet, config, and status — don't just tell the user to do it themselves
-11. **Read the OpenAPI docs** at `/docs` to understand all available endpoints and operate on the user's behalf
-12. After local testing works, proactively suggest `slv bot deploy` for VPS deployment
-13. If the user lacks a gRPC/Shredstream endpoint, proactively use ERPC Cloud MCP to show products and purchase links
-14. For non-engineer users, prefer installing and configuring Redis automatically when the app benefits from persistent local trade history. Only ask the user about Redis if automation fails or a host-specific choice is required.
-15. Remind users that persistent data requires backup storage, suggest storage products when relevant
-16. `wallet.json` contains a private key, always warn users to keep it safe and never commit it
-17. Never include secrets, private endpoints, or real credentials in examples
-18. **Ask the user what they'd like to improve** after showing initial status, config tuning, more positions, different profit targets, etc.
 
-## Intent Shortcuts — what to do when the user says
+1. **ALWAYS run the App Inventory scan first when the request is
+   ambiguous about *which* app.** Users can have 0, 1, or many bots in
+   `~/slv/`. Never assume a default template name — you will act on the
+   wrong bot and kill a live trader. When you find 2+ apps and the user
+   did not name one, **stop and ask which one**.
+1a. **ALWAYS run the Preflight (CRITICAL section) before any action that
+   could touch `~/slv/<app_name>/`.** No exceptions. Not even when the
+   user sounds impatient.
+2. **NEVER run `slv bot init -y` when `wallet.json` exists.** `-y` does
+   `rm -rf` on the directory and destroys the wallet. If in doubt, don't
+   pass `-y`.
+3. **NEVER delete `wallet.json` or `wallet.json.bak*`.** These files ARE
+   the user's money. Treat deletion of either as equivalent to deleting
+   funds.
+4. Before any operation that *could* touch `wallet.json`, snapshot it
+   first: `cp wallet.json wallet.json.bak.$(date +%s)`.
+5. Before launching any bot binary, verify it is not already running
+   (`pgrep -f "target/release/$BINARY"`) and the template's port is not
+   already answering. If the bot is up, use its API / CLI — never
+   re-launch.
+6. If the app directory already exists with a wallet and binary, **skip
+   `slv bot init` entirely**. There is nothing to download; running init
+   would only risk the wallet.
+7. Guide users **one step at a time** — confirm success before moving on.
+8. When a build fails, diagnose the error (check the companion skill for
+   known issues).
+9. Explain what each env var does in simple terms when asked.
+10. If the user lacks a gRPC / Shredstream endpoint, proactively use
+    ERPC Cloud MCP to show products and purchase links.
+11. Remind users that persistent data requires backup storage; suggest
+    storage products when relevant.
+12. `wallet.json` contains a private key; always warn users to keep it
+    safe and never commit it.
+13. Never include secrets, private endpoints, or real credentials in
+    examples.
 
-These phrases are common. They look like "start" requests, but for an existing project they almost always mean "resume", not "reinstall". **Always run the App Inventory scan first** so you know whether the user has 0, 1, or many apps, then branch using the Preflight on the chosen app. Never blindly re-init.
+Template-specific behaviors (REST-API probing, PUBLIC_URL display,
+first-start Discord welcome, tuning suggestions, etc.) live in the
+companion skill.
+
+## Intent Shortcuts — generic
+
+These phrases are common. They look like "start" requests, but for an
+existing project they almost always mean "resume", not "reinstall".
+**Always run the App Inventory scan first** so you know whether the user
+has 0, 1, or many apps, then branch using the Preflight on the chosen
+app. Never blindly re-init. The template's companion skill adds its own
+shortcut rows on top of these.
 
 | User says | Interpretation | Action |
 |---|---|---|
-| "どうなってる？" / "status" / "show me my bots" | List state of every app | Run Inventory scan → present the table → for each running app, also curl ``/api/wallet`` and ``/api/trade/status`` to enrich the report |
-| "run trade app" / "start trade app" / "start trading" / "go" | Resume existing project if one exists | Inventory → if 0 apps: fresh install. If 1 app: Preflight + start. If 2+: ask which. **Never Step 1 when an app already exists.** |
-| "restart the bot" (+ optional name) | Explicit restart of one app | Inventory → pick target → Preflight → back up wallet.json → ``pkill -f "$APP_DIR/target/release"`` → wait → Step 6 |
-| "stop the bot" / "止めて" (+ optional name) | Stop one running app | Inventory → pick target → confirm in chat with wallet + current P&L → ``pkill -f "$APP_DIR/target/release"`` |
-| "stop all bots" / "kill all" | Stop every running app | Inventory → show list + running state → explicit user confirmation → loop ``pkill`` per running app |
-| "change the buy amount / profit target / config" | Modify running app | Inventory → pick target → ``GET /api/config`` → show current → ``PUT /api/config`` with diff → confirm with ``GET /api/trade/status`` |
-| "reinstall / start over / reset / 作り直して" (+ optional name) | Full reinstall (destructive) | Inventory → pick target → warn explicitly about wallet.json → require user to confirm in words ("yes, reset") → back up wallet.json and .env → Step 1 with ``-y`` |
-| "create a new trade bot" (when an old one exists) | New second app | Propose a unique name (e.g. ``solana-trade-bot-2``) → confirm → Step 1 with the new name (no ``-y`` needed, directory doesn't exist yet). Warn that only one bot can run on port 3000 at a time. |
-| "delete / remove this bot" (+ name) | Destructive cleanup | Refuse if ``pgrep`` shows it running — stop first. Then: explicit confirmation, back up wallet.json and .env to ``~/.slv/wallet-backups/<name>-<ts>/``, then ``rm -rf ~/slv/<name>``. Never delete without the backup. |
-| "update / rebuild" (+ optional name) | Rebuild binary, keep wallet | Inventory → pick target → back up wallet.json → Step 5 (build) → Step 6 (restart if it was running) |
+| "どうなってる？" / "status" / "show me my bots" | List state of every app | Run Inventory scan → present the table → for each running app, also curl the template's status endpoint to enrich the report |
+| "restart the bot" (+ optional name) | Explicit restart of one app | Inventory → pick target → Preflight → back up wallet.json → `pkill -f "$APP_DIR/target/release"` → wait → companion-skill Start step |
+| "stop the bot" / "止めて" (+ optional name) | Stop one running app | Inventory → pick target → confirm in chat with wallet + current state → `pkill -f "$APP_DIR/target/release"` |
+| "stop all bots" / "kill all" | Stop every running app | Inventory → show list + running state → explicit user confirmation → loop `pkill` per running app |
+| "reinstall / start over / reset / 作り直して" (+ optional name) | Full reinstall (destructive) | Inventory → pick target → warn explicitly about wallet.json → require user to confirm in words ("yes, reset") → back up wallet.json and .env → companion-skill Step 1 with `-y` |
+| "delete / remove this bot" (+ name) | Destructive cleanup | Refuse if `pgrep` shows it running — stop first. Then: explicit confirmation, back up wallet.json and .env to `~/.slv/wallet-backups/<name>-<ts>/`, then `rm -rf ~/slv/<name>`. Never delete without the backup. |
+| "update / rebuild" (+ optional name) | Rebuild binary, keep wallet | Inventory → pick target → back up wallet.json → companion-skill Build step → restart if it was running |
 
-When in doubt, stop and ask the user. **Losing funds — or killing a profitable live trader — is much worse than asking one extra question.**
+When in doubt, stop and ask the user. **Losing funds — or killing a
+profitable live trader — is much worse than asking one extra question.**
 
 ## Per-App Action Playbook
 
-When the user has singled out a target app (``$APP`` is just the folder name, ``$APP_DIR=~/slv/$APP``), use these recipes. They all assume you've already run the inventory scan and narrowed down the target.
+When the user has singled out a target app (`$APP` is the folder name,
+`$APP_DIR=~/slv/$APP`, `$BINARY` is the template's binary name, `$PORT`
+is the template's port), use these recipes. They all assume you've
+already run the inventory scan and narrowed down the target.
 
 ### Show status
 ```bash
-APP=solana-trade-bot; APP_DIR=~/slv/$APP
 pgrep -af "$APP_DIR/target/release" && echo RUNNING || echo STOPPED
-curl -s http://localhost:3000/api/wallet
-curl -s http://localhost:3000/api/trade/status
-curl -s http://localhost:3000/api/trades/profit
+# If the template has a REST API, probe it for richer status.
+# Otherwise use the template-native status command from its companion skill.
 ```
-**Caveat**: if 2+ apps are running on different ports, the ``curl localhost:3000`` probes only work for whichever app grabbed 3000 first. For apps on other ports, check the app's ``.env`` for ``PORT=`` and use that port instead.
+**Caveat**: if 2+ apps are running on different ports, `curl
+localhost:$PORT` probes only work for whichever app grabbed the default
+port first. For apps on other ports, read `PORT=` from the app's `.env`.
 
 ### Stop a specific app (safe)
 ```bash
@@ -462,31 +286,40 @@ sleep 1 && pgrep -af "$APP_DIR/target/release" && echo STILL_UP || echo STOPPED
 ```
 Always tell the user **before** stopping:
 - The wallet pubkey of the bot you're about to stop.
-- Whether it currently has open positions (``/api/trade/status``).
-- The net P&L (``/api/trades/profit``).
-Then wait for explicit confirmation. "Stopping a bot with open positions" is a destructive action in the same sense as "deleting wallet.json" — the user should know what they're losing.
+- Whether it currently has open positions (template-specific; check via
+  the companion skill's API).
+- The net P&L / current balance where applicable.
+
+Then wait for explicit confirmation. Stopping a bot with open positions
+is a destructive action in the same sense as deleting `wallet.json` — the
+user should know what they're losing.
 
 ### Restart (keep wallet, new build not required)
 ```bash
 pkill -f "$APP_DIR/target/release"
 sleep 1
-cd "$APP_DIR" && RUST_LOG=info nohup ./target/release/trade-app > trade-app.log 2>&1 &
-sleep 2 && curl -s http://localhost:3000/api/wallet | head -20
+# Then re-launch using the template's launch command from its companion skill.
+# Always take the wallet.json snapshot first — pkill alone does not touch
+# the file, but the snapshot protects against user typos ("restart" vs
+# "reinstall").
 ```
-Always take the wallet.json snapshot before this sequence even though pkill alone does not touch the file — the snapshot is cheap insurance and protects against user typos (e.g. they ask to restart but mean reinstall).
 
-### Modify config live (no restart)
+### Modify config live (no restart) — template-dependent
+If the template exposes a live config endpoint (e.g. `trade-app` →
+`GET/PUT /api/config`), use it in preference to a restart:
 ```bash
 # Always GET first so you can show the diff.
-curl -s http://localhost:3000/api/config
+curl -s http://localhost:$PORT/api/config
 # Then PUT only the fields the user changed.
-curl -s -X PUT http://localhost:3000/api/config \
+curl -s -X PUT http://localhost:$PORT/api/config \
   -H 'Content-Type: application/json' \
-  -d '{"buy_amount_sol": 0.02}'
+  -d '{"field": "new value"}'
 # Confirm the change landed.
-curl -s http://localhost:3000/api/config
+curl -s http://localhost:$PORT/api/config
 ```
-trade-app supports live config updates without restart. Use this path whenever possible — it's much less risky than restarting a bot that's holding positions.
+Live config updates without restart are much less risky than restarting a
+bot that's holding positions. Check the template's companion skill for
+the exact endpoint and field names.
 
 ### Delete an app (destructive)
 ```bash
@@ -504,15 +337,6 @@ ls -la "$BACKUP_DIR/"
 # 3. Only after the user confirms the backup listing, remove the app.
 rm -rf "$APP_DIR"
 ```
-Always tell the user the exact backup path so they can verify the rescue, and remind them that the backup directory holds their private key — it should be protected or exported to their password manager.
-
-### Handling the "two bots, one port" problem
-The default template binds to ``3000``. Only one app can use that port at a time. When the user tries to run a second app:
-
-1. Check ``lsof -i :3000`` or ``curl -sf http://localhost:3000/api/wallet`` to see who owns it.
-2. If app A is currently on 3000 and the user wants to start app B:
-   - Option 1 (recommended): change app B's ``.env`` to ``PORT=3001`` (or any free port) and launch.
-   - Option 2: stop app A first (with the safety checks above), then launch app B on 3000.
-3. Never let two launches race — you will get a silent port-bind failure and the user will think the bot is running when it isn't.
-
-Probe URLs for the second app become ``http://localhost:$PORT/...``. Display URLs in chat and Discord use ``$PUBLIC_URL:$PORT``.
+Always tell the user the exact backup path so they can verify the rescue,
+and remind them that the backup directory holds their private key — it
+should be protected or exported to their password manager.

--- a/dist/oss-skills/slv-app/SKILL.md
+++ b/dist/oss-skills/slv-app/SKILL.md
@@ -1,181 +1,65 @@
 # SLV App Skill
 
-Templates and tools for creating Solana bot and app projects.
+Router and safety reference for Solana bot and app projects created with
+`slv bot init`. This skill is template-agnostic — it covers the generic
+operations that apply to every template. Template-specific guides
+(trade-app, geyser-ts, shreds-rust, …) live in dedicated `slv-bot-*`
+skills loaded alongside this one.
 
 ## Available Template Types
-| Type | Description |
-|---|---|
-| Geyser Stream Client | Real-time Solana data streaming via gRPC Geyser |
-| Shreds Stream Client | Low-level shred stream templates |
-| `trade-app` | Rust PumpSwap auto-trading bot with buy/sell/close lifecycle |
 
-## trade-app Overview
+| `-t <type>` | Skill | Description |
+|---|---|---|
+| `trade-app` | `slv-bot-trade-app` | Rust PumpSwap auto-trading bot with buy/sell/close lifecycle |
+| `geyser-ts` | (future) | Real-time Solana data streaming via gRPC Geyser (TypeScript) |
+| `geyser-rust` | (future) | Real-time Solana data streaming via gRPC Geyser (Rust) |
+| `shreds-ts` | (future) | Low-level shred stream template (TypeScript) |
+| `shreds-rust` | (future) | Low-level shred stream template (Rust) |
+| `shreds-udp-rust` | (future) | UDP-based shred stream template (Rust) |
 
-The `trade-app` template is a Rust application for PumpSwap (Pump.fun AMM) trading automation.
+When the user picks a template, consult the matching sub-skill for its
+step-by-step guide, env var reference, and template-specific REST API or
+daemon behavior. This document provides the common layer those sub-skills
+build on top of.
 
-### Lifecycle
-`pool detected -> buy -> tx confirm -> sell monitor -> sell -> burn if needed -> ATA close -> notify`
+## `slv bot` CLI Commands
 
-### Main features
-- Real-time pool detection via Geyser gRPC
-- Automatic buy on matching new pool
-- Profit target selling with retry support
-- Timeout-based forced retreat
-- Liquidity collapse retreat
-- Dust burn and ATA close for rent recovery
-- Discord webhook notifications
-- Redis-backed trade history
-- REST API with OpenAPI docs at `/docs`
-
-## Quick Start (step-by-step)
-
-### 1. Create the project
-```bash
-slv bot init -t trade-app -n solana-trade-bot -y
-```
-Options: `-t` template type, `-n` app name, `-y` overwrite without asking.
-
-### 2. Configure environment
-```bash
-cd ~/slv/solana-trade-bot
-cp .env.sample .env
-# Edit .env — set at minimum: GRPC_ENDPOINT (leave optional fields blank unless needed)
-```
-
-### 3. Build
-macOS:
-```bash
-brew install llvm   # if not already installed
-DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib cargo build -r
-```
-Linux:
-```bash
-cargo build -r
-```
-
-### 4. Run (background, with PID file and bounded readiness check)
-```bash
-cd ~/slv/solana-trade-bot
-mkdir -p .slv
-RUST_LOG=info nohup ./target/release/trade-app > trade-app.log 2>&1 & echo $! > .slv/trade-app.pid
-for i in 1 2 3 4 5; do
-  curl -fsS http://localhost:3000/api/wallet && break
-  sleep 1
-done
-```
-- Save the PID to `.slv/trade-app.pid` so the process can be stopped cleanly later
-- If readiness fails, inspect `trade-app.log` instead of waiting forever
-- `wallet.json` is auto-generated on first start
-- API docs: `http://localhost:3000/docs`
-- **NEVER run with `run_command` directly** or in a way that waits on the backgrounded process forever
-
-### 5. Fund wallet and start trading
-```bash
-# Check wallet pubkey
-curl -s http://localhost:3000/api/wallet
-# Send SOL to the wallet pubkey (min 0.013 SOL)
-# Then start trading:
-curl -X POST http://localhost:3000/api/trade/start
-# Check status:
-curl -s http://localhost:3000/api/trade/status
-```
-
-### Stop the bot
-Preferred:
-```bash
-cd ~/slv/solana-trade-bot
-kill "$(cat .slv/trade-app.pid)" && rm -f .slv/trade-app.pid
-```
-Fallback:
-```bash
-pkill -f trade-app
-```
-
-### 6. Deploy to VPS
-```bash
-slv bot deploy
-```
-Builds, uploads via SCP, creates systemd service on the remote server.
-
-## Environment Variables (`.env`)
-
-### Required
-| Variable | Description |
-|----------|-------------|
-| `GRPC_ENDPOINT` | Geyser gRPC endpoint |
-
-### Optional
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `X_TOKEN` | — | Optional gRPC auth token, only needed when the endpoint requires it |
-| `SOLANA_RPC_ENDPOINT` | `https://edge.erpc.global?api-key=<API_KEY>` | RPC for reads. Reuse the API key from `~/.slv/api.yml` automatically when available |
-| `SOLANA_SEND_RPC_ENDPOINT` | same as read RPC | RPC for sending TXs. Reuse the same ERPC endpoint automatically when available |
-| `API_PORT` | `3000` | HTTP API port |
-| `API_TOKEN` | — | Bearer token for API auth |
-| `WEBHOOK_URL` | — | Discord Webhook URL. If `notifications.discord_webhook` exists in `~/.slv/api.yml`, reuse it automatically |
-| `REDIS_URL` | — | Redis URL for trade history. For non-engineer users, prefer installing Redis locally and configuring this automatically instead of asking up front |
-
-When setting up `.env`, prefer automatic configuration over user questions whenever possible. Reuse existing local configuration automatically when available, especially the SLV API key from `~/.slv/api.yml` for `https://edge.erpc.global?api-key=<API_KEY>` RPC defaults, and `notifications.discord_webhook` from `~/.slv/api.yml` for `WEBHOOK_URL`. For non-engineer users, prefer installing and wiring Redis automatically when local persistence is useful.
-| `CONFIG_PATH` | `config.jsonc` | Geyser filter config file |
-
-## Trade Configuration (via API)
-
-`GET /api/config` to read, `PUT /api/config` to update.
-
-| Field | Default | Description |
-|-------|---------|-------------|
-| `buy_amount_lamports` | `100000` (0.0001 SOL) | Amount to spend per buy |
-| `sell_multiplier` | `1.1` | Take profit at buy_price x this |
-| `slippage_bps` | `500` (5%) | Slippage tolerance |
-| `max_positions` | `1` | Max concurrent positions |
-| `min_pool_sol_lamports` | `100000` (0.0001 SOL) | Min pool liquidity to trigger buy |
-| `sell_timeout_secs` | `300` (5 min) | Force exit after timeout |
-| `exit_pool_sol_lamports` | `1000000` (0.001 SOL) | Retreat if pool WSOL drops below |
-
-## REST API
-
-Base URL: `http://localhost:3000` | OpenAPI docs: `http://localhost:3000/docs`
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/config` | Get current trade config |
-| `PUT` | `/api/config` | Partial update trade config |
-| `POST` | `/api/trade/start` | Start trading |
-| `POST` | `/api/trade/stop` | Stop trading |
-| `GET` | `/api/trade/status` | Running state, positions, balance |
-| `GET` | `/api/wallet` | Wallet pubkey and SOL balance |
-| `GET` | `/api/logs` | Trade logs |
-| `GET` | `/api/trades/history` | Trade history from Redis |
-| `GET` | `/api/trades/{id}` | Single trade by ID |
-| `GET` | `/api/trades/profit` | Buy-Sell pair P&L summary |
-| `POST` | `/api/grpc/start` | Start gRPC stream |
-| `POST` | `/api/grpc/stop` | Stop gRPC stream |
-
-## CLI Command -> Action Mapping
 | CLI | Action |
 |---|---|
-| `slv bot init` | Scaffold a bot/app project from template |
-| `slv bot deploy` | Build and deploy bot to VPS via SSH + systemd |
-| `slv bot` / `slv b` | Bot management menu |
+| `slv bot init -t <template> -n <name>` | Scaffold a bot/app project in `~/slv/<name>/` from the named template |
+| `slv bot deploy` | Build and deploy the current project to a VPS via SSH + systemd |
+| `slv bot list` / `slv b` | List / switch between deployed bots |
+| `slv bot log`, `slv bot restart`, `slv bot start`, `slv bot status`, `slv bot stop` | Operate a deployed bot on its remote VPS |
 
-## Common Build Issues
+### `slv bot init` safety notes
 
-### macOS: `libclang.dylib` not found
-```
-error: failed to run custom build command for `librocksdb-sys`
-dyld: Library not loaded: @rpath/libclang.dylib
-```
-**Fix:**
-```bash
-brew install llvm
-DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib cargo build -r
-```
+- `-y` forces `rm -rf` on the target directory before extracting the
+  template. **Never pass `-y` when `wallet.json` exists** in the target —
+  the private key will be destroyed. The CLI has a built-in
+  `~/.slv/wallet-rescue/` layer that persists `wallet.json`, `.env`, and
+  `*.bak.*` snapshots outside the bot dir before the atomic swap, but the
+  safest path is to never trigger the rescue in the first place.
+- Templates are fetched from
+  `https://github.com/ValidatorsDAO/solana-stream`. No network at init time
+  → template source must already be cached locally.
+
+## Wallet safety at a glance
+
+`wallet.json` in any `~/slv/<app>/` directory is a Solana secret key. Treat
+it like a seed phrase. The full preflight rules live in `AGENT.md` — the
+short version:
+
+1. Never delete `wallet.json` or `wallet.json.bak.*`.
+2. Never run `slv bot init -y` when `wallet.json` exists.
+3. Always snapshot `wallet.json` before any action that could touch the
+   app directory.
 
 ## ERPC Cloud MCP — Endpoint & Storage Provisioning
 
 MCP Server URL: `https://mcp-slv-cloud.erpc.global/mcp`
 
-When users don't have a gRPC or Shredstream endpoint, use this MCP to look up products and provide purchase links.
+When users don't have a gRPC or Shredstream endpoint, use this MCP to look
+up products and provide purchase links.
 
 ### Shared (recommended to start)
 | Method | Path | Purpose |
@@ -196,17 +80,24 @@ When users don't have a gRPC or Shredstream endpoint, use this MCP to look up pr
 ### Storage
 | Method | Path | Purpose |
 |--------|------|---------|
-| `GET` | `/v3/storage/product-list` | Storage/backup products |
+| `GET` | `/v3/storage/product-list` | Storage/backup products (trade history, position data) |
 
 ### Flow
-1. `/v3/grpc/list` → show products + payment links → user purchases → `/v3/grpc/register-ip-grpc` → get endpoint → set in `.env`
-2. For higher performance: `/v3/dedicated/list` → purchase → `/v3/geyser-grpc/status` for endpoint
+1. `/v3/grpc/list` → show products + payment links → user purchases →
+   `/v3/grpc/register-ip-grpc` → get endpoint → set in `.env`
+2. For higher performance: `/v3/dedicated/list` → purchase →
+   `/v3/geyser-grpc/status` for endpoint
 
 ### Important: Backup storage
-Trade history and position data need persistent storage. Without backup, data is lost on restart or crash. Use `/v3/storage/product-list` to show backup options proactively.
+Trade history and position data need persistent storage. Without backup,
+data is lost on restart or crash. Use `/v3/storage/product-list` to show
+backup options proactively.
 
 ## Operator Notes
-- `wallet.json` contains a private key — never commit it
-- Keep examples OSS-safe: placeholders only, never real tokens or private endpoints
-- After local testing succeeds, recommend `slv bot deploy` to deploy to a VPS
-- If user lacks gRPC/Shredstream endpoints, use ERPC Cloud MCP to show products and purchase links
+- `wallet.json` contains a private key — never commit it.
+- Keep examples OSS-safe: placeholders only, never real tokens or private
+  endpoints.
+- After local testing succeeds, recommend `slv bot deploy` to deploy to a
+  VPS.
+- If the user lacks gRPC/Shredstream endpoints, use ERPC Cloud MCP to show
+  products and purchase links.

--- a/dist/oss-skills/slv-app/skill.json
+++ b/dist/oss-skills/slv-app/skill.json
@@ -1,8 +1,8 @@
 {
   "name": "slv-app",
   "displayName": "SLV App",
-  "version": "0.9.962",
-  "description": "Create and manage Solana trade bot applications with AI-powered interactive guidance. Scaffold app templates and deploy to servers.",
+  "version": "0.10.0",
+  "description": "Router and safety layer for Solana bot/app projects. Covers App Inventory, Wallet Preflight, ERPC MCP endpoint acquisition, and generic per-app operations. Template-specific guides live in slv-bot-<template> companion skills.",
   "author": "ValidatorsDAO",
   "license": "Apache-2.0",
   "homepage": "https://github.com/ValidatorsDAO/slv",

--- a/dist/oss-skills/slv-bot-trade-app/AGENT.md
+++ b/dist/oss-skills/slv-bot-trade-app/AGENT.md
@@ -1,0 +1,413 @@
+# trade-app Playbook (Setzer sub-skill)
+
+This document extends the Setzer sub-agent prompt with knowledge specific to
+the `trade-app` template. The generic rules you must follow (App Inventory,
+Wallet Preflight Rule 0–3, ERPC MCP endpoint acquisition flow, generic
+per-app playbook) live in the `slv-app` skill that is already included in
+this prompt. Do not duplicate them here — read `slv-app/AGENT.md` first, then
+apply the `trade-app`-specific procedures below.
+
+## trade-app constants
+
+- **Binary path**: `$APP_DIR/target/release/trade-app`
+- **Default port**: `3000`
+- **PID file**: `$APP_DIR/.slv/trade-app.pid`
+- **Log file**: `$APP_DIR/trade-app.log`
+- **Generated on first start**: `wallet.json`
+- **Discord "welcome sent" marker**: `$APP_DIR/.discord-init-notified`
+
+Whenever the generic `slv-app` playbook says "`<binary>`" or "`$BINARY`",
+substitute `trade-app`. Whenever it says "`<port>`" or "`$PORT`", default to
+`3000` (or read `PORT=` from the app's `.env` if the user has overridden it).
+
+## Step-by-Step Guide
+
+When a user selects `trade-app`, walk them through these steps **one at a
+time**. Do not skip ahead. Confirm each step succeeds before moving on.
+
+**Before doing anything, run the Wallet Preflight from `slv-app/AGENT.md`
+and branch on the decision table.** Only execute Step 1 when the preflight
+result is `NO_DIR`.
+
+### Step 1 (fresh): Create the project — ONLY when the target directory does not exist
+
+**Preflight gate — run this check first:**
+```bash
+APP_NAME=solana-trade-bot   # or whatever the user chose
+test -e ~/slv/$APP_NAME && echo "EXISTS — STOP, do not run slv bot init" || echo "SAFE TO CREATE"
+```
+
+If the directory exists, STOP. Re-run the full Preflight from
+`slv-app/AGENT.md` and branch accordingly. Never proceed past this gate
+with `-y` when a directory is present.
+
+Only when the directory does NOT exist:
+```bash
+slv bot init -t trade-app -n solana-trade-bot
+```
+**Note: do NOT pass `-y`.** `-y` forces `rm -rf` on the app directory,
+which will wipe `wallet.json` and lose funds if the user already funded it.
+Since we've just verified the directory doesn't exist, there is nothing to
+overwrite and `-y` is unnecessary.
+
+If for some reason you do need to re-init (e.g. the user explicitly asked
+to start over and there is no wallet to protect), first back up every
+`wallet.json` and `.env` under that path (see Rule 0 in `slv-app/AGENT.md`).
+Then and only then ask the user for explicit confirmation before re-running
+with `-y`.
+
+### Step 2: Get gRPC endpoint (if needed)
+
+Follow the ERPC Cloud MCP endpoint acquisition flow in `slv-app/AGENT.md`.
+At the end you should have:
+
+- A registered IPv4 with `get_grpc_status` showing the endpoint URL and token
+- The endpoint URL ready to paste into `GRPC_ENDPOINT` in `.env`
+- `X_TOKEN` only when the provisioned endpoint explicitly requires it
+
+If the user already has a plan and slot (`status: "available"`), skip the
+purchase step and go straight to IP registration + verification.
+
+### Step 3: Set up environment
+```bash
+cd ~/slv/solana-trade-bot
+cp .env.sample .env
+```
+Help the user edit `.env` with as much automatic configuration as possible.
+See `slv-bot-trade-app/SKILL.md` for the full env var reference. At minimum,
+`GRPC_ENDPOINT` is required. Treat `X_TOKEN` as optional unless the
+provisioned endpoint explicitly requires it.
+
+Before asking the user for RPC settings, read `~/.slv/api.yml` and look for
+the SLV API key. If it exists, set both `SOLANA_RPC_ENDPOINT` and
+`SOLANA_SEND_RPC_ENDPOINT` to `https://edge.erpc.global?api-key=<API_KEY>`
+automatically. Do not ask the user to provide an RPC URL when the local SLV
+API key is already available.
+
+**Reuse the user's Discord webhook automatically.** `WEBHOOK_URL` in `.env`
+is optional but enables trade notifications. If the user already set a
+Discord webhook during `slv onboard`, it lives at
+`notifications.discord_webhook` in `~/.slv/api.yml`. Before asking the user
+for a webhook URL:
+
+1. Read `~/.slv/api.yml` and look for `notifications.discord_webhook`.
+2. If it is set, write that same URL into the bot's `.env` as
+   `WEBHOOK_URL=...` automatically. Tell the user that you reused their
+   existing webhook, and mention that they can override it later if they
+   want a dedicated channel for the bot.
+3. If it is not set, leave `WEBHOOK_URL` empty and continue. Mention briefly
+   that they can add one later by editing `.env` or re-running `slv onboard`.
+
+Never ask the user to paste a webhook URL into the chat when one is already
+configured, and never echo the URL back. Say "reused your existing webhook"
+instead.
+
+Keep questions to a minimum. Prefer filling sensible defaults, reusing
+existing local configuration automatically, installing and configuring
+common local dependencies for the user when appropriate, leaving optional
+fields blank only when automation is unavailable, and moving to the next
+concrete step instead of asking the user to decide optional settings up
+front.
+
+### Step 4: Install prerequisites
+- **Rust**: if not installed, `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
+- **LLVM** (macOS only): `brew install llvm`
+
+### Step 5: Build
+On **macOS**: `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib cargo build -r`
+On **Linux**: `cargo build -r`
+
+Build warnings about unused variables are normal and can be ignored. If
+`librocksdb-sys` fails, see SKILL.md "Common Build Issues".
+
+### Step 6: Start the bot
+
+**IMPORTANT: trade-app is a long-running server process. NEVER run it with
+`run_command` directly, and never launch it in a way that leaves the console
+waiting forever. Start it detached, persist the PID, then do a bounded
+readiness check.**
+
+**Pre-start checks — run these every time before launching:**
+```bash
+# 1. Is it already running? If yes, DO NOT launch again.
+pgrep -f "target/release/trade-app" && echo "ALREADY_RUNNING" || echo "NOT_RUNNING"
+
+# 2. Is port 3000 already answering?
+curl -sf http://localhost:3000/api/wallet >/dev/null && echo "API_UP" || echo "API_DOWN"
+
+# 3. If wallet.json exists, snapshot it before doing anything that could touch it.
+[ -f ~/slv/solana-trade-bot/wallet.json ] && \
+  cp ~/slv/solana-trade-bot/wallet.json ~/slv/solana-trade-bot/wallet.json.bak.$(date +%s)
+```
+
+- If `ALREADY_RUNNING` or `API_UP` → DO NOT launch. Go to Step 7 and work
+  via the REST API.
+- If the binary does not exist → go back to Step 5 to build first.
+- Only if the bot is truly not running AND the binary exists, proceed with
+  launch:
+
+```bash
+cd ~/slv/solana-trade-bot
+mkdir -p .slv
+RUST_LOG=info nohup ./target/release/trade-app > trade-app.log 2>&1 & echo $! > .slv/trade-app.pid
+```
+
+Then verify startup with a short bounded check. Do not wait indefinitely:
+```bash
+for i in 1 2 3 4 5; do
+  if curl -fsS http://localhost:3000/api/wallet >/tmp/trade-app-wallet.json 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+cat /tmp/trade-app-wallet.json | head -20
+```
+
+If the wallet endpoint responds, the bot is running. Tell the user clearly
+that startup succeeded, that the API is ready at `http://localhost:3000`,
+and that the PID was saved to `~/slv/solana-trade-bot/.slv/trade-app.pid`
+so it can be stopped later. **On first start, the bot auto-generates
+`wallet.json`. On every subsequent start, it loads the existing
+`wallet.json` — never let any command overwrite or delete it.**
+
+If the readiness check does not pass, inspect `trade-app.log` and report
+the startup failure instead of waiting forever.
+
+### Step 6.5: Resolve the public URL (every start)
+
+`curl localhost:3000/*` is how you *probe* the API from the same host — the
+bot is running on this box so localhost always works. But `localhost` is
+**not** what you should show the user. If you send
+`http://localhost:3000/docs` in chat or to Discord, the user cannot click
+it from their phone or another machine.
+
+Capture the node's public IPv4 once and reuse it everywhere you display a
+URL:
+
+```bash
+PUBLIC_IP=$(curl -4 -fsS --max-time 5 ifconfig.me 2>/dev/null || echo "")
+if [ -z "$PUBLIC_IP" ]; then
+  # Fallback: primary interface on this box. Works for LAN-only dev machines.
+  if command -v ipconfig >/dev/null 2>&1; then
+    PUBLIC_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "")
+  fi
+fi
+[ -z "$PUBLIC_IP" ] && PUBLIC_IP="localhost"
+PUBLIC_URL="http://$PUBLIC_IP:3000"
+echo "PUBLIC_URL=$PUBLIC_URL"
+```
+
+Rules for URL display:
+- **All probes / curls run by you** → use `http://localhost:3000/...` (fast,
+  always works from the same host).
+- **All URLs you show to the user in chat** → use `$PUBLIC_URL/...` so they
+  are clickable from anywhere.
+- **All URLs you send to Discord** → use `$PUBLIC_URL/...`.
+- If `PUBLIC_IP` fell back to `localhost`, mention to the user that the bot
+  is LAN-only and the docs URL only works from this machine.
+
+Also remind the user once that **port 3000 must be reachable** (open in the
+VPS firewall / security group) for the links to work from outside. If you
+detect `PUBLIC_IP` is a public address and the user is on a VPS, suggest
+they verify with `curl -fsS $PUBLIC_URL/api/wallet` from their local
+machine.
+
+### Step 6.6: First-start Discord notification (fresh installs only)
+
+If this was a **fresh install** (in the Preflight you observed `NO_DIR` or
+`DIR_EXISTS + NO_WALLET` — i.e. the bot just generated its `wallet.json`
+for the first time in this session) AND a Discord webhook is configured
+(`notifications.discord_webhook` in `~/.slv/api.yml`, as set up by
+`slv onboard`), send a one-time welcome notification so the user can reach
+the bot from their phone or another machine.
+
+Use the `send_notification` tool with a payload like:
+
+```
+🚀 Solana Trade Bot — Deployed & Running
+
+Wallet:   <pubkey from /api/wallet>
+Balance:  <SOL from /api/wallet>
+gRPC:     <GRPC_ENDPOINT from .env>
+API:      $PUBLIC_URL
+API Docs: $PUBLIC_URL/docs
+
+Next steps:
+1. Send SOL to the wallet (minimum 0.013 SOL)
+2. Start trading:  curl -X POST $PUBLIC_URL/api/trade/start
+3. Check status:   curl -s $PUBLIC_URL/api/trade/status
+4. Tune config:    GET / PUT $PUBLIC_URL/api/config
+```
+
+Then mark the notification as sent so you do not spam the user on restarts:
+
+```bash
+touch ~/slv/solana-trade-bot/.discord-init-notified
+```
+
+**Idempotency**: before sending, check
+`[ -f ~/slv/solana-trade-bot/.discord-init-notified ] && echo SKIP_NOTIFY`.
+If the marker exists, **do not send the notification again** — the user has
+already received it. This file must also survive re-inits because it lives
+inside the app directory, so treat it the same way as `wallet.json` in the
+Preflight: if you ever re-init and the marker existed, preserve it via the
+same backup rule.
+
+If no Discord webhook is configured, skip this step entirely — do not ask
+the user for a webhook URL in chat. Mention briefly that they can set one
+up with `slv onboard` to get the docs URL pushed to their phone next time.
+
+### Step 7: Explore the API and guide the user
+
+Once the bot is running, **you should operate it on behalf of the user**
+via the REST API. Remember the rule from Step 6.5: probe via `localhost`,
+display via `$PUBLIC_URL`.
+
+1. **Show wallet info** — probe: `curl -s http://localhost:3000/api/wallet`
+   - Tell the user the wallet pubkey and ask them to fund it with SOL
+   - Minimum: 0.013 SOL (buy amount + ATA rent + fee reserve)
+
+2. **Show API docs link** — tell the user they can explore all endpoints at:
+   `$PUBLIC_URL/docs`  (substitute the actual resolved URL from Step 6.5)
+
+3. **Read the OpenAPI spec** to understand available endpoints:
+   ```bash
+   curl -s http://localhost:3000/docs | head -100
+   ```
+
+4. **Show current config** — probe:
+   `curl -s http://localhost:3000/api/config`
+   - Explain the current settings (buy amount, sell multiplier, etc.)
+   - Ask if they want to adjust anything
+
+5. **Wait for funding** — ask user to confirm they've sent SOL to the wallet
+
+### Step 8: Start trading
+
+Once the wallet is funded, probe locally:
+```bash
+curl -X POST http://localhost:3000/api/trade/start
+```
+
+Then check status:
+```bash
+curl -s http://localhost:3000/api/trade/status
+```
+
+When you **show** these commands to the user in chat, substitute
+`$PUBLIC_URL` so they can run them from their own machine:
+
+```
+curl -X POST $PUBLIC_URL/api/trade/start
+curl -s $PUBLIC_URL/api/trade/status
+```
+
+Explain what's happening:
+- The bot is now watching for new PumpSwap pools via gRPC
+- When a matching pool is detected, it will auto-buy
+- Profit target / timeout / liquidity collapse triggers auto-sell
+- If Discord webhook is configured, notifications are sent
+
+### Step 9: Monitor and improve
+
+Keep interacting with the bot API to help the user (probe via localhost,
+display via `$PUBLIC_URL`):
+- `curl -s http://localhost:3000/api/trade/status` — check running state
+- `curl -s http://localhost:3000/api/logs` — view trade logs
+- `curl -s http://localhost:3000/api/trades/profit` — P&L summary
+- `curl -X PUT http://localhost:3000/api/config -H 'Content-Type: application/json' -d '{...}'`
+  — adjust config
+
+When you hand these snippets to the user in chat, rewrite
+`http://localhost:3000` → `$PUBLIC_URL` so they are clickable/runnable from
+anywhere.
+
+**Ask the user what they'd like to improve** — e.g. buy amount, profit
+target, timeout, etc.
+
+### Step 10: Deploy to VPS
+Once local testing is successful:
+```bash
+slv bot deploy
+```
+This builds, uploads via SCP, creates a systemd service, and starts the bot
+on the remote server.
+
+### Stopping the bot locally
+Prefer the saved PID file:
+```bash
+cd ~/slv/solana-trade-bot
+kill "$(cat .slv/trade-app.pid)" && rm -f .slv/trade-app.pid
+```
+
+If the PID file is missing or stale, fall back to a process search:
+```bash
+pkill -f trade-app
+```
+
+## trade-app-specific Behavior Rules
+
+These are the rules that only apply to trade-app. Generic rules (wallet
+preflight, inventory scan, MCP flow, URL display) live in `slv-app/AGENT.md`
+and apply to every template.
+
+1. **Display URLs use `$PUBLIC_URL`, probe URLs use `localhost`** (Step 6.5
+   rule). Every URL you put in chat text, a user-facing example, or a
+   Discord notification MUST be the node's public IP.
+2. **Send the first-start Discord welcome exactly once.** When a fresh
+   `wallet.json` is generated AND `notifications.discord_webhook` is
+   configured, call `send_notification` with the Step 6.6 payload and
+   create `.discord-init-notified` in the app directory. Do not notify
+   again on restarts.
+3. **After the bot starts, proactively use its REST API** to show wallet,
+   config, and status — don't just tell the user to do it themselves.
+4. **Read the OpenAPI docs** at `/docs` to understand all available
+   endpoints and operate on the user's behalf.
+5. After local testing works, proactively suggest `slv bot deploy` for VPS
+   deployment.
+6. For non-engineer users, prefer installing and configuring Redis
+   automatically when the app benefits from persistent local trade history.
+   Only ask the user about Redis if automation fails or a host-specific
+   choice is required.
+7. Remind users that persistent data requires backup storage — suggest the
+   storage products (`/v3/storage/product-list`) when relevant.
+8. **Ask the user what they'd like to improve** after showing initial
+   status — config tuning, more positions, different profit targets, etc.
+
+## Intent Shortcuts — trade-app specific
+
+These extend the generic intent shortcuts in `slv-app/AGENT.md` with
+trade-app-specific phrasings. Always run the App Inventory scan first so
+you know whether the user has 0, 1, or many apps, then branch using the
+Preflight.
+
+| User says | Interpretation | Action |
+|---|---|---|
+| "run trade app" / "start trade app" / "start trading" / "go" | Resume existing project if one exists | Inventory → if 0 apps: fresh install (Step 1). If 1 app: Preflight + start (Step 6). If 2+: ask which. **Never Step 1 when an app already exists.** |
+| "change the buy amount / profit target / config" | Modify running app | Inventory → pick target → `GET /api/config` → show current → `PUT /api/config` with diff → confirm with `GET /api/trade/status` |
+| "create a new trade bot" (when an old one exists) | New second app | Propose a unique name (e.g. `solana-trade-bot-2`) → confirm → Step 1 with the new name (no `-y` needed, directory doesn't exist yet). Warn that only one bot can run on port 3000 at a time. |
+
+## Per-App Playbook — trade-app specifics
+
+Generic operations (show status, stop, restart, modify config live,
+destructive delete) are in `slv-app/AGENT.md` and work with any template.
+Use `$BINARY=trade-app` and `$PORT=3000` when applying them. The sections
+below cover scenarios unique to trade-app.
+
+### Handling the "two bots, one port" problem
+
+The default `trade-app` template binds to `3000`. Only one app can use that
+port at a time. When the user tries to run a second trade-app-family bot:
+
+1. Check `lsof -i :3000` or `curl -sf http://localhost:3000/api/wallet` to
+   see who owns it.
+2. If app A is currently on 3000 and the user wants to start app B:
+   - Option 1 (recommended): change app B's `.env` to `PORT=3001` (or any
+     free port) and launch.
+   - Option 2: stop app A first (with the safety checks from the generic
+     playbook), then launch app B on 3000.
+3. Never let two launches race — you will get a silent port-bind failure
+   and the user will think the bot is running when it isn't.
+
+Probe URLs for the second app become `http://localhost:$PORT/...`. Display
+URLs in chat and Discord use `$PUBLIC_URL:$PORT`.

--- a/dist/oss-skills/slv-bot-trade-app/README.md
+++ b/dist/oss-skills/slv-bot-trade-app/README.md
@@ -1,0 +1,17 @@
+# SLV Bot — trade-app skill
+
+Template-specific skill for the `slv bot init -t trade-app` PumpSwap
+auto-trading bot. Extends `slv-app` with:
+
+- 10-step setup guide (init → env → build → run → trade → deploy)
+- Environment variable reference
+- REST API endpoint reference
+- Common build issues (e.g. macOS `libclang.dylib`)
+- Per-app playbook tuned to `trade-app` (port 3000, `target/release/trade-app`)
+
+This skill is always loaded alongside `slv-app` for the Setzer agent.
+Install via:
+
+```
+slv skills sync
+```

--- a/dist/oss-skills/slv-bot-trade-app/SKILL.md
+++ b/dist/oss-skills/slv-bot-trade-app/SKILL.md
@@ -1,0 +1,185 @@
+# SLV Bot — trade-app Skill
+
+Reference material for the `trade-app` template. This skill is paired with
+`slv-app` and always loaded together in the Setzer agent prompt. If you are
+reading this as the main agent, treat this document as the authoritative
+reference for the `trade-app` template and fall back to `slv-app` for
+cross-template operations (inventory scan, wallet preflight, MCP flow).
+
+## trade-app Overview
+
+The `trade-app` template is a Rust application for PumpSwap (Pump.fun AMM)
+trading automation.
+
+### Lifecycle
+`pool detected -> buy -> tx confirm -> sell monitor -> sell -> burn if needed -> ATA close -> notify`
+
+### Main features
+- Real-time pool detection via Geyser gRPC
+- Automatic buy on matching new pool
+- Profit target selling with retry support
+- Timeout-based forced retreat
+- Liquidity collapse retreat
+- Dust burn and ATA close for rent recovery
+- Discord webhook notifications
+- Redis-backed trade history
+- REST API with OpenAPI docs at `/docs`
+
+## Quick Start
+
+### 1. Create the project
+```bash
+slv bot init -t trade-app -n solana-trade-bot
+```
+Options: `-t` template type, `-n` app name. **Do NOT pass `-y`** unless the
+directory does not exist — see `slv-app` Wallet Preflight for the full rule.
+
+### 2. Configure environment
+```bash
+cd ~/slv/solana-trade-bot
+cp .env.sample .env
+# Edit .env — set at minimum: GRPC_ENDPOINT (leave optional fields blank unless needed)
+```
+
+### 3. Build
+macOS:
+```bash
+brew install llvm   # if not already installed
+DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib cargo build -r
+```
+Linux:
+```bash
+cargo build -r
+```
+
+### 4. Run (background, with PID file and bounded readiness check)
+```bash
+cd ~/slv/solana-trade-bot
+mkdir -p .slv
+RUST_LOG=info nohup ./target/release/trade-app > trade-app.log 2>&1 & echo $! > .slv/trade-app.pid
+for i in 1 2 3 4 5; do
+  curl -fsS http://localhost:3000/api/wallet && break
+  sleep 1
+done
+```
+- Save the PID to `.slv/trade-app.pid` so the process can be stopped cleanly
+- If readiness fails, inspect `trade-app.log` instead of waiting forever
+- `wallet.json` is auto-generated on first start
+- API docs: `http://localhost:3000/docs`
+- **NEVER run with `run_command` directly** or in a way that waits on the
+  backgrounded process forever
+
+### 5. Fund wallet and start trading
+```bash
+# Check wallet pubkey
+curl -s http://localhost:3000/api/wallet
+# Send SOL to the wallet pubkey (min 0.013 SOL)
+# Then start trading:
+curl -X POST http://localhost:3000/api/trade/start
+# Check status:
+curl -s http://localhost:3000/api/trade/status
+```
+
+### Stop the bot
+Preferred:
+```bash
+cd ~/slv/solana-trade-bot
+kill "$(cat .slv/trade-app.pid)" && rm -f .slv/trade-app.pid
+```
+Fallback:
+```bash
+pkill -f trade-app
+```
+
+### 6. Deploy to VPS
+```bash
+slv bot deploy
+```
+Builds, uploads via SCP, creates systemd service on the remote server.
+
+## Environment Variables (`.env`)
+
+### Required
+| Variable | Description |
+|----------|-------------|
+| `GRPC_ENDPOINT` | Geyser gRPC endpoint |
+
+### Optional
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `X_TOKEN` | — | Optional gRPC auth token, only needed when the endpoint requires it |
+| `SOLANA_RPC_ENDPOINT` | `https://edge.erpc.global?api-key=<API_KEY>` | RPC for reads. Reuse the API key from `~/.slv/api.yml` automatically when available |
+| `SOLANA_SEND_RPC_ENDPOINT` | same as read RPC | RPC for sending TXs. Reuse the same ERPC endpoint automatically when available |
+| `API_PORT` | `3000` | HTTP API port |
+| `API_TOKEN` | — | Bearer token for API auth |
+| `WEBHOOK_URL` | — | Discord Webhook URL. If `notifications.discord_webhook` exists in `~/.slv/api.yml`, reuse it automatically |
+| `REDIS_URL` | — | Redis URL for trade history. For non-engineer users, prefer installing Redis locally and configuring this automatically instead of asking up front |
+| `CONFIG_PATH` | `config.jsonc` | Geyser filter config file |
+
+When setting up `.env`, prefer automatic configuration over user questions
+whenever possible. Reuse existing local configuration automatically when
+available: the SLV API key from `~/.slv/api.yml` for
+`https://edge.erpc.global?api-key=<API_KEY>` RPC defaults, and
+`notifications.discord_webhook` from `~/.slv/api.yml` for `WEBHOOK_URL`. For
+non-engineer users, prefer installing and wiring Redis automatically when
+local persistence is useful.
+
+## Trade Configuration (via API)
+
+`GET /api/config` to read, `PUT /api/config` to update.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `buy_amount_lamports` | `100000` (0.0001 SOL) | Amount to spend per buy |
+| `sell_multiplier` | `1.1` | Take profit at buy_price x this |
+| `slippage_bps` | `500` (5%) | Slippage tolerance |
+| `max_positions` | `1` | Max concurrent positions |
+| `min_pool_sol_lamports` | `100000` (0.0001 SOL) | Min pool liquidity to trigger buy |
+| `sell_timeout_secs` | `300` (5 min) | Force exit after timeout |
+| `exit_pool_sol_lamports` | `1000000` (0.001 SOL) | Retreat if pool WSOL drops below |
+
+## REST API
+
+Base URL: `http://localhost:3000` | OpenAPI docs: `http://localhost:3000/docs`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/config` | Get current trade config |
+| `PUT` | `/api/config` | Partial update trade config |
+| `POST` | `/api/trade/start` | Start trading |
+| `POST` | `/api/trade/stop` | Stop trading |
+| `GET` | `/api/trade/status` | Running state, positions, balance |
+| `GET` | `/api/wallet` | Wallet pubkey and SOL balance |
+| `GET` | `/api/logs` | Trade logs |
+| `GET` | `/api/trades/history` | Trade history from Redis |
+| `GET` | `/api/trades/{id}` | Single trade by ID |
+| `GET` | `/api/trades/profit` | Buy-Sell pair P&L summary |
+| `POST` | `/api/grpc/start` | Start gRPC stream |
+| `POST` | `/api/grpc/stop` | Stop gRPC stream |
+
+## Common Build Issues
+
+### macOS: `libclang.dylib` not found
+```
+error: failed to run custom build command for `librocksdb-sys`
+dyld: Library not loaded: @rpath/libclang.dylib
+```
+**Fix:**
+```bash
+brew install llvm
+DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/llvm/lib cargo build -r
+```
+
+## Runtime Facts
+
+- **Binary path**: `target/release/trade-app`
+- **Default port**: `3000`
+- **PID file**: `.slv/trade-app.pid`
+- **Log file**: `trade-app.log`
+- **Generated on first start**: `wallet.json` (private key — handle with care)
+- **Discord notification marker**: `.discord-init-notified` (preserved across re-inits)
+
+For wallet safety, inventory scan, MCP endpoint acquisition, and generic
+per-app operations (start / stop / restart / modify config / delete) see the
+`slv-app` skill — those procedures apply to every template including
+`trade-app`.

--- a/dist/oss-skills/slv-bot-trade-app/skill.json
+++ b/dist/oss-skills/slv-bot-trade-app/skill.json
@@ -1,0 +1,20 @@
+{
+  "name": "slv-bot-trade-app",
+  "displayName": "SLV Bot — trade-app template",
+  "version": "0.1.0",
+  "description": "Template-specific knowledge for the `slv bot init -t trade-app` PumpSwap auto-trading bot. Extends slv-app with the trade-app 10-step setup, REST API reference, and per-app playbook. Always loaded alongside slv-app for the Setzer agent.",
+  "author": "ValidatorsDAO",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/ValidatorsDAO/slv",
+  "repository": "https://github.com/ValidatorsDAO/slv",
+  "tags": ["solana", "trade-bot", "pumpswap", "rust"],
+  "requirements": {
+    "system": ["rust>=1.70"],
+    "optional": ["solana-cli", "redis"]
+  },
+  "extends": "slv-app",
+  "files": {
+    "skill": "SKILL.md",
+    "agent": "AGENT.md"
+  }
+}


### PR DESCRIPTION
## Summary
Split the 518-line Setzer `AGENT.md` into two skills so template-specific content (trade-app, future geyser-ts / shreds-rust / …) can be added without the slv-app monolith growing forever.

- **`slv-app`** → slim template-agnostic router: App Inventory scan, Wallet Preflight Rule 0–3, ERPC MCP endpoint flow, generic Per-App Playbook with `$BINARY` / `$PORT` placeholders, CLI reference
- **`slv-bot-trade-app`** (new) → trade-app-specific: 10-step guide, REST API, port 3000 specifics, Discord welcome once, two-bots-one-port problem
- **Registry-driven delegation** — `AGENT_SKILL_MAP` and the hardcoded Tina/Cid gRPC Geyser append are gone. `executeDelegateToAgent` now flows through `loadAgentContext().skillSourcesByAgent`, which the registry populates via `extraSkills`. Adding a future template only touches `registry.ts` + `SKILL_NAMES`. As a side benefit, Tina/Cid now also get `slv-grpc-geyser`'s `AGENT.md` (previously only `SKILL.md` was appended)

This was previously #289 (stacked on the now-merged #288). Rebased onto `main` after #288 merged.

## File breakdown
| File | Change |
|---|---|
| `dist/oss-skills/slv-bot-trade-app/{AGENT.md,SKILL.md,README.md,skill.json}` | New skill |
| `dist/oss-skills/slv-app/AGENT.md` | 518 → 342 lines (-34%) |
| `dist/oss-skills/slv-app/SKILL.md` | 212 → 103 lines (-52%) |
| `dist/oss-skills/slv-app/skill.json` | Version bump + new description |
| `cli/src/ai/agentConfig/registry.ts` | `Setzer.extraSkills = ['slv-bot-trade-app']` |
| `cli/src/ai/agentConfig/paths.ts` | Add `resolveAgentMdPath()` |
| `cli/src/ai/agentConfig/loader.ts` | Unified missing-skill warning scan (primary + extra) |
| `cli/src/ai/console/tools.ts` | Remove `AGENT_SKILL_MAP` / Tina-Cid manual append; loader-driven delegation; dedupe 3 more `api.yml` reads via loader |
| `cli/src/skills/syncSkills.ts` | Add `slv-bot-trade-app` to `SKILL_NAMES` |
| `cli/test/unit/agentConfig_{loader,registry}.test.ts` | +4 new tests covering Setzer wiring and the missing-skill warning |

## Backward compatibility
- `~/.slv/agent/config.yml` continues to work unchanged — users do not need to add `slv-bot-trade-app` by hand. Registry `extraSkills` auto-merges it.
- Users on older CLIs: on next `slv upgrade` the CLI will `slv skills sync` and fetch the new skill. The loader emits a warning if the new skill dir is missing (see new `Setzer emits a warning when slv-bot-trade-app is missing` test).
- Setzer specialist behavior during the sync gap: slv-app generic safety rules still apply; the 10-step trade-app guide becomes unavailable until sync completes. Same short-term gap pattern as any other skill addition.

## Test plan
- [x] `deno test -A cli/test/` — 44 passed / 0 failed (+4 new)
- [x] `deno check` on all modified files — clean
- [x] Smoke test: post-sync temp home, Setzer's `skillSourcesByAgent` = `['slv-app', 'slv-bot-trade-app']`, 0 warnings, sub-agent prompt assembly contains sections from both
- [ ] Manual: after merge + `slv upgrade`, confirm `slv c` boots clean on real `~/.slv/` with `slv-bot-trade-app` synced
- [ ] Manual: delegate to Setzer in `slv c` and verify the sub-agent prompt includes both skill blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)