### PR TITLE
feat(console): i18n for slv c console messages

### DIFF
--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -135,12 +135,12 @@ class ChatLog extends Container {
   addTool(name: string, detail: string) {
     // Show user-friendly tool descriptions instead of raw JSON
     const friendlyNames: Record<string, string> = {
-      'run_command': '⚡ Running command',
-      'read_file': '📄 Reading file',
-      'enable_tools': '🧰 Enabling tools',
-      'write_file': '📝 Writing file',
-      'list_files': '📂 Listing files',
-      'call_mcp': '🔗 Calling SLV Cloud API',
+      'run_command': t('⚡ Running command'),
+      'read_file': t('📄 Reading file'),
+      'enable_tools': t('🧰 Enabling tools'),
+      'write_file': t('📝 Writing file'),
+      'list_files': t('📂 Listing files'),
+      'call_mcp': t('🔗 Calling SLV Cloud API'),
       'delegate_to_agent': '', // handled separately
     }
     const friendly = friendlyNames[name]
@@ -180,13 +180,13 @@ class ChatLog extends Container {
         )
         : []
       const whyMap: Record<string, string> = {
-        'run_command': 'inspect or operate the local/remote SLV environment',
-        'read_file': 'inspect focused local SLV files',
-        'call_mcp': 'check subscriptions or fetch SLV Cloud data',
-        'write_file': 'save configuration or update memory',
-        'list_files': 'inspect available files before acting',
-        'send_notification': 'notify you when a long task finishes',
-        'delegate_to_agent': 'hand work to a specialist agent',
+        'run_command': t('inspect or operate the local/remote SLV environment'),
+        'read_file': t('inspect focused local SLV files'),
+        'call_mcp': t('check subscriptions or fetch SLV Cloud data'),
+        'write_file': t('save configuration or update memory'),
+        'list_files': t('inspect available files before acting'),
+        'send_notification': t('notify you when a long task finishes'),
+        'delegate_to_agent': t('hand work to a specialist agent'),
       }
       if (tools.length > 0) {
         const why = tools
@@ -293,16 +293,25 @@ async function checkDependencies(): Promise<string[]> {
 
 async function promptInstallDependencies(missing: string[]): Promise<void> {
   console.log(
-    yellow(`\n  ⚠️  Missing dependencies: ${missing.join(', ')}`),
+    yellow(
+      `\n  ${
+        t('⚠️  Missing dependencies: {deps}').replace(
+          '{deps}',
+          missing.join(', '),
+        )
+      }`,
+    ),
   )
   const buf = new Uint8Array(1)
   Deno.stdout.writeSync(
-    new TextEncoder().encode('  Install now? (Y/n) '),
+    new TextEncoder().encode(`  ${t('Install now? (Y/n) ')}`),
   )
   await Deno.stdin.read(buf)
   const answer = new TextDecoder().decode(buf).trim().toLowerCase()
   if (answer === 'n') {
-    console.log(gray('  Skipping installation. Some features may not work.\n'))
+    console.log(
+      gray(`  ${t('Skipping installation. Some features may not work.')}\n`),
+    )
     return
   }
 
@@ -310,7 +319,7 @@ async function promptInstallDependencies(missing: string[]): Promise<void> {
 
   for (const dep of missing) {
     if (dep === 'ansible') {
-      console.log(green('  Installing ansible-core...'))
+      console.log(green(`  ${t('Installing ansible-core...')}`))
       if (os === 'darwin') {
         const cmd = new Deno.Command('brew', {
           args: ['install', 'ansible'],
@@ -332,7 +341,7 @@ async function promptInstallDependencies(missing: string[]): Promise<void> {
         } catch { /* not found */ }
 
         if (!hasPip3) {
-          console.log(green('  Installing python3-pip...'))
+          console.log(green(`  ${t('Installing python3-pip...')}`))
           // Try apt-get first (Debian/Ubuntu)
           let aptSuccess = false
           try {
@@ -363,7 +372,11 @@ async function promptInstallDependencies(missing: string[]): Promise<void> {
             } catch {
               console.log(
                 red(
-                  '  ✗ Could not install python3-pip. Please install manually: sudo apt-get install -y python3-pip',
+                  `  ${
+                    t(
+                      '✗ Could not install python3-pip. Please install manually: sudo apt-get install -y python3-pip',
+                    )
+                  }`,
                 ),
               )
             }
@@ -419,11 +432,11 @@ async function promptInstallDependencies(missing: string[]): Promise<void> {
           }
         }
       }
-      console.log(green('  ✓ ansible-core installed'))
+      console.log(green(`  ${t('✓ ansible-core installed')}`))
     }
 
     if (dep === 'solana-cli') {
-      console.log(green('  Installing solana-cli (agave)...'))
+      console.log(green(`  ${t('Installing solana-cli (agave)...')}`))
       // Try to read agave version from versions.yml in ~/.slv
       let agaveVersion = 'stable'
       try {
@@ -443,7 +456,7 @@ async function promptInstallDependencies(missing: string[]): Promise<void> {
         stderr: 'inherit',
       })
       await cmd.output()
-      console.log(green('  ✓ solana-cli installed'))
+      console.log(green(`  ${t('✓ solana-cli installed')}`))
     }
   }
   console.log('')
@@ -817,7 +830,9 @@ export const consoleAction = async () => {
     const ctx = await loadAgentContext()
     slvApiKey = ctx.raw.api.slv.api_key ?? ''
     if (!slvApiKey) {
-      console.log('\n  SLV API Key not found. Run `slv login` first.\n')
+      console.log(
+        `\n  ${t('SLV API Key not found. Run `slv login` first.')}\n`,
+      )
       return
     }
     provider = new SLVProvider(
@@ -856,7 +871,7 @@ export const consoleAction = async () => {
     tui,
     white,
     white,
-    'Checking for new versions…',
+    t('Checking for new versions…'),
   )
   chatLog.addChild(versionCheckLoader)
   tui.requestRender()
@@ -871,14 +886,14 @@ export const consoleAction = async () => {
 
     // Deduplicate for display only (all updates are applied)
     const seen = new Set<string>()
-    let msg = '🔄 New versions available:\n'
+    let msg = `${t('🔄 New versions available:')}\n`
     for (const u of updates) {
       const displayKey = `${u.component}-${u.network}-${u.latest}`
       if (seen.has(displayKey)) continue
       seen.add(displayKey)
       msg += `  • ${u.component} (${u.network}): ${u.current} → ${u.latest}\n`
     }
-    msg += '\nType /update to apply, or ignore to keep current versions.'
+    msg += `\n${t('Type /update to apply, or ignore to keep current versions.')}`
 
     chatLog.addSystem(msg)
     tui.requestRender(true)
@@ -929,7 +944,12 @@ export const consoleAction = async () => {
     if (hydratedUserContextKinds.has(kind)) return
 
     if (kind === 'mcp_user_account') {
-      renderStage(`📚 Loading ${describeUserContextKind(kind)}…`)
+      renderStage(
+        t('📚 Loading {context}…').replace(
+          '{context}',
+          t(describeUserContextKind(kind)),
+        ),
+      )
       try {
         if (!slvApiKey) {
           const ctx = await loadAgentContext()
@@ -977,7 +997,12 @@ export const consoleAction = async () => {
       inventoryMap[kind as Exclude<UserContextKind, 'mcp_user_account'>]
     if (!inventoryFile) return
 
-    renderStage(`📚 Loading ${describeUserContextKind(kind)}…`)
+    renderStage(
+      t('📚 Loading {context}…').replace(
+        '{context}',
+        t(describeUserContextKind(kind)),
+      ),
+    )
     try {
       const content = await Deno.readTextFile(
         `${resolveHome()}/.slv/${inventoryFile}`,
@@ -991,7 +1016,7 @@ export const consoleAction = async () => {
 
   const saveMemoryAndExit = async () => {
     if (userMessageCount > 0) {
-      chatLog.addSystem('  Saving session memory...')
+      chatLog.addSystem(`  ${t('Saving session memory...')}`)
       tui.requestRender()
       try {
         await provider.chat(
@@ -1054,7 +1079,7 @@ RULES:
   }
 
   const applyIntentBootstrap = async (input: string) => {
-    renderStage('👂 Understanding your request…')
+    renderStage(t('👂 Understanding your request…'))
     await delay(150)
     let plan = await classifyIntent(
       {
@@ -1086,26 +1111,46 @@ RULES:
       }
     }
 
-    renderStage(`🎓 Intent detected: ${describeIntent(plan.intent)}`)
+    renderStage(
+      t('🎓 Intent detected: {intent}').replace(
+        '{intent}',
+        t(describeIntent(plan.intent)),
+      ),
+    )
     await delay(150)
 
     if (plan.toolsToEnable.length > 0) {
       const enabled = activateExtendedTools(plan.toolsToEnable)
       if (enabled.length > 0) {
-        renderStage(`🧰 Enabling tools: ${enabled.join(', ')}`)
+        renderStage(
+          t('🧰 Enabling tools: {tools}').replace(
+            '{tools}',
+            enabled.join(', '),
+          ),
+        )
         await delay(150)
       }
     }
 
     const newlyLoadedModules = filterUnloadedContextModules(plan.contextModulesToLoad)
     if (newlyLoadedModules.length > 0) {
-      renderStage(`📚 Loading context: ${newlyLoadedModules.join(', ')}`)
+      renderStage(
+        t('📚 Loading context: {modules}').replace(
+          '{modules}',
+          newlyLoadedModules.join(', '),
+        ),
+      )
       await delay(150)
       loadContextModules(newlyLoadedModules)
     }
 
     if (plan.delegateAgent && plan.delegateAgent !== currentSpecialist) {
-      renderStage(`🤖 Loading specialist: ${plan.delegateAgent}`)
+      renderStage(
+        t('🤖 Loading specialist: {specialist}').replace(
+          '{specialist}',
+          plan.delegateAgent,
+        ),
+      )
       await injectSkillDocs(plan.delegateAgent)
       currentSpecialist = plan.delegateAgent
     } else if (!plan.delegateAgent && plan.confidence >= 0.7 && intentDomain(plan.intent) !== intentDomain(currentIntent)) {
@@ -1136,24 +1181,29 @@ RULES:
       chatLog.addUser(input)
       const elapsed = currentTaskStartedAt
         ? formatElapsedTime(currentTaskStartedAt)
-        : 'a moment'
-      const agent = currentDelegateAgent || 'The system'
+        : t('a moment')
+      const agent = currentDelegateAgent || t('The system')
 
       // Build a helpful status response
-      let status = `⏳ ${agent} is still working (${elapsed} elapsed).`
+      let status = t('⏳ {agent} is still working ({elapsed} elapsed).')
+        .replace('{agent}', agent)
+        .replace('{elapsed}', elapsed)
       if (currentDelegateAgent === 'Cecil') {
-        status +=
-          ' Validator deployment can take 20-40 minutes — building Solana, downloading snapshots, and configuring the node.'
+        status += t(
+          ' Validator deployment can take 20-40 minutes — building Solana, downloading snapshots, and configuring the node.',
+        )
       } else if (currentDelegateAgent === 'Tina') {
-        status +=
-          ' RPC deployment can take 30-60 minutes — building Solana, syncing with the cluster.'
+        status += t(
+          ' RPC deployment can take 30-60 minutes — building Solana, syncing with the cluster.',
+        )
       } else if (currentDelegateAgent === 'Cid') {
-        status +=
-          ' Benchmark and connectivity checks usually finish faster, but larger throughput tests can still take a few minutes.'
+        status += t(
+          ' Benchmark and connectivity checks usually finish faster, but larger throughput tests can still take a few minutes.',
+        )
       } else if (currentDelegateAgent === 'Figaro') {
-        status += ' Checking server availability and preparing your options.'
+        status += t(' Checking server availability and preparing your options.')
       }
-      status += " I'll let you know as soon as it's done!"
+      status += t(" I'll let you know as soon as it's done!")
 
       chatLog.addSystem(status)
       tui.requestRender()
@@ -1204,7 +1254,7 @@ RULES:
           callbacks,
         )
       }
-      chatLog.addSystem('  Conversation cleared.')
+      chatLog.addSystem(`  ${t('Conversation cleared.')}`)
       tui.requestRender()
       return
     }
@@ -1212,26 +1262,32 @@ RULES:
     if (input === '/update') {
       if (pendingUpdates && pendingUpdates.length > 0) {
         await applyVersionUpdates(pendingUpdates)
-        chatLog.addSystem('  ✅ versions.yml updated successfully!')
+        chatLog.addSystem(`  ${t('✅ versions.yml updated successfully!')}`)
         pendingUpdates = null
       } else {
-        chatLog.addSystem('  No pending updates.')
+        chatLog.addSystem(`  ${t('No pending updates.')}`)
       }
       tui.requestRender(true)
       return
     }
 
     if (input === '/help') {
-      chatLog.addSystem('  /exit, /quit — Exit')
-      chatLog.addSystem('  /clear — Clear conversation')
-      chatLog.addSystem('  /update — Apply pending version updates')
+      chatLog.addSystem(`  ${t('/exit, /quit — Exit')}`)
+      chatLog.addSystem(`  ${t('/clear — Clear conversation')}`)
+      chatLog.addSystem(`  ${t('/update — Apply pending version updates')}`)
       chatLog.addSystem(
-        '  /focus <validator|rpc|app|mixed|auto> — Switch or reset the main agent\'s primary focus',
+        `  ${
+          t(
+            '/focus <validator|rpc|app|mixed|auto> — Switch or reset the main agent\'s primary focus',
+          )
+        }`,
       )
       chatLog.addSystem(
-        '  /<command> — Execute shell command directly (e.g. /slv ai usage)',
+        `  ${
+          t('/<command> — Execute shell command directly (e.g. /slv ai usage)')
+        }`,
       )
-      chatLog.addSystem('  /help — Show this help')
+      chatLog.addSystem(`  ${t('/help — Show this help')}`)
       tui.requestRender()
       return
     }
@@ -1251,18 +1307,24 @@ RULES:
       if (!rest) {
         try {
           const profile = await detectProfile()
+          const focusKey = profile.overridden
+            ? 'Current focus: {focus} (manual override)'
+            : 'Current focus: {focus} (auto)'
           chatLog.addSystem(
-            `  Current focus: ${profile.primary}${
-              profile.overridden ? ' (manual override)' : ' (auto)'
-            }`,
+            `  ${t(focusKey).replace('{focus}', profile.primary)}`,
           )
         } catch (err) {
           chatLog.addSystem(
-            `  ⚠ Could not detect current focus: ${(err as Error).message}`,
+            `  ${
+              t('⚠ Could not detect current focus: {error}').replace(
+                '{error}',
+                (err as Error).message,
+              )
+            }`,
           )
         }
         chatLog.addSystem(
-          '  Usage: /focus validator | rpc | app | mixed | auto',
+          `  ${t('Usage: /focus validator | rpc | app | mixed | auto')}`,
         )
         tui.requestRender()
         return
@@ -1272,11 +1334,16 @@ RULES:
       if (rest === 'auto' || rest === 'clear' || rest === 'reset') {
         try {
           await clearFocusOverride()
-          chatLog.addSystem('  ◇ Focus override cleared.')
+          chatLog.addSystem(`  ${t('◇ Focus override cleared.')}`)
           handled = true
         } catch (err) {
           chatLog.addSystem(
-            `  ⚠ Failed to clear focus override: ${(err as Error).message}`,
+            `  ${
+              t('⚠ Failed to clear focus override: {error}').replace(
+                '{error}',
+                (err as Error).message,
+              )
+            }`,
           )
           tui.requestRender()
           return
@@ -1284,11 +1351,18 @@ RULES:
       } else if ((valid as string[]).includes(rest)) {
         try {
           await writeFocusOverride(rest as PrimaryFocus)
-          chatLog.addSystem(`  ◇ Focus set to: ${rest}`)
+          chatLog.addSystem(
+            `  ${t('◇ Focus set to: {focus}').replace('{focus}', rest)}`,
+          )
           handled = true
         } catch (err) {
           chatLog.addSystem(
-            `  ⚠ Failed to set focus: ${(err as Error).message}`,
+            `  ${
+              t('⚠ Failed to set focus: {error}').replace(
+                '{error}',
+                (err as Error).message,
+              )
+            }`,
           )
           tui.requestRender()
           return
@@ -1297,7 +1371,11 @@ RULES:
 
       if (!handled) {
         chatLog.addSystem(
-          `  Unknown focus "${rest}". Use: validator | rpc | app | mixed | auto`,
+          `  ${
+            t(
+              'Unknown focus "{focus}". Use: validator | rpc | app | mixed | auto',
+            ).replace('{focus}', rest)
+          }`,
         )
         tui.requestRender()
         return
@@ -1313,7 +1391,12 @@ RULES:
         chatLog.addSystem(`  ${describeProfile(refreshed)}`)
       } catch (err) {
         chatLog.addSystem(
-          `  ⚠ Profile refresh failed: ${(err as Error).message}`,
+          `  ${
+            t('⚠ Profile refresh failed: {error}').replace(
+              '{error}',
+              (err as Error).message,
+            )
+          }`,
         )
       }
       tui.requestRender()
@@ -1375,10 +1458,25 @@ RULES:
           }
         }
         if (!status.success) {
-          chatLog.addSystem(red(`  (exit code ${status.code})`))
+          chatLog.addSystem(
+            red(
+              `  ${
+                t('(exit code {code})').replace('{code}', String(status.code))
+              }`,
+            ),
+          )
         }
       } catch (error) {
-        chatLog.addSystem(red(`  Error: ${(error as Error).message}`))
+        chatLog.addSystem(
+          red(
+            `  ${
+              t('Error: {message}').replace(
+                '{message}',
+                (error as Error).message,
+              )
+            }`,
+          ),
+        )
       }
 
       tui.requestRender()
@@ -1394,7 +1492,7 @@ RULES:
       tui,
       (s: string) => green(s),
       (s: string) => gray(s),
-      'Understanding your request...',
+      t('Understanding your request...'),
     )
     chatLog.addChild(loader)
     loader.start()
@@ -1423,7 +1521,9 @@ RULES:
     } catch (error) {
       const msg = (error as Error).message
       const color = /[Ii]nsufficient.*token|token.*limit/i.test(msg) ? yellow : red
-      chatLog.addSystem(color(`  Error: ${msg}`))
+      chatLog.addSystem(
+        color(`  ${t('Error: {message}').replace('{message}', msg)}`),
+      )
     }
 
     if (loader) {
@@ -1453,7 +1553,7 @@ RULES:
         // Double Ctrl+C: force exit immediately no matter what
         killActiveProcess()
         tui.stop()
-        console.log('\n  Force exit.\n')
+        console.log(`\n  ${t('Force exit.')}\n`)
         Deno.exit(1)
       }
 
@@ -1461,7 +1561,9 @@ RULES:
         // First Ctrl+C during processing: kill child process, show message
         killActiveProcess()
         chatLog.addSystem(
-          '  ⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.',
+          `  ${
+            t('⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.')
+          }`,
         )
         isProcessing = false
         if (loader) {

--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -1318,7 +1318,7 @@ RULES:
             `  ${
               t('⚠ Could not detect current focus: {error}').replace(
                 '{error}',
-                (err as Error).message,
+                () => (err as Error).message,
               )
             }`,
           )
@@ -1341,7 +1341,7 @@ RULES:
             `  ${
               t('⚠ Failed to clear focus override: {error}').replace(
                 '{error}',
-                (err as Error).message,
+                () => (err as Error).message,
               )
             }`,
           )
@@ -1360,7 +1360,7 @@ RULES:
             `  ${
               t('⚠ Failed to set focus: {error}').replace(
                 '{error}',
-                (err as Error).message,
+                () => (err as Error).message,
               )
             }`,
           )
@@ -1374,7 +1374,7 @@ RULES:
           `  ${
             t(
               'Unknown focus "{focus}". Use: validator | rpc | app | mixed | auto',
-            ).replace('{focus}', rest)
+            ).replace('{focus}', () => rest)
           }`,
         )
         tui.requestRender()
@@ -1394,7 +1394,7 @@ RULES:
           `  ${
             t('⚠ Profile refresh failed: {error}').replace(
               '{error}',
-              (err as Error).message,
+              () => (err as Error).message,
             )
           }`,
         )
@@ -1472,7 +1472,7 @@ RULES:
             `  ${
               t('Error: {message}').replace(
                 '{message}',
-                (error as Error).message,
+                () => (error as Error).message,
               )
             }`,
           ),
@@ -1522,7 +1522,7 @@ RULES:
       const msg = (error as Error).message
       const color = /[Ii]nsufficient.*token|token.*limit/i.test(msg) ? yellow : red
       chatLog.addSystem(
-        color(`  ${t('Error: {message}').replace('{message}', msg)}`),
+        color(`  ${t('Error: {message}').replace('{message}', () => msg)}`),
       )
     }
 

--- a/cli/src/ai/i18n/messages/en.ts
+++ b/cli/src/ai/i18n/messages/en.ts
@@ -126,4 +126,133 @@ export const messages: Record<string, string> = {
     'Focused on RPC / gRPC Node Operations. Ask me about endpoint setup, health, or tuning.',
   'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
     'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.',
+
+  // --- Console stages (shown after user input) ---
+  '👂 Understanding your request…': '👂 Understanding your request…',
+  'Understanding your request...': 'Understanding your request...',
+  '🎓 Intent detected: {intent}': '🎓 Intent detected: {intent}',
+  '🧰 Enabling tools: {tools}': '🧰 Enabling tools: {tools}',
+  '📚 Loading context: {modules}': '📚 Loading context: {modules}',
+  '🤖 Loading specialist: {specialist}': '🤖 Loading specialist: {specialist}',
+  '📚 Loading {context}…': '📚 Loading {context}…',
+
+  // --- Intent labels (used inside stage messages) ---
+  'general conversation': 'general conversation',
+  'server availability': 'server availability',
+  'server procurement': 'server procurement',
+  'account or billing': 'account or billing',
+  'validator deployment': 'validator deployment',
+  'validator operations': 'validator operations',
+  'RPC deployment': 'RPC deployment',
+  'RPC operations': 'RPC operations',
+  'benchmark or connectivity testing': 'benchmark or connectivity testing',
+  'app or bot development': 'app or bot development',
+  'CLI or file operation': 'CLI or file operation',
+  'needs clarification': 'needs clarification',
+
+  // --- User context kind labels (used inside stage messages) ---
+  'account availability': 'account availability',
+  'testnet validator inventory': 'testnet validator inventory',
+  'mainnet validator inventory': 'mainnet validator inventory',
+  'mainnet RPC inventory': 'mainnet RPC inventory',
+
+  // --- Console commands & status ---
+  'Saving session memory...': 'Saving session memory...',
+  'Conversation cleared.': 'Conversation cleared.',
+  '✅ versions.yml updated successfully!':
+    '✅ versions.yml updated successfully!',
+  'No pending updates.': 'No pending updates.',
+
+  // --- /help ---
+  '/exit, /quit — Exit': '/exit, /quit — Exit',
+  '/clear — Clear conversation': '/clear — Clear conversation',
+  '/update — Apply pending version updates':
+    '/update — Apply pending version updates',
+  "/focus <validator|rpc|app|mixed|auto> — Switch or reset the main agent's primary focus":
+    "/focus <validator|rpc|app|mixed|auto> — Switch or reset the main agent's primary focus",
+  '/<command> — Execute shell command directly (e.g. /slv ai usage)':
+    '/<command> — Execute shell command directly (e.g. /slv ai usage)',
+  '/help — Show this help': '/help — Show this help',
+
+  // --- /focus ---
+  'Current focus: {focus} (manual override)':
+    'Current focus: {focus} (manual override)',
+  'Current focus: {focus} (auto)': 'Current focus: {focus} (auto)',
+  '⚠ Could not detect current focus: {error}':
+    '⚠ Could not detect current focus: {error}',
+  'Usage: /focus validator | rpc | app | mixed | auto':
+    'Usage: /focus validator | rpc | app | mixed | auto',
+  '◇ Focus override cleared.': '◇ Focus override cleared.',
+  '⚠ Failed to clear focus override: {error}':
+    '⚠ Failed to clear focus override: {error}',
+  '◇ Focus set to: {focus}': '◇ Focus set to: {focus}',
+  '⚠ Failed to set focus: {error}': '⚠ Failed to set focus: {error}',
+  'Unknown focus "{focus}". Use: validator | rpc | app | mixed | auto':
+    'Unknown focus "{focus}". Use: validator | rpc | app | mixed | auto',
+  '⚠ Profile refresh failed: {error}': '⚠ Profile refresh failed: {error}',
+
+  // --- Side-chat agent status (shown while another task is running) ---
+  '⏳ {agent} is still working ({elapsed} elapsed).':
+    '⏳ {agent} is still working ({elapsed} elapsed).',
+  ' Validator deployment can take 20-40 minutes — building Solana, downloading snapshots, and configuring the node.':
+    ' Validator deployment can take 20-40 minutes — building Solana, downloading snapshots, and configuring the node.',
+  ' RPC deployment can take 30-60 minutes — building Solana, syncing with the cluster.':
+    ' RPC deployment can take 30-60 minutes — building Solana, syncing with the cluster.',
+  ' Benchmark and connectivity checks usually finish faster, but larger throughput tests can still take a few minutes.':
+    ' Benchmark and connectivity checks usually finish faster, but larger throughput tests can still take a few minutes.',
+  ' Checking server availability and preparing your options.':
+    ' Checking server availability and preparing your options.',
+  " I'll let you know as soon as it's done!":
+    " I'll let you know as soon as it's done!",
+  'The system': 'The system',
+  'a moment': 'a moment',
+
+  // --- Dependency installation ---
+  '⚠️  Missing dependencies: {deps}': '⚠️  Missing dependencies: {deps}',
+  'Install now? (Y/n) ': 'Install now? (Y/n) ',
+  'Skipping installation. Some features may not work.':
+    'Skipping installation. Some features may not work.',
+  'Installing ansible-core...': 'Installing ansible-core...',
+  'Installing python3-pip...': 'Installing python3-pip...',
+  '✗ Could not install python3-pip. Please install manually: sudo apt-get install -y python3-pip':
+    '✗ Could not install python3-pip. Please install manually: sudo apt-get install -y python3-pip',
+  '✓ ansible-core installed': '✓ ansible-core installed',
+  'Installing solana-cli (agave)...': 'Installing solana-cli (agave)...',
+  '✓ solana-cli installed': '✓ solana-cli installed',
+
+  // --- Startup guard / version check ---
+  'SLV API Key not found. Run `slv login` first.':
+    'SLV API Key not found. Run `slv login` first.',
+  'Checking for new versions…': 'Checking for new versions…',
+  '🔄 New versions available:': '🔄 New versions available:',
+  'Type /update to apply, or ignore to keep current versions.':
+    'Type /update to apply, or ignore to keep current versions.',
+
+  // --- Tool call labels (addTool) ---
+  '⚡ Running command': '⚡ Running command',
+  '📄 Reading file': '📄 Reading file',
+  '📝 Writing file': '📝 Writing file',
+  '📂 Listing files': '📂 Listing files',
+  '🔗 Calling SLV Cloud API': '🔗 Calling SLV Cloud API',
+  'inspect or operate the local/remote SLV environment':
+    'inspect or operate the local/remote SLV environment',
+  'inspect focused local SLV files': 'inspect focused local SLV files',
+  'check subscriptions or fetch SLV Cloud data':
+    'check subscriptions or fetch SLV Cloud data',
+  'save configuration or update memory':
+    'save configuration or update memory',
+  'inspect available files before acting':
+    'inspect available files before acting',
+  'notify you when a long task finishes':
+    'notify you when a long task finishes',
+  'hand work to a specialist agent': 'hand work to a specialist agent',
+
+  // --- Shell execution / errors ---
+  '(exit code {code})': '(exit code {code})',
+  'Error: {message}': 'Error: {message}',
+
+  // --- Ctrl+C handler ---
+  'Force exit.': 'Force exit.',
+  '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
+    '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.',
 }

--- a/cli/src/ai/i18n/messages/ja.ts
+++ b/cli/src/ai/i18n/messages/ja.ts
@@ -119,4 +119,117 @@ export const messages: Record<string, string> = {
     'RPC / gRPC ノード運用にフォーカス中。エンドポイント設定、ヘルス、チューニングなどご相談ください。',
   'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
     '複数の役割にフォーカス中 — validator + app / rpc。`/focus <validator|rpc|app>` で絞り込めます。',
+
+  '👂 Understanding your request…': '👂 ご依頼内容を確認しています…',
+  'Understanding your request...': 'ご依頼内容を確認しています...',
+  '🎓 Intent detected: {intent}': '🎓 意図を検出: {intent}',
+  '🧰 Enabling tools: {tools}': '🧰 ツールを有効化: {tools}',
+  '📚 Loading context: {modules}': '📚 コンテキストを読み込み中: {modules}',
+  '🤖 Loading specialist: {specialist}': '🤖 スペシャリストを起動中: {specialist}',
+  '📚 Loading {context}…': '📚 {context}を読み込み中…',
+
+  'general conversation': '一般的な会話',
+  'server availability': 'サーバー空き状況',
+  'server procurement': 'サーバー調達',
+  'account or billing': 'アカウント / 請求',
+  'validator deployment': 'バリデータのデプロイ',
+  'validator operations': 'バリデータ運用',
+  'RPC deployment': 'RPC デプロイ',
+  'RPC operations': 'RPC 運用',
+  'benchmark or connectivity testing': 'ベンチマーク / 接続テスト',
+  'app or bot development': 'アプリ / ボット開発',
+  'CLI or file operation': 'CLI / ファイル操作',
+  'needs clarification': '要確認',
+
+  'account availability': 'アカウント情報',
+  'testnet validator inventory': 'testnet バリデータ一覧',
+  'mainnet validator inventory': 'mainnet バリデータ一覧',
+  'mainnet RPC inventory': 'mainnet RPC 一覧',
+
+  'Saving session memory...': 'セッションメモリを保存中...',
+  'Conversation cleared.': '会話をクリアしました。',
+  '✅ versions.yml updated successfully!': '✅ versions.yml を更新しました！',
+  'No pending updates.': '適用可能なアップデートはありません。',
+
+  '/exit, /quit — Exit': '/exit, /quit — 終了',
+  '/clear — Clear conversation': '/clear — 会話をクリア',
+  '/update — Apply pending version updates':
+    '/update — 保留中のバージョン更新を適用',
+  "/focus <validator|rpc|app|mixed|auto> — Switch or reset the main agent's primary focus":
+    '/focus <validator|rpc|app|mixed|auto> — メインエージェントのフォーカスを切り替え / リセット',
+  '/<command> — Execute shell command directly (e.g. /slv ai usage)':
+    '/<command> — シェルコマンドを直接実行（例: /slv ai usage）',
+  '/help — Show this help': '/help — このヘルプを表示',
+
+  'Current focus: {focus} (manual override)':
+    '現在のフォーカス: {focus}（手動設定）',
+  'Current focus: {focus} (auto)': '現在のフォーカス: {focus}（自動検出）',
+  '⚠ Could not detect current focus: {error}':
+    '⚠ 現在のフォーカスを検出できませんでした: {error}',
+  'Usage: /focus validator | rpc | app | mixed | auto':
+    '使い方: /focus validator | rpc | app | mixed | auto',
+  '◇ Focus override cleared.': '◇ フォーカスの手動設定を解除しました。',
+  '⚠ Failed to clear focus override: {error}':
+    '⚠ フォーカス設定の解除に失敗しました: {error}',
+  '◇ Focus set to: {focus}': '◇ フォーカスを設定: {focus}',
+  '⚠ Failed to set focus: {error}': '⚠ フォーカス設定に失敗しました: {error}',
+  'Unknown focus "{focus}". Use: validator | rpc | app | mixed | auto':
+    '不明なフォーカス "{focus}"。次を使用してください: validator | rpc | app | mixed | auto',
+  '⚠ Profile refresh failed: {error}': '⚠ プロフィール再読み込みに失敗: {error}',
+
+  '⏳ {agent} is still working ({elapsed} elapsed).':
+    '⏳ {agent} は作業中です（経過: {elapsed}）。',
+  ' Validator deployment can take 20-40 minutes — building Solana, downloading snapshots, and configuring the node.':
+    ' バリデータのデプロイには 20〜40 分かかることがあります — Solana のビルド、スナップショットのダウンロード、ノードの設定を行います。',
+  ' RPC deployment can take 30-60 minutes — building Solana, syncing with the cluster.':
+    ' RPC のデプロイには 30〜60 分かかることがあります — Solana のビルドとクラスタ同期を行います。',
+  ' Benchmark and connectivity checks usually finish faster, but larger throughput tests can still take a few minutes.':
+    ' ベンチマークや接続性テストは比較的すぐに終わりますが、大きめのスループットテストでは数分かかることがあります。',
+  ' Checking server availability and preparing your options.':
+    ' サーバー空き状況を確認し、候補を準備しています。',
+  " I'll let you know as soon as it's done!": ' 完了次第お知らせします！',
+  'The system': 'システム',
+  'a moment': '少し前',
+
+  '⚠️  Missing dependencies: {deps}': '⚠️  不足している依存関係: {deps}',
+  'Install now? (Y/n) ': '今すぐインストールしますか？ (Y/n) ',
+  'Skipping installation. Some features may not work.':
+    'インストールをスキップしました。一部機能が動作しないことがあります。',
+  'Installing ansible-core...': 'ansible-core をインストール中...',
+  'Installing python3-pip...': 'python3-pip をインストール中...',
+  '✗ Could not install python3-pip. Please install manually: sudo apt-get install -y python3-pip':
+    '✗ python3-pip をインストールできませんでした。手動でインストールしてください: sudo apt-get install -y python3-pip',
+  '✓ ansible-core installed': '✓ ansible-core をインストールしました',
+  'Installing solana-cli (agave)...': 'solana-cli (agave) をインストール中...',
+  '✓ solana-cli installed': '✓ solana-cli をインストールしました',
+
+  'SLV API Key not found. Run `slv login` first.':
+    'SLV API キーが見つかりません。先に `slv login` を実行してください。',
+  'Checking for new versions…': '新しいバージョンを確認中…',
+  '🔄 New versions available:': '🔄 新しいバージョンが利用可能です:',
+  'Type /update to apply, or ignore to keep current versions.':
+    '適用するには /update を入力、現在のバージョンを維持する場合は無視してください。',
+
+  '⚡ Running command': '⚡ コマンド実行',
+  '📄 Reading file': '📄 ファイル読み込み',
+  '📝 Writing file': '📝 ファイル書き込み',
+  '📂 Listing files': '📂 ファイル一覧',
+  '🔗 Calling SLV Cloud API': '🔗 SLV Cloud API 呼び出し',
+  'inspect or operate the local/remote SLV environment':
+    'ローカル / リモートの SLV 環境を確認・操作',
+  'inspect focused local SLV files': '関連するローカル SLV ファイルを確認',
+  'check subscriptions or fetch SLV Cloud data':
+    'サブスクリプションの確認や SLV Cloud データの取得',
+  'save configuration or update memory': '設定の保存やメモリの更新',
+  'inspect available files before acting': '実行前に対象ファイルを確認',
+  'notify you when a long task finishes':
+    '長時間タスクの完了をお知らせ',
+  'hand work to a specialist agent': 'スペシャリストエージェントへ引き継ぎ',
+
+  '(exit code {code})': '(終了コード {code})',
+  'Error: {message}': 'エラー: {message}',
+
+  'Force exit.': '強制終了します。',
+  '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
+    '⚠️ 中断しました。もう一度 Ctrl+C で終了、またはメッセージを入力してください。',
 }

--- a/cli/src/ai/i18n/messages/ru.ts
+++ b/cli/src/ai/i18n/messages/ru.ts
@@ -120,4 +120,126 @@ export const messages: Record<string, string> = {
     'Фокус на эксплуатации RPC / gRPC узлов. Спрашивайте о настройке эндпоинтов, здоровье и тюнинге.',
   'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
     'Смешанный фокус — validator + app / rpc. Используйте `/focus <validator|rpc|app>`, чтобы сузить.',
+
+  '👂 Understanding your request…': '👂 Разбираюсь в вашем запросе…',
+  'Understanding your request...': 'Разбираюсь в вашем запросе...',
+  '🎓 Intent detected: {intent}': '🎓 Определено намерение: {intent}',
+  '🧰 Enabling tools: {tools}': '🧰 Включаю инструменты: {tools}',
+  '📚 Loading context: {modules}': '📚 Загружаю контекст: {modules}',
+  '🤖 Loading specialist: {specialist}':
+    '🤖 Загружаю специалиста: {specialist}',
+  '📚 Loading {context}…': '📚 Загружаю {context}…',
+
+  'general conversation': 'обычный разговор',
+  'server availability': 'доступность серверов',
+  'server procurement': 'закупка серверов',
+  'account or billing': 'аккаунт или оплата',
+  'validator deployment': 'развёртывание валидатора',
+  'validator operations': 'эксплуатация валидатора',
+  'RPC deployment': 'развёртывание RPC',
+  'RPC operations': 'эксплуатация RPC',
+  'benchmark or connectivity testing':
+    'бенчмарк или тестирование соединения',
+  'app or bot development': 'разработка приложения или бота',
+  'CLI or file operation': 'команда CLI или работа с файлами',
+  'needs clarification': 'требуется уточнение',
+
+  'account availability': 'информация об аккаунте',
+  'testnet validator inventory': 'инвентарь валидаторов testnet',
+  'mainnet validator inventory': 'инвентарь валидаторов mainnet',
+  'mainnet RPC inventory': 'инвентарь RPC mainnet',
+
+  'Saving session memory...': 'Сохраняю память сессии...',
+  'Conversation cleared.': 'Диалог очищен.',
+  '✅ versions.yml updated successfully!': '✅ versions.yml успешно обновлён!',
+  'No pending updates.': 'Нет ожидающих обновлений.',
+
+  '/exit, /quit — Exit': '/exit, /quit — Выход',
+  '/clear — Clear conversation': '/clear — Очистить диалог',
+  '/update — Apply pending version updates':
+    '/update — Применить ожидающие обновления версий',
+  "/focus <validator|rpc|app|mixed|auto> — Switch or reset the main agent's primary focus":
+    '/focus <validator|rpc|app|mixed|auto> — Переключить или сбросить основной фокус главного агента',
+  '/<command> — Execute shell command directly (e.g. /slv ai usage)':
+    '/<command> — Выполнить shell-команду напрямую (например, /slv ai usage)',
+  '/help — Show this help': '/help — Показать эту справку',
+
+  'Current focus: {focus} (manual override)':
+    'Текущий фокус: {focus} (ручное переопределение)',
+  'Current focus: {focus} (auto)': 'Текущий фокус: {focus} (авто)',
+  '⚠ Could not detect current focus: {error}':
+    '⚠ Не удалось определить текущий фокус: {error}',
+  'Usage: /focus validator | rpc | app | mixed | auto':
+    'Использование: /focus validator | rpc | app | mixed | auto',
+  '◇ Focus override cleared.': '◇ Переопределение фокуса сброшено.',
+  '⚠ Failed to clear focus override: {error}':
+    '⚠ Не удалось сбросить переопределение фокуса: {error}',
+  '◇ Focus set to: {focus}': '◇ Фокус установлен: {focus}',
+  '⚠ Failed to set focus: {error}': '⚠ Не удалось установить фокус: {error}',
+  'Unknown focus "{focus}". Use: validator | rpc | app | mixed | auto':
+    'Неизвестный фокус "{focus}". Используйте: validator | rpc | app | mixed | auto',
+  '⚠ Profile refresh failed: {error}':
+    '⚠ Не удалось обновить профиль: {error}',
+
+  '⏳ {agent} is still working ({elapsed} elapsed).':
+    '⏳ {agent} всё ещё работает (прошло {elapsed}).',
+  ' Validator deployment can take 20-40 minutes — building Solana, downloading snapshots, and configuring the node.':
+    ' Развёртывание валидатора может занять 20–40 минут — сборка Solana, загрузка снапшотов и настройка ноды.',
+  ' RPC deployment can take 30-60 minutes — building Solana, syncing with the cluster.':
+    ' Развёртывание RPC может занять 30–60 минут — сборка Solana и синхронизация с кластером.',
+  ' Benchmark and connectivity checks usually finish faster, but larger throughput tests can still take a few minutes.':
+    ' Бенчмарки и проверки соединения обычно завершаются быстрее, но большие тесты пропускной способности могут занять несколько минут.',
+  ' Checking server availability and preparing your options.':
+    ' Проверяю доступность серверов и готовлю варианты.',
+  " I'll let you know as soon as it's done!":
+    ' Сообщу, как только будет готово!',
+  'The system': 'Система',
+  'a moment': 'немного времени',
+
+  '⚠️  Missing dependencies: {deps}':
+    '⚠️  Отсутствуют зависимости: {deps}',
+  'Install now? (Y/n) ': 'Установить сейчас? (Y/n) ',
+  'Skipping installation. Some features may not work.':
+    'Установка пропущена. Некоторые функции могут не работать.',
+  'Installing ansible-core...': 'Установка ansible-core...',
+  'Installing python3-pip...': 'Установка python3-pip...',
+  '✗ Could not install python3-pip. Please install manually: sudo apt-get install -y python3-pip':
+    '✗ Не удалось установить python3-pip. Установите вручную: sudo apt-get install -y python3-pip',
+  '✓ ansible-core installed': '✓ ansible-core установлен',
+  'Installing solana-cli (agave)...': 'Установка solana-cli (agave)...',
+  '✓ solana-cli installed': '✓ solana-cli установлен',
+
+  'SLV API Key not found. Run `slv login` first.':
+    'SLV API ключ не найден. Сначала запустите `slv login`.',
+  'Checking for new versions…': 'Проверяю новые версии…',
+  '🔄 New versions available:': '🔄 Доступны новые версии:',
+  'Type /update to apply, or ignore to keep current versions.':
+    'Введите /update, чтобы применить, или проигнорируйте, чтобы оставить текущие версии.',
+
+  '⚡ Running command': '⚡ Выполняю команду',
+  '📄 Reading file': '📄 Читаю файл',
+  '📝 Writing file': '📝 Пишу файл',
+  '📂 Listing files': '📂 Список файлов',
+  '🔗 Calling SLV Cloud API': '🔗 Вызываю SLV Cloud API',
+  'inspect or operate the local/remote SLV environment':
+    'проверить или управлять локальным / удалённым окружением SLV',
+  'inspect focused local SLV files':
+    'проверить связанные локальные файлы SLV',
+  'check subscriptions or fetch SLV Cloud data':
+    'проверить подписки или получить данные SLV Cloud',
+  'save configuration or update memory':
+    'сохранить конфигурацию или обновить память',
+  'inspect available files before acting':
+    'проверить доступные файлы перед действием',
+  'notify you when a long task finishes':
+    'уведомить по завершении долгой задачи',
+  'hand work to a specialist agent':
+    'передать работу специализированному агенту',
+
+  '(exit code {code})': '(код выхода {code})',
+  'Error: {message}': 'Ошибка: {message}',
+
+  'Force exit.': 'Принудительный выход.',
+  '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
+    '⚠️ Прервано. Нажмите Ctrl+C ещё раз для выхода или введите сообщение.',
 }

--- a/cli/src/ai/i18n/messages/vi.ts
+++ b/cli/src/ai/i18n/messages/vi.ts
@@ -120,4 +120,123 @@ export const messages: Record<string, string> = {
     'Đang tập trung vào vận hành node RPC / gRPC. Hỏi tôi về cấu hình endpoint, health hoặc tinh chỉnh.',
   'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
     'Focus hỗn hợp — validator + app / rpc. Dùng `/focus <validator|rpc|app>` để thu hẹp.',
+
+  '👂 Understanding your request…': '👂 Đang hiểu yêu cầu của bạn…',
+  'Understanding your request...': 'Đang hiểu yêu cầu của bạn...',
+  '🎓 Intent detected: {intent}': '🎓 Đã phát hiện ý định: {intent}',
+  '🧰 Enabling tools: {tools}': '🧰 Đang bật công cụ: {tools}',
+  '📚 Loading context: {modules}': '📚 Đang tải ngữ cảnh: {modules}',
+  '🤖 Loading specialist: {specialist}':
+    '🤖 Đang tải chuyên gia: {specialist}',
+  '📚 Loading {context}…': '📚 Đang tải {context}…',
+
+  'general conversation': 'trò chuyện chung',
+  'server availability': 'tình trạng sẵn có của máy chủ',
+  'server procurement': 'mua sắm máy chủ',
+  'account or billing': 'tài khoản hoặc thanh toán',
+  'validator deployment': 'triển khai validator',
+  'validator operations': 'vận hành validator',
+  'RPC deployment': 'triển khai RPC',
+  'RPC operations': 'vận hành RPC',
+  'benchmark or connectivity testing': 'benchmark hoặc kiểm tra kết nối',
+  'app or bot development': 'phát triển ứng dụng hoặc bot',
+  'CLI or file operation': 'thao tác CLI hoặc tệp',
+  'needs clarification': 'cần làm rõ',
+
+  'account availability': 'thông tin tài khoản',
+  'testnet validator inventory': 'danh sách validator testnet',
+  'mainnet validator inventory': 'danh sách validator mainnet',
+  'mainnet RPC inventory': 'danh sách RPC mainnet',
+
+  'Saving session memory...': 'Đang lưu bộ nhớ phiên...',
+  'Conversation cleared.': 'Đã xóa cuộc hội thoại.',
+  '✅ versions.yml updated successfully!':
+    '✅ versions.yml đã được cập nhật thành công!',
+  'No pending updates.': 'Không có bản cập nhật chờ xử lý.',
+
+  '/exit, /quit — Exit': '/exit, /quit — Thoát',
+  '/clear — Clear conversation': '/clear — Xóa cuộc hội thoại',
+  '/update — Apply pending version updates':
+    '/update — Áp dụng bản cập nhật phiên bản đang chờ',
+  "/focus <validator|rpc|app|mixed|auto> — Switch or reset the main agent's primary focus":
+    '/focus <validator|rpc|app|mixed|auto> — Chuyển hoặc đặt lại focus chính của agent chính',
+  '/<command> — Execute shell command directly (e.g. /slv ai usage)':
+    '/<command> — Thực thi lệnh shell trực tiếp (ví dụ /slv ai usage)',
+  '/help — Show this help': '/help — Hiển thị trợ giúp này',
+
+  'Current focus: {focus} (manual override)':
+    'Focus hiện tại: {focus} (đặt thủ công)',
+  'Current focus: {focus} (auto)': 'Focus hiện tại: {focus} (tự động)',
+  '⚠ Could not detect current focus: {error}':
+    '⚠ Không thể phát hiện focus hiện tại: {error}',
+  'Usage: /focus validator | rpc | app | mixed | auto':
+    'Cách dùng: /focus validator | rpc | app | mixed | auto',
+  '◇ Focus override cleared.': '◇ Đã xóa focus đặt thủ công.',
+  '⚠ Failed to clear focus override: {error}':
+    '⚠ Không thể xóa focus đặt thủ công: {error}',
+  '◇ Focus set to: {focus}': '◇ Đã đặt focus thành: {focus}',
+  '⚠ Failed to set focus: {error}': '⚠ Không thể đặt focus: {error}',
+  'Unknown focus "{focus}". Use: validator | rpc | app | mixed | auto':
+    'Focus không xác định "{focus}". Dùng: validator | rpc | app | mixed | auto',
+  '⚠ Profile refresh failed: {error}':
+    '⚠ Làm mới hồ sơ thất bại: {error}',
+
+  '⏳ {agent} is still working ({elapsed} elapsed).':
+    '⏳ {agent} vẫn đang làm việc (đã trôi qua {elapsed}).',
+  ' Validator deployment can take 20-40 minutes — building Solana, downloading snapshots, and configuring the node.':
+    ' Triển khai validator có thể mất 20-40 phút — biên dịch Solana, tải snapshot và cấu hình node.',
+  ' RPC deployment can take 30-60 minutes — building Solana, syncing with the cluster.':
+    ' Triển khai RPC có thể mất 30-60 phút — biên dịch Solana và đồng bộ với cluster.',
+  ' Benchmark and connectivity checks usually finish faster, but larger throughput tests can still take a few minutes.':
+    ' Benchmark và kiểm tra kết nối thường nhanh hơn, nhưng các bài kiểm tra throughput lớn vẫn có thể mất vài phút.',
+  ' Checking server availability and preparing your options.':
+    ' Đang kiểm tra máy chủ sẵn có và chuẩn bị lựa chọn cho bạn.',
+  " I'll let you know as soon as it's done!":
+    ' Tôi sẽ báo cho bạn ngay khi xong!',
+  'The system': 'Hệ thống',
+  'a moment': 'một lát',
+
+  '⚠️  Missing dependencies: {deps}': '⚠️  Thiếu phụ thuộc: {deps}',
+  'Install now? (Y/n) ': 'Cài đặt ngay? (Y/n) ',
+  'Skipping installation. Some features may not work.':
+    'Đã bỏ qua cài đặt. Một số tính năng có thể không hoạt động.',
+  'Installing ansible-core...': 'Đang cài đặt ansible-core...',
+  'Installing python3-pip...': 'Đang cài đặt python3-pip...',
+  '✗ Could not install python3-pip. Please install manually: sudo apt-get install -y python3-pip':
+    '✗ Không thể cài đặt python3-pip. Vui lòng cài đặt thủ công: sudo apt-get install -y python3-pip',
+  '✓ ansible-core installed': '✓ Đã cài đặt ansible-core',
+  'Installing solana-cli (agave)...': 'Đang cài đặt solana-cli (agave)...',
+  '✓ solana-cli installed': '✓ Đã cài đặt solana-cli',
+
+  'SLV API Key not found. Run `slv login` first.':
+    'Không tìm thấy khóa SLV API. Vui lòng chạy `slv login` trước.',
+  'Checking for new versions…': 'Đang kiểm tra phiên bản mới…',
+  '🔄 New versions available:': '🔄 Đã có phiên bản mới:',
+  'Type /update to apply, or ignore to keep current versions.':
+    'Gõ /update để áp dụng, hoặc bỏ qua để giữ phiên bản hiện tại.',
+
+  '⚡ Running command': '⚡ Đang chạy lệnh',
+  '📄 Reading file': '📄 Đang đọc tệp',
+  '📝 Writing file': '📝 Đang ghi tệp',
+  '📂 Listing files': '📂 Liệt kê tệp',
+  '🔗 Calling SLV Cloud API': '🔗 Đang gọi SLV Cloud API',
+  'inspect or operate the local/remote SLV environment':
+    'kiểm tra hoặc vận hành môi trường SLV cục bộ / từ xa',
+  'inspect focused local SLV files': 'kiểm tra tệp SLV cục bộ liên quan',
+  'check subscriptions or fetch SLV Cloud data':
+    'kiểm tra đăng ký hoặc lấy dữ liệu SLV Cloud',
+  'save configuration or update memory': 'lưu cấu hình hoặc cập nhật bộ nhớ',
+  'inspect available files before acting':
+    'kiểm tra tệp có sẵn trước khi thực hiện',
+  'notify you when a long task finishes':
+    'thông báo khi tác vụ dài hoàn tất',
+  'hand work to a specialist agent':
+    'chuyển công việc cho agent chuyên trách',
+
+  '(exit code {code})': '(mã thoát {code})',
+  'Error: {message}': 'Lỗi: {message}',
+
+  'Force exit.': 'Thoát bắt buộc.',
+  '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
+    '⚠️ Đã ngắt. Nhấn Ctrl+C lần nữa để thoát, hoặc nhập tin nhắn.',
 }

--- a/cli/src/ai/i18n/messages/zh.ts
+++ b/cli/src/ai/i18n/messages/zh.ts
@@ -115,4 +115,113 @@ export const messages: Record<string, string> = {
     '专注于 RPC / gRPC 节点运维。可询问端点配置、健康或调优。',
   'Mixed focus — validator + app / rpc. Use /focus <validator|rpc|app> to narrow.':
     '混合焦点 — validator + app / rpc。使用 `/focus <validator|rpc|app>` 进行细分。',
+
+  '👂 Understanding your request…': '👂 正在理解您的请求…',
+  'Understanding your request...': '正在理解您的请求...',
+  '🎓 Intent detected: {intent}': '🎓 已识别意图: {intent}',
+  '🧰 Enabling tools: {tools}': '🧰 正在启用工具: {tools}',
+  '📚 Loading context: {modules}': '📚 正在加载上下文: {modules}',
+  '🤖 Loading specialist: {specialist}': '🤖 正在加载专家: {specialist}',
+  '📚 Loading {context}…': '📚 正在加载{context}…',
+
+  'general conversation': '一般对话',
+  'server availability': '服务器可用性',
+  'server procurement': '服务器采购',
+  'account or billing': '账户或账单',
+  'validator deployment': '验证者部署',
+  'validator operations': '验证者运维',
+  'RPC deployment': 'RPC 部署',
+  'RPC operations': 'RPC 运维',
+  'benchmark or connectivity testing': '基准测试或连通性测试',
+  'app or bot development': '应用或机器人开发',
+  'CLI or file operation': 'CLI 或文件操作',
+  'needs clarification': '需要澄清',
+
+  'account availability': '账户信息',
+  'testnet validator inventory': 'testnet 验证者清单',
+  'mainnet validator inventory': 'mainnet 验证者清单',
+  'mainnet RPC inventory': 'mainnet RPC 清单',
+
+  'Saving session memory...': '正在保存会话记忆...',
+  'Conversation cleared.': '会话已清空。',
+  '✅ versions.yml updated successfully!': '✅ versions.yml 更新成功！',
+  'No pending updates.': '没有待应用的更新。',
+
+  '/exit, /quit — Exit': '/exit, /quit — 退出',
+  '/clear — Clear conversation': '/clear — 清空会话',
+  '/update — Apply pending version updates': '/update — 应用待处理的版本更新',
+  "/focus <validator|rpc|app|mixed|auto> — Switch or reset the main agent's primary focus":
+    '/focus <validator|rpc|app|mixed|auto> — 切换或重置主代理的主要焦点',
+  '/<command> — Execute shell command directly (e.g. /slv ai usage)':
+    '/<command> — 直接执行 shell 命令（例如 /slv ai usage）',
+  '/help — Show this help': '/help — 显示本帮助',
+
+  'Current focus: {focus} (manual override)': '当前焦点: {focus}（手动覆盖）',
+  'Current focus: {focus} (auto)': '当前焦点: {focus}（自动）',
+  '⚠ Could not detect current focus: {error}':
+    '⚠ 无法检测当前焦点: {error}',
+  'Usage: /focus validator | rpc | app | mixed | auto':
+    '用法: /focus validator | rpc | app | mixed | auto',
+  '◇ Focus override cleared.': '◇ 已清除焦点覆盖。',
+  '⚠ Failed to clear focus override: {error}': '⚠ 清除焦点覆盖失败: {error}',
+  '◇ Focus set to: {focus}': '◇ 焦点已设置为: {focus}',
+  '⚠ Failed to set focus: {error}': '⚠ 设置焦点失败: {error}',
+  'Unknown focus "{focus}". Use: validator | rpc | app | mixed | auto':
+    '未知焦点 "{focus}"。请使用: validator | rpc | app | mixed | auto',
+  '⚠ Profile refresh failed: {error}': '⚠ 配置刷新失败: {error}',
+
+  '⏳ {agent} is still working ({elapsed} elapsed).':
+    '⏳ {agent} 仍在工作中（已耗时 {elapsed}）。',
+  ' Validator deployment can take 20-40 minutes — building Solana, downloading snapshots, and configuring the node.':
+    ' 验证者部署可能需要 20-40 分钟 — 构建 Solana、下载快照以及配置节点。',
+  ' RPC deployment can take 30-60 minutes — building Solana, syncing with the cluster.':
+    ' RPC 部署可能需要 30-60 分钟 — 构建 Solana 并与集群同步。',
+  ' Benchmark and connectivity checks usually finish faster, but larger throughput tests can still take a few minutes.':
+    ' 基准测试与连通性检查通常很快完成，但较大的吞吐测试仍可能需要数分钟。',
+  ' Checking server availability and preparing your options.':
+    ' 正在检查服务器可用性并准备候选方案。',
+  " I'll let you know as soon as it's done!": ' 完成后我会立即通知您！',
+  'The system': '系统',
+  'a moment': '片刻',
+
+  '⚠️  Missing dependencies: {deps}': '⚠️  缺少依赖: {deps}',
+  'Install now? (Y/n) ': '现在安装? (Y/n) ',
+  'Skipping installation. Some features may not work.':
+    '已跳过安装。部分功能可能无法使用。',
+  'Installing ansible-core...': '正在安装 ansible-core...',
+  'Installing python3-pip...': '正在安装 python3-pip...',
+  '✗ Could not install python3-pip. Please install manually: sudo apt-get install -y python3-pip':
+    '✗ 无法安装 python3-pip。请手动安装: sudo apt-get install -y python3-pip',
+  '✓ ansible-core installed': '✓ ansible-core 安装完成',
+  'Installing solana-cli (agave)...': '正在安装 solana-cli (agave)...',
+  '✓ solana-cli installed': '✓ solana-cli 安装完成',
+
+  'SLV API Key not found. Run `slv login` first.':
+    '未找到 SLV API 密钥。请先运行 `slv login`。',
+  'Checking for new versions…': '正在检查新版本…',
+  '🔄 New versions available:': '🔄 有新版本可用:',
+  'Type /update to apply, or ignore to keep current versions.':
+    '输入 /update 应用更新，或忽略以保持当前版本。',
+
+  '⚡ Running command': '⚡ 执行命令',
+  '📄 Reading file': '📄 读取文件',
+  '📝 Writing file': '📝 写入文件',
+  '📂 Listing files': '📂 列出文件',
+  '🔗 Calling SLV Cloud API': '🔗 调用 SLV Cloud API',
+  'inspect or operate the local/remote SLV environment':
+    '检查或操作本地 / 远程 SLV 环境',
+  'inspect focused local SLV files': '检查相关本地 SLV 文件',
+  'check subscriptions or fetch SLV Cloud data':
+    '检查订阅或获取 SLV Cloud 数据',
+  'save configuration or update memory': '保存配置或更新记忆',
+  'inspect available files before acting': '操作前检查可用文件',
+  'notify you when a long task finishes': '在长任务完成时通知您',
+  'hand work to a specialist agent': '移交工作给专家代理',
+
+  '(exit code {code})': '(退出码 {code})',
+  'Error: {message}': '错误: {message}',
+
+  'Force exit.': '强制退出。',
+  '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
+    '⚠️ 已中断。再次按 Ctrl+C 退出，或输入消息。',
 }


### PR DESCRIPTION
## Summary
- Wrap every hardcoded English string shown by `slv c` with `t()` so the console follows the `api.yml` `lang:` setting (same path `slv onboard` already uses)
- Added built-in translations for ja / zh / ru / vi; non-builtin langs fall through to the existing SLV AI auto-translate → `~/.slv/i18n/{lang}.json` cache
- Covers: post-input stages (`👂 Understanding your request…`, `🎓 Intent detected`, `🧰 Enabling tools`, `📚 Loading context / specialist`), loader text, `/help` / `/focus` / `/clear` / `/update`, side-chat "still working" status, dep install flow, startup API-key guard, version-check banner, tool call labels (`⚡` / `📄` / `📝` / `📂` / `🔗` + `enable_tools` reason strings), shell-exec error / exit-code output, Ctrl+C handler

Left intentionally untranslated: provider names (`OpenAI` / `SLV AI` / `Anthropic`), `⚡ $ <cmd>` shell prompt marker, upstream provider error payloads.

## Test plan
- [ ] Set `lang: ja` in `~/.slv/api.yml`, run `slv c`, send a message — verify `👂 ご依頼内容を確認しています…` etc.
- [ ] Flip `lang: en` — verify English still renders
- [ ] Try a non-builtin lang (e.g. `lang: ko`) with an SLV API key — verify auto-translate writes `~/.slv/i18n/ko.json`
- [ ] Exercise `/help`, `/focus`, `/clear`, `/update`, Ctrl+C — all messages should be localized
- [ ] Trigger a missing-dep path (e.g. uninstall ansible) — install prompts should be localized
- [ ] `deno check` passes on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)