### PR TITLE
feat(bot): add `slv bot build` + localhost-aware lifecycle commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ build
 !tsconfig.json
 !package.json
 !.eslintrc.json
+!cli/src/bot/build/
+!cli/src/bot/build/**
 
 .log
 .logs

--- a/cli/src/bot/build/buildAction.ts
+++ b/cli/src/bot/build/buildAction.ts
@@ -1,0 +1,224 @@
+import { Input, prompt } from '@cliffy/prompt'
+import { colors } from '@cliffy/colors'
+import { loadBotConfig, saveBotConfig } from '/src/bot/botConfig.ts'
+import type { BotConfig } from '@cmn/zod/bot.ts'
+import { renderSystemdUnit, validateAppName } from '/src/bot/systemdUnit.ts'
+
+const errToString = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e)
+
+const resolveAppName = async (provided?: string): Promise<string | null> => {
+  if (provided) {
+    const err = validateAppName(provided)
+    if (err) {
+      console.log(colors.red(`❌ ${err}`))
+      return null
+    }
+    return provided
+  }
+  const { appName } = await prompt([
+    {
+      name: 'appName',
+      message: '🤖 Enter bot app name',
+      type: Input,
+      validate: (v: string) => validateAppName(v) ?? true,
+    },
+  ])
+  return appName ?? null
+}
+
+const resolveLocalPath = async (
+  appName: string,
+  provided?: string,
+): Promise<string | null> => {
+  if (provided) return provided
+  const homeDir = Deno.env.get('HOME') ?? '.'
+  const { localPath } = await prompt([
+    {
+      name: 'localPath',
+      message: '📁 Local Rust project path',
+      type: Input,
+      default: `${homeDir}/slv/${appName}`,
+    },
+  ])
+  return localPath ?? null
+}
+
+const installSystemdUnit = async (
+  serviceName: string,
+  unitContent: string,
+): Promise<boolean> => {
+  const unitPath = `/etc/systemd/system/${serviceName}.service`
+  try {
+    const st = await Deno.stat(unitPath)
+    if (st.isFile) {
+      console.log(
+        colors.cyan(
+          `ℹ️ Systemd unit already exists at ${unitPath} — keeping it`,
+        ),
+      )
+      return true
+    }
+  } catch { /* missing — install below */ }
+
+  console.log(colors.cyan(`⚙️ Installing systemd unit at ${unitPath} ...`))
+
+  // Refresh the sudo credential cache once so mv/daemon-reload/enable below
+  // don't each trigger their own password prompt.
+  const primeSudo = new Deno.Command('sudo', {
+    args: ['-v'],
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  const primed = await primeSudo.output()
+  if (!primed.success) {
+    console.log(colors.red('❌ sudo authentication failed'))
+    return false
+  }
+
+  const tmpPath = await Deno.makeTempFile({ suffix: '.service' })
+  try {
+    await Deno.writeTextFile(tmpPath, unitContent)
+    const mv = new Deno.Command('sudo', {
+      args: ['mv', tmpPath, unitPath],
+      stdout: 'piped',
+      stderr: 'piped',
+    })
+    const mvOut = await mv.output()
+    if (!mvOut.success) {
+      const err = new TextDecoder().decode(mvOut.stderr).trim()
+      console.log(colors.red('❌ Failed to install systemd unit'))
+      if (err) console.log(colors.yellow(err))
+      return false
+    }
+  } catch (err) {
+    console.log(
+      colors.red(`❌ Failed to create systemd unit: ${errToString(err)}`),
+    )
+    return false
+  } finally {
+    await Deno.remove(tmpPath).catch(() => {})
+  }
+
+  const reload = new Deno.Command('sudo', {
+    args: ['systemctl', 'daemon-reload'],
+    stdout: 'piped',
+    stderr: 'piped',
+  })
+  const reloadOut = await reload.output()
+  if (!reloadOut.success) {
+    const err = new TextDecoder().decode(reloadOut.stderr).trim()
+    console.log(colors.red('❌ systemctl daemon-reload failed'))
+    if (err) console.log(colors.yellow(err))
+    return false
+  }
+
+  const enable = new Deno.Command('sudo', {
+    args: ['systemctl', 'enable', serviceName],
+    stdout: 'piped',
+    stderr: 'piped',
+  })
+  const enableOut = await enable.output()
+  if (!enableOut.success) {
+    const err = new TextDecoder().decode(enableOut.stderr).trim()
+    console.log(colors.red('❌ systemctl enable failed'))
+    if (err) console.log(colors.yellow(err))
+    return false
+  }
+
+  console.log(colors.green('✅ Systemd unit installed'))
+  return true
+}
+
+const buildAction = async (
+  options: { name?: string; path?: string },
+): Promise<boolean> => {
+  const appName = await resolveAppName(options.name)
+  if (!appName) {
+    console.log(colors.red('❌ App name is required'))
+    return false
+  }
+
+  const localPath = await resolveLocalPath(appName, options.path)
+  if (!localPath) {
+    console.log(colors.red('❌ Local project path is required'))
+    return false
+  }
+
+  console.log(
+    colors.cyan(`\n🔨 Building (cargo build --release) in ${localPath} ...`),
+  )
+  const buildCmd = new Deno.Command('cargo', {
+    args: ['build', '--release'],
+    cwd: localPath,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  const buildOut = await buildCmd.output()
+  if (!buildOut.success) {
+    console.log(colors.red('❌ Build failed'))
+    return false
+  }
+  console.log(colors.green('✅ Build succeeded'))
+
+  // cargo exits 0 only if the declared bin built; this check catches the case
+  // where Cargo.toml's package/[[bin]] name diverges from appName.
+  const binaryPath = `${localPath}/target/release/${appName}`
+  try {
+    await Deno.stat(binaryPath)
+  } catch {
+    console.log(colors.red(`❌ Built binary not found at ${binaryPath}`))
+    console.log(
+      colors.white(
+        `   (check Cargo.toml — the binary name must match the app name)`,
+      ),
+    )
+    return false
+  }
+
+  const existing = await loadBotConfig(appName)
+  const username = existing?.username ?? Deno.env.get('USER') ?? 'solv'
+  const config: BotConfig = {
+    ...existing,
+    name: appName,
+    ip: 'localhost',
+    username,
+    sshKeyPath: existing?.sshKeyPath ?? '',
+    binaryName: appName,
+    remotePath: localPath,
+    serviceName: existing?.serviceName ?? `slv-${appName}`,
+    localProjectPath: localPath,
+    deployedAt: new Date().toISOString(),
+  }
+
+  if (Deno.build.os !== 'linux') {
+    console.log(
+      colors.yellow(
+        `⚠️ Host is ${Deno.build.os}; skipping systemd unit creation.`,
+      ),
+    )
+    console.log(colors.white(`   Binary: ${binaryPath}`))
+    await saveBotConfig(config)
+    console.log(colors.green(`\n✅ Config saved (${config.name})`))
+    return true
+  }
+
+  const unitContent = renderSystemdUnit({
+    name: appName,
+    username,
+    workDir: localPath,
+    execStart: binaryPath,
+  })
+  const ok = await installSystemdUnit(config.serviceName, unitContent)
+  if (!ok) return false
+
+  await saveBotConfig(config)
+  console.log(
+    colors.green(
+      `\n🎉 Build complete. Run: slv bot start -n ${config.name}`,
+    ),
+  )
+  return true
+}
+
+export { buildAction }

--- a/cli/src/bot/deploy/deployAction.ts
+++ b/cli/src/bot/deploy/deployAction.ts
@@ -9,26 +9,15 @@ import {
   shellQuote,
   sshExec,
 } from '/src/bot/sshUtil.ts'
+import { renderSystemdUnit } from '/src/bot/systemdUnit.ts'
 
-const SYSTEMD_UNIT_TEMPLATE = (config: BotConfig) =>
-  `[Unit]
-Description=SLV Bot - ${config.name}
-After=network.target
-
-[Service]
-Type=simple
-User=${config.username}
-WorkingDirectory=${config.remotePath}
-ExecStart=${config.remotePath}/${config.binaryName}
-Restart=on-failure
-RestartSec=5
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=slv-${config.name}
-
-[Install]
-WantedBy=multi-user.target
-`
+const unitForConfig = (config: BotConfig): string =>
+  renderSystemdUnit({
+    name: config.name,
+    username: config.username,
+    workDir: config.remotePath,
+    execStart: `${config.remotePath}/${config.binaryName}`,
+  })
 
 const deployAction = async (options: { name?: string; localhost?: boolean }) => {
   // 1. App name
@@ -180,7 +169,7 @@ const deployAction = async (options: { name?: string; localhost?: boolean }) => 
 
     // 9. Create systemd unit via temp file + sudo mv
     console.log(colors.cyan('⚙️ Creating systemd service...'))
-    const unitContent = SYSTEMD_UNIT_TEMPLATE(config)
+    const unitContent = unitForConfig(config)
     const tmpPath = await Deno.makeTempFile({ suffix: '.service' })
     try {
       await Deno.writeTextFile(tmpPath, unitContent)
@@ -266,7 +255,7 @@ const deployAction = async (options: { name?: string; localhost?: boolean }) => 
 
     // 9. Create systemd unit via temp file + SCP
     console.log(colors.cyan('⚙️ Creating systemd service...'))
-    const unitContent = SYSTEMD_UNIT_TEMPLATE(config)
+    const unitContent = unitForConfig(config)
     const tmpLocal = await Deno.makeTempFile({ suffix: '.service' })
     try {
       await Deno.writeTextFile(tmpLocal, unitContent)

--- a/cli/src/bot/execUtil.ts
+++ b/cli/src/bot/execUtil.ts
@@ -1,0 +1,94 @@
+import { colors } from '@cliffy/colors'
+import type { BotConfig } from '@cmn/zod/bot.ts'
+import {
+  buildRemoteCmd,
+  sshExec,
+  testSSHConnection,
+} from '/src/bot/sshUtil.ts'
+
+export type ExecResult = {
+  success: boolean
+  stdout: string
+  stderr: string
+  code: number
+}
+
+export const isLocalhost = (config: Pick<BotConfig, 'ip'>): boolean =>
+  config.ip === 'localhost'
+
+export const localExec = async (
+  cmd: string,
+  args: string[],
+): Promise<ExecResult> => {
+  const c = new Deno.Command(cmd, {
+    args,
+    stdout: 'piped',
+    stderr: 'piped',
+  })
+  const out = await c.output()
+  const decoder = new TextDecoder()
+  return {
+    success: out.success,
+    stdout: decoder.decode(out.stdout),
+    stderr: decoder.decode(out.stderr),
+    code: out.code,
+  }
+}
+
+export const runSystemctl = async (
+  config: BotConfig,
+  ...args: string[]
+): Promise<ExecResult> => {
+  if (isLocalhost(config)) {
+    return localExec('sudo', ['systemctl', ...args])
+  }
+  return sshExec(config, buildRemoteCmd('sudo', 'systemctl', ...args))
+}
+
+// `systemctl status` does not require sudo and is kept separate so the remote
+// branch matches prior non-sudo behavior.
+export const runSystemctlStatus = async (
+  config: BotConfig,
+): Promise<ExecResult> => {
+  if (isLocalhost(config)) {
+    return localExec('systemctl', ['status', config.serviceName])
+  }
+  return sshExec(
+    config,
+    buildRemoteCmd('systemctl', 'status', config.serviceName),
+  )
+}
+
+export const runJournalctl = async (
+  config: BotConfig,
+  lines: number,
+): Promise<ExecResult> => {
+  const args = [
+    '-u',
+    config.serviceName,
+    '-n',
+    String(lines),
+    '--no-pager',
+  ]
+  if (isLocalhost(config)) {
+    return localExec('journalctl', args)
+  }
+  return sshExec(config, buildRemoteCmd('journalctl', ...args))
+}
+
+// Skip SSH liveness probe when local; otherwise fail fast with a friendly
+// message before running the real command.
+export const ensureConnectivity = async (
+  config: BotConfig,
+): Promise<boolean> => {
+  if (isLocalhost(config)) return true
+  const ok = await testSSHConnection(config)
+  if (!ok) {
+    console.log(
+      colors.red(
+        `❌ SSH connection failed to ${config.username}@${config.ip}`,
+      ),
+    )
+  }
+  return ok
+}

--- a/cli/src/bot/index.ts
+++ b/cli/src/bot/index.ts
@@ -1,6 +1,7 @@
 import { Command } from '@cliffy'
 import { initBotTemplate } from '/src/bot/init/initBotTemplate.ts'
 import { deployAction } from '/src/bot/deploy/deployAction.ts'
+import { buildAction } from '/src/bot/build/buildAction.ts'
 import { startAction } from '/src/bot/start/startAction.ts'
 import { stopAction } from '/src/bot/stop/stopAction.ts'
 import { restartAction } from '/src/bot/restart/restartAction.ts'
@@ -41,6 +42,17 @@ botCmd.command('deploy')
   })
   .action(async (options: { name?: string; localhost?: boolean }) => {
     await deployAction(options)
+  })
+
+// bot build subcommand
+botCmd.command('build')
+  .description(
+    'Build Rust bot binary locally and (on Linux) install a systemd service',
+  )
+  .option('-n, --name <name:string>', 'Bot app name')
+  .option('-p, --path <path:string>', 'Local Rust project path')
+  .action(async (options: { name?: string; path?: string }) => {
+    await buildAction(options)
   })
 
 // bot start subcommand

--- a/cli/src/bot/log/logAction.ts
+++ b/cli/src/bot/log/logAction.ts
@@ -1,6 +1,6 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
-import { shellQuote, sshExec, testSSHConnection } from '/src/bot/sshUtil.ts'
+import { ensureConnectivity, runJournalctl } from '/src/bot/execUtil.ts'
 
 const logAction = async (options: { name?: string; lines?: number }) => {
   const config = await selectBot(options.name)
@@ -11,21 +11,9 @@ const logAction = async (options: { name?: string; lines?: number }) => {
     colors.cyan(`📜 Fetching logs: ${config.name} (last ${lines} lines)...`),
   )
 
-  // Test SSH connectivity first
-  const connected = await testSSHConnection(config)
-  if (!connected) {
-    console.log(
-      colors.red(
-        `❌ SSH connection failed to ${config.username}@${config.ip}`,
-      ),
-    )
-    return false
-  }
+  if (!(await ensureConnectivity(config))) return false
 
-  const result = await sshExec(
-    config,
-    `journalctl -u ${shellQuote(config.serviceName)} -n ${shellQuote(String(lines))} --no-pager`,
-  )
+  const result = await runJournalctl(config, lines)
 
   // journalctl may return non-zero if the unit has no logs yet — show output regardless
   const output = result.stdout || result.stderr

--- a/cli/src/bot/restart/restartAction.ts
+++ b/cli/src/bot/restart/restartAction.ts
@@ -1,16 +1,13 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
-import { buildRemoteCmd, sshExec } from '/src/bot/sshUtil.ts'
+import { runSystemctl } from '/src/bot/execUtil.ts'
 
 const restartAction = async (options: { name?: string }) => {
   const config = await selectBot(options.name)
   if (!config) return false
 
   console.log(colors.cyan(`🔄 Restarting bot: ${config.name}...`))
-  const result = await sshExec(
-    config,
-    buildRemoteCmd('sudo', 'systemctl', 'restart', config.serviceName),
-  )
+  const result = await runSystemctl(config, 'restart', config.serviceName)
   if (!result.success) {
     console.log(colors.red(`❌ Failed to restart ${config.name}`))
     if (result.stderr) console.log(colors.yellow(result.stderr))

--- a/cli/src/bot/start/startAction.ts
+++ b/cli/src/bot/start/startAction.ts
@@ -1,16 +1,13 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
-import { buildRemoteCmd, sshExec } from '/src/bot/sshUtil.ts'
+import { runSystemctl } from '/src/bot/execUtil.ts'
 
 const startAction = async (options: { name?: string }) => {
   const config = await selectBot(options.name)
   if (!config) return false
 
   console.log(colors.cyan(`🚀 Starting bot: ${config.name}...`))
-  const result = await sshExec(
-    config,
-    buildRemoteCmd('sudo', 'systemctl', 'start', config.serviceName),
-  )
+  const result = await runSystemctl(config, 'start', config.serviceName)
   if (!result.success) {
     console.log(colors.red(`❌ Failed to start ${config.name}`))
     if (result.stderr) console.log(colors.yellow(result.stderr))

--- a/cli/src/bot/status/statusAction.ts
+++ b/cli/src/bot/status/statusAction.ts
@@ -1,6 +1,6 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
-import { buildRemoteCmd, sshExec, testSSHConnection } from '/src/bot/sshUtil.ts'
+import { ensureConnectivity, runSystemctlStatus } from '/src/bot/execUtil.ts'
 
 const statusAction = async (options: { name?: string }) => {
   const config = await selectBot(options.name)
@@ -8,21 +8,9 @@ const statusAction = async (options: { name?: string }) => {
 
   console.log(colors.cyan(`📊 Checking status: ${config.name}...`))
 
-  // Test SSH connectivity first
-  const connected = await testSSHConnection(config)
-  if (!connected) {
-    console.log(
-      colors.red(
-        `❌ SSH connection failed to ${config.username}@${config.ip}`,
-      ),
-    )
-    return false
-  }
+  if (!(await ensureConnectivity(config))) return false
 
-  const result = await sshExec(
-    config,
-    buildRemoteCmd('systemctl', 'status', config.serviceName),
-  )
+  const result = await runSystemctlStatus(config)
 
   // systemctl status returns non-zero for inactive/dead services — that's not an error
   const output = result.stdout || result.stderr

--- a/cli/src/bot/stop/stopAction.ts
+++ b/cli/src/bot/stop/stopAction.ts
@@ -1,16 +1,13 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
-import { buildRemoteCmd, sshExec } from '/src/bot/sshUtil.ts'
+import { runSystemctl } from '/src/bot/execUtil.ts'
 
 const stopAction = async (options: { name?: string }) => {
   const config = await selectBot(options.name)
   if (!config) return false
 
   console.log(colors.cyan(`🛑 Stopping bot: ${config.name}...`))
-  const result = await sshExec(
-    config,
-    buildRemoteCmd('sudo', 'systemctl', 'stop', config.serviceName),
-  )
+  const result = await runSystemctl(config, 'stop', config.serviceName)
   if (!result.success) {
     console.log(colors.red(`❌ Failed to stop ${config.name}`))
     if (result.stderr) console.log(colors.yellow(result.stderr))

--- a/cli/src/bot/systemdUnit.ts
+++ b/cli/src/bot/systemdUnit.ts
@@ -1,0 +1,40 @@
+export type SystemdUnitInput = {
+  name: string
+  username: string
+  workDir: string
+  execStart: string
+}
+
+export const renderSystemdUnit = (u: SystemdUnitInput): string =>
+  `[Unit]
+Description=SLV Bot - ${u.name}
+After=network.target
+
+[Service]
+Type=simple
+User=${u.username}
+WorkingDirectory=${u.workDir}
+ExecStart=${u.execStart}
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=slv-${u.name}
+
+[Install]
+WantedBy=multi-user.target
+`
+
+// Matches the rule enforced by `slv bot init`. Keep in sync with
+// cli/src/bot/init/initBotTemplate.ts. `appName` flows into a privileged
+// systemd unit path via `sudo mv`, so rejecting shell metacharacters and
+// path separators here is a security boundary, not cosmetic.
+const APP_NAME_RE = /^[a-zA-Z0-9-_]+$/
+
+export const validateAppName = (name: string): string | null => {
+  if (!name.trim()) return 'App name cannot be empty'
+  if (!APP_NAME_RE.test(name)) {
+    return 'App name can only contain letters, numbers, hyphens, and underscores'
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

- Adds `slv bot build` — runs `cargo build --release` locally and, on Linux, installs a systemd unit (idempotent: existing unit is kept untouched) with `ExecStart` pointed at the built binary. Non-Linux hosts just save config and skip systemd.
- Makes `start` / `stop` / `restart` / `status` / `log` localhost-aware via a new `cli/src/bot/execUtil.ts` dispatcher (`ip === 'localhost'` → `Deno.Command`, otherwise SSH). Previously those always went through SSH, so the localhost deploy path couldn't be driven by the lifecycle commands.
- Extracts the systemd unit template + `appName` validator to `cli/src/bot/systemdUnit.ts`, reused by `deploy` and `build`.
- Validates `appName` with the same regex `slv bot init` uses before it flows into a root-privileged `sudo mv` path.
- `sudo -v` primes the credential cache so build's three-step install doesn't re-prompt for the password.
- Respects `-n` / `-p` to skip prompts (scriptable).
- Carves out `cli/src/bot/build/` in `.gitignore` so the new source dir isn't swallowed by the repo-wide `build` rule.

## Test plan

- [ ] `slv bot build --help` shows the new subcommand
- [ ] On macOS: `slv bot build -n foo -p ~/slv/foo` builds, warns about non-Linux, saves config
- [ ] On Linux: first run installs `/etc/systemd/system/slv-foo.service`; second run is a no-op
- [ ] `slv bot start -n foo` / `stop` / `restart` / `status` / `log` all work against the locally-built bot
- [ ] Pre-existing remote-deploy flow (`slv bot deploy`) still builds, uploads, and starts via SSH
- [ ] `slv bot build -n "../evil"` rejects the name before touching any sudo path

🤖 Generated with [Claude Code](https://claude.com/claude-code)