### PR TITLE
feat(bot): run bots under nohup/pidfile on macOS (no systemd)

### DIFF
--- a/cli/src/bot/localProc.ts
+++ b/cli/src/bot/localProc.ts
@@ -1,0 +1,176 @@
+import { join } from '@std/path'
+import { configRoot } from '@cmn/constants/path.ts'
+import type { BotConfig } from '@cmn/zod/bot.ts'
+
+// Non-Linux localhost backend: the binary is started in the background via
+// `nohup`, its PID is written to <configRoot>/bot/runtime/<name>.pid, and
+// stdout/stderr are appended to <configRoot>/bot/runtime/<name>.log.
+// Used on macOS because there is no systemd; Linux still uses systemd.
+
+const runtimeDir = (): string => join(configRoot, 'bot', 'runtime')
+export const pidPath = (name: string): string =>
+  join(runtimeDir(), `${name}.pid`)
+export const logPath = (name: string): string =>
+  join(runtimeDir(), `${name}.log`)
+
+export const isLocalNonSystemd = (
+  config: Pick<BotConfig, 'ip'>,
+): boolean => config.ip === 'localhost' && Deno.build.os !== 'linux'
+
+export const readPid = async (name: string): Promise<number | null> => {
+  try {
+    const raw = (await Deno.readTextFile(pidPath(name))).trim()
+    const n = Number(raw)
+    return Number.isFinite(n) && n > 0 ? n : null
+  } catch {
+    return null
+  }
+}
+
+// Probe whether a PID is alive. SIGCONT is harmless on running processes
+// (kernel resumes stopped ones, no-op on running ones). If the process has
+// exited, Deno.kill throws NotFound.
+export const isAlive = (pid: number): boolean => {
+  try {
+    Deno.kill(pid, 'SIGCONT')
+    return true
+  } catch {
+    return false
+  }
+}
+
+const errToString = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e)
+
+export type StartResult =
+  | { ok: true; pid: number }
+  | { ok: false; err: string }
+
+export const startLocalProc = async (
+  config: BotConfig,
+): Promise<StartResult> => {
+  await Deno.mkdir(runtimeDir(), { recursive: true })
+
+  const existing = await readPid(config.name)
+  if (existing && isAlive(existing)) {
+    return { ok: false, err: `already running (pid=${existing})` }
+  }
+  if (existing) {
+    // Stale pidfile from a prior crash — clean up before relaunch.
+    await Deno.remove(pidPath(config.name)).catch(() => {})
+  }
+
+  const binary =
+    `${config.localProjectPath}/target/release/${config.binaryName}`
+  try {
+    const st = await Deno.stat(binary)
+    if (!st.isFile) throw new Error('not a file')
+  } catch {
+    return { ok: false, err: `binary not found: ${binary}` }
+  }
+
+  // `sh -c '…' _ "$1" "$2"` passes paths as positional parameters so they
+  // aren't re-parsed by the shell (no injection via paths containing $ or `).
+  // $! is the PID of the just-backgrounded process, which nohup exec's into
+  // so it stays the PID of the bot binary itself.
+  const script = 'nohup "$1" >> "$2" 2>&1 & echo $!'
+  const cmd = new Deno.Command('sh', {
+    args: ['-c', script, '_', binary, logPath(config.name)],
+    cwd: config.localProjectPath,
+    stdout: 'piped',
+    stderr: 'piped',
+  })
+  const out = await cmd.output()
+  if (!out.success) {
+    return {
+      ok: false,
+      err: new TextDecoder().decode(out.stderr).trim() ||
+        'spawn failed',
+    }
+  }
+  const pid = Number(new TextDecoder().decode(out.stdout).trim())
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return { ok: false, err: 'failed to capture pid' }
+  }
+
+  try {
+    await Deno.writeTextFile(pidPath(config.name), String(pid))
+  } catch (e) {
+    // Pid wasn't recorded — try to stop what we just started so the caller
+    // doesn't leak an unmanaged process.
+    try {
+      Deno.kill(pid, 'SIGTERM')
+    } catch { /* best-effort */ }
+    return { ok: false, err: `failed to write pidfile: ${errToString(e)}` }
+  }
+
+  return { ok: true, pid }
+}
+
+export type StopResult =
+  | { ok: true; pid: number }
+  | { ok: false; err: string }
+
+export const stopLocalProc = async (
+  config: BotConfig,
+): Promise<StopResult> => {
+  const pid = await readPid(config.name)
+  if (pid === null) return { ok: false, err: 'not running (no pidfile)' }
+  if (!isAlive(pid)) {
+    await Deno.remove(pidPath(config.name)).catch(() => {})
+    return { ok: false, err: `stale pidfile (pid=${pid} not alive) — removed` }
+  }
+
+  try {
+    Deno.kill(pid, 'SIGTERM')
+  } catch (e) {
+    return { ok: false, err: errToString(e) }
+  }
+
+  // Give the bot up to ~5 s to exit cleanly, then escalate to SIGKILL.
+  for (let i = 0; i < 10; i++) {
+    await new Promise((r) => setTimeout(r, 500))
+    if (!isAlive(pid)) break
+  }
+  if (isAlive(pid)) {
+    try {
+      Deno.kill(pid, 'SIGKILL')
+    } catch { /* already gone */ }
+  }
+  await Deno.remove(pidPath(config.name)).catch(() => {})
+  return { ok: true, pid }
+}
+
+export const statusLocalProc = async (config: BotConfig): Promise<string> => {
+  const pid = await readPid(config.name)
+  if (pid === null) {
+    return `● ${config.name}: stopped (no pidfile)\n  log: ${
+      logPath(config.name)
+    }`
+  }
+  const alive = isAlive(pid)
+  const label = alive ? 'active (running)' : 'inactive (stale pidfile)'
+  return `● ${config.name}: ${label}\n  pid: ${pid}\n  log: ${
+    logPath(config.name)
+  }`
+}
+
+export const tailLocalLog = async (
+  config: BotConfig,
+  lines: number,
+): Promise<string> => {
+  const log = logPath(config.name)
+  try {
+    const out = await new Deno.Command('tail', {
+      args: ['-n', String(lines), log],
+      stdout: 'piped',
+      stderr: 'piped',
+    }).output()
+    if (!out.success) {
+      return new TextDecoder().decode(out.stderr)
+    }
+    return new TextDecoder().decode(out.stdout)
+  } catch (e) {
+    return `failed to read log (${log}): ${errToString(e)}`
+  }
+}

--- a/cli/src/bot/log/logAction.ts
+++ b/cli/src/bot/log/logAction.ts
@@ -1,6 +1,7 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
 import { ensureConnectivity, runJournalctl } from '/src/bot/execUtil.ts'
+import { isLocalNonSystemd, tailLocalLog } from '/src/bot/localProc.ts'
 
 const logAction = async (options: { name?: string; lines?: number }) => {
   const config = await selectBot(options.name)
@@ -10,6 +11,12 @@ const logAction = async (options: { name?: string; lines?: number }) => {
   console.log(
     colors.cyan(`📜 Fetching logs: ${config.name} (last ${lines} lines)...`),
   )
+
+  if (isLocalNonSystemd(config)) {
+    const text = await tailLocalLog(config, lines)
+    if (text) console.log(text)
+    return true
+  }
 
   if (!(await ensureConnectivity(config))) return false
 

--- a/cli/src/bot/restart/restartAction.ts
+++ b/cli/src/bot/restart/restartAction.ts
@@ -1,12 +1,36 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
 import { runSystemctl } from '/src/bot/execUtil.ts'
+import {
+  isLocalNonSystemd,
+  startLocalProc,
+  stopLocalProc,
+} from '/src/bot/localProc.ts'
 
 const restartAction = async (options: { name?: string }) => {
   const config = await selectBot(options.name)
   if (!config) return false
 
   console.log(colors.cyan(`🔄 Restarting bot: ${config.name}...`))
+
+  if (isLocalNonSystemd(config)) {
+    // Best-effort stop: a missing pidfile is fine (treat as already stopped).
+    const stopped = await stopLocalProc(config)
+    if (!stopped.ok && !stopped.err.includes('no pidfile')) {
+      console.log(colors.yellow(`⚠️ stop: ${stopped.err}`))
+    }
+    const started = await startLocalProc(config)
+    if (!started.ok) {
+      console.log(colors.red(`❌ Failed to restart ${config.name}`))
+      console.log(colors.yellow(started.err))
+      return false
+    }
+    console.log(
+      colors.green(`✅ Bot "${config.name}" restarted (pid=${started.pid})`),
+    )
+    return true
+  }
+
   const result = await runSystemctl(config, 'restart', config.serviceName)
   if (!result.success) {
     console.log(colors.red(`❌ Failed to restart ${config.name}`))

--- a/cli/src/bot/start/startAction.ts
+++ b/cli/src/bot/start/startAction.ts
@@ -1,12 +1,27 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
 import { runSystemctl } from '/src/bot/execUtil.ts'
+import { isLocalNonSystemd, startLocalProc } from '/src/bot/localProc.ts'
 
 const startAction = async (options: { name?: string }) => {
   const config = await selectBot(options.name)
   if (!config) return false
 
   console.log(colors.cyan(`🚀 Starting bot: ${config.name}...`))
+
+  if (isLocalNonSystemd(config)) {
+    const r = await startLocalProc(config)
+    if (!r.ok) {
+      console.log(colors.red(`❌ Failed to start ${config.name}`))
+      console.log(colors.yellow(r.err))
+      return false
+    }
+    console.log(
+      colors.green(`✅ Bot "${config.name}" started (pid=${r.pid})`),
+    )
+    return true
+  }
+
   const result = await runSystemctl(config, 'start', config.serviceName)
   if (!result.success) {
     console.log(colors.red(`❌ Failed to start ${config.name}`))

--- a/cli/src/bot/status/statusAction.ts
+++ b/cli/src/bot/status/statusAction.ts
@@ -1,12 +1,18 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
 import { ensureConnectivity, runSystemctlStatus } from '/src/bot/execUtil.ts'
+import { isLocalNonSystemd, statusLocalProc } from '/src/bot/localProc.ts'
 
 const statusAction = async (options: { name?: string }) => {
   const config = await selectBot(options.name)
   if (!config) return false
 
   console.log(colors.cyan(`📊 Checking status: ${config.name}...`))
+
+  if (isLocalNonSystemd(config)) {
+    console.log(colors.white(await statusLocalProc(config)))
+    return true
+  }
 
   if (!(await ensureConnectivity(config))) return false
 

--- a/cli/src/bot/stop/stopAction.ts
+++ b/cli/src/bot/stop/stopAction.ts
@@ -1,12 +1,27 @@
 import { colors } from '@cliffy/colors'
 import { selectBot } from '/src/bot/selectBot.ts'
 import { runSystemctl } from '/src/bot/execUtil.ts'
+import { isLocalNonSystemd, stopLocalProc } from '/src/bot/localProc.ts'
 
 const stopAction = async (options: { name?: string }) => {
   const config = await selectBot(options.name)
   if (!config) return false
 
   console.log(colors.cyan(`🛑 Stopping bot: ${config.name}...`))
+
+  if (isLocalNonSystemd(config)) {
+    const r = await stopLocalProc(config)
+    if (!r.ok) {
+      console.log(colors.red(`❌ Failed to stop ${config.name}`))
+      console.log(colors.yellow(r.err))
+      return false
+    }
+    console.log(
+      colors.green(`✅ Bot "${config.name}" stopped (pid=${r.pid})`),
+    )
+    return true
+  }
+
   const result = await runSystemctl(config, 'stop', config.serviceName)
   if (!result.success) {
     console.log(colors.red(`❌ Failed to stop ${config.name}`))


### PR DESCRIPTION
## Summary

On macOS (and any non-Linux host) there is no `systemctl`, so the lifecycle commands introduced in #292 couldn't actually run a bot. This PR adds a PID-file backend that kicks in automatically when `config.ip === 'localhost'` AND `Deno.build.os !== 'linux'`:

- `slv bot start -n <name>` — launches the built binary via `nohup`, appends stdout+stderr to `~/.slv/bot/runtime/<name>.log`, captures the backgrounded PID from `$!`, and writes it to `~/.slv/bot/runtime/<name>.pid`. Refuses to start if a live PID is already recorded. Cleans up stale pidfiles from prior crashes.
- `slv bot stop -n <name>` — reads the pidfile, sends SIGTERM, waits up to 5 s for clean exit, escalates to SIGKILL, removes the pidfile.
- `slv bot restart -n <name>` — stop + start; tolerates a missing pidfile.
- `slv bot status -n <name>` — probes the PID via a harmless SIGCONT; reports `active (running)`, `inactive (stale pidfile)`, or `stopped (no pidfile)`.
- `slv bot log -n <name>` — tails the logfile with `tail -n <lines>`.

Linux hosts and remote SSH-deployed bots are untouched — they continue to use the systemd path from #292.

Path injection is handled by passing the binary/log paths as positional args to `sh -c` (never interpolated into the script string).

## Test plan

Smoke-tested locally on macOS with a dummy binary:

- [x] `slv bot start` spawns, writes pidfile, process is alive
- [x] `slv bot status` reports running pid
- [x] `slv bot log` shows recent output
- [x] `slv bot start` second time → already-running error
- [x] `slv bot restart` stops old pid and starts a new one
- [x] `slv bot stop` terminates and clears pidfile
- [x] `slv bot status` after stop → `stopped (no pidfile)`
- [x] `ps -p <old-pid>` confirms the process is actually gone
- [ ] On Linux: existing systemd path still works (unchanged code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)