### PR TITLE
docs(slv-app): refresh bot command reference for build + localhost lifecycle

### DIFF
--- a/dist/oss-skills/slv-app/SKILL.md
+++ b/dist/oss-skills/slv-app/SKILL.md
@@ -29,7 +29,7 @@ build on top of.
 | CLI | Action |
 |---|---|
 | `slv bot init -t <template> -n <name>` | Scaffold a bot/app project in `~/slv/<name>/` from the named template |
-| `slv bot build [-n <name>] [-p <path>]` | `cargo build --release` locally. On Linux, also install an idempotent systemd unit (`slv-<name>.service`) pointing `ExecStart` at the built binary; existing units are kept untouched. On macOS / non-Linux the systemd step is skipped |
+| `slv bot build [-n <name>] [-p <path>]` | Rust templates only (`trade-app`, `shreds-rust`, `geyser-rust`, `shreds-udp-rust`). Runs `cargo build --release` locally. On Linux, also installs an idempotent systemd unit (`slv-<name>.service`) pointing `ExecStart` at the built binary; existing units are kept untouched. On macOS / non-Linux the systemd step is skipped |
 | `slv bot deploy [-l\|--localhost] [-n <name>]` | Build + push to a VPS via SSH and install a systemd unit there. `-l` deploys to the current host instead (no SSH) |
 | `slv bot list` | List registered bots |
 | `slv bot start`, `slv bot stop`, `slv bot restart`, `slv bot status`, `slv bot log` | Lifecycle control. `log` accepts `-l/--lines <n>` (default 100) |
@@ -46,7 +46,7 @@ build on top of.
 
 ### Typical flows
 
-- **Dev on macOS**: `slv bot init` → `slv bot build -n <name>` → `slv bot start -n <name>` (runs under `nohup`; see logs in `~/.slv/bot/runtime/<name>.log`)
+- **Dev on macOS (Rust template)**: `slv bot init` → `slv bot build -n <name>` → `slv bot start -n <name>` (runs under `nohup`; see logs in `~/.slv/bot/runtime/<name>.log`). For TypeScript templates (`geyser-ts`, `shreds-ts`), skip `slv bot build` and run `pnpm dev` / the template's own script directly
 - **Prod on a VPS**: `slv bot init` → `slv bot deploy -n <name>` (SCP + systemd, `sudo` required on remote)
 - **Single-host Linux**: `slv bot init` → `slv bot deploy -l -n <name>` (no SSH; installs systemd locally)
 

--- a/dist/oss-skills/slv-app/SKILL.md
+++ b/dist/oss-skills/slv-app/SKILL.md
@@ -24,12 +24,33 @@ build on top of.
 
 ## `slv bot` CLI Commands
 
+`slv b` is an alias for `slv bot`.
+
 | CLI | Action |
 |---|---|
 | `slv bot init -t <template> -n <name>` | Scaffold a bot/app project in `~/slv/<name>/` from the named template |
-| `slv bot deploy` | Build and deploy the current project to a VPS via SSH + systemd |
-| `slv bot list` / `slv b` | List / switch between deployed bots |
-| `slv bot log`, `slv bot restart`, `slv bot start`, `slv bot status`, `slv bot stop` | Operate a deployed bot on its remote VPS |
+| `slv bot build [-n <name>] [-p <path>]` | `cargo build --release` locally. On Linux, also install an idempotent systemd unit (`slv-<name>.service`) pointing `ExecStart` at the built binary; existing units are kept untouched. On macOS / non-Linux the systemd step is skipped |
+| `slv bot deploy [-l\|--localhost] [-n <name>]` | Build + push to a VPS via SSH and install a systemd unit there. `-l` deploys to the current host instead (no SSH) |
+| `slv bot list` | List registered bots |
+| `slv bot start`, `slv bot stop`, `slv bot restart`, `slv bot status`, `slv bot log` | Lifecycle control. `log` accepts `-l/--lines <n>` (default 100) |
+
+### Lifecycle backend (auto-selected)
+
+`start` / `stop` / `restart` / `status` / `log` dispatch to the right backend based on where the bot lives, so the same command works everywhere:
+
+| Bot location | Host OS | Backend |
+|---|---|---|
+| Remote (`deploy`) | Linux | `ssh … sudo systemctl …` / `journalctl` |
+| Local (`deploy -l` or `build`) | Linux | Local `sudo systemctl …` / `journalctl` |
+| Local (`build`) | macOS / non-Linux | `nohup` + PID file under `~/.slv/bot/runtime/<name>.{pid,log}`; `stop` sends SIGTERM, waits ~5 s, escalates to SIGKILL |
+
+### Typical flows
+
+- **Dev on macOS**: `slv bot init` → `slv bot build -n <name>` → `slv bot start -n <name>` (runs under `nohup`; see logs in `~/.slv/bot/runtime/<name>.log`)
+- **Prod on a VPS**: `slv bot init` → `slv bot deploy -n <name>` (SCP + systemd, `sudo` required on remote)
+- **Single-host Linux**: `slv bot init` → `slv bot deploy -l -n <name>` (no SSH; installs systemd locally)
+
+Bot config (`~/.slv/bot/<name>.yml`) is written by both `build` and `deploy`. Once registered, every lifecycle command works with just `-n <name>`.
 
 ### `slv bot init` safety notes
 

--- a/dist/oss-skills/slv-bot-trade-app/SKILL.md
+++ b/dist/oss-skills/slv-bot-trade-app/SKILL.md
@@ -115,14 +115,16 @@ Builds, uploads via SCP, creates systemd service on the remote server.
 | `WEBHOOK_URL` | — | Discord Webhook URL. If `notifications.discord_webhook` exists in `~/.slv/api.yml`, reuse it automatically |
 | `REDIS_URL` | — | Redis URL for trade history. For non-engineer users, prefer installing Redis locally and configuring this automatically instead of asking up front |
 | `CONFIG_PATH` | `config.jsonc` | Geyser filter config file |
+| `TRADE_APP_LANG` | `en` | Output / log language for the bot (supported: `en`, `ja`, `ru`, `vi`, `zh`). When launched from `slv c`, this is automatically inherited from `lang` in `~/.slv/api.yml` (set during `slv onboard`) — no need to add it to `.env` |
 
 When setting up `.env`, prefer automatic configuration over user questions
 whenever possible. Reuse existing local configuration automatically when
 available: the SLV API key from `~/.slv/api.yml` for
-`https://edge.erpc.global?api-key=<API_KEY>` RPC defaults, and
-`notifications.discord_webhook` from `~/.slv/api.yml` for `WEBHOOK_URL`. For
-non-engineer users, prefer installing and wiring Redis automatically when
-local persistence is useful.
+`https://edge.erpc.global?api-key=<API_KEY>` RPC defaults,
+`notifications.discord_webhook` for `WEBHOOK_URL`, and `lang` (injected
+into `TRADE_APP_LANG` by `slv c` at spawn time). For non-engineer users,
+prefer installing and wiring Redis automatically when local persistence is
+useful.
 
 ## Trade Configuration (via API)
 


### PR DESCRIPTION
## Summary

`slv bot build` (PR #292) and the localhost-aware + macOS lifecycle commands (PR #293) landed but the `slv-app` skill was still pointing users at the old `deploy → remote-only systemd` flow. This PR aligns the skill with the current CLI spec.

## What changed in `SKILL.md`

- Added `slv bot build` to the command table (cargo build + idempotent systemd install on Linux, no-op systemd step on macOS).
- Added `-l / --localhost` to `slv bot deploy`.
- New subsection **Lifecycle backend (auto-selected)** spells out how `start/stop/restart/status/log` dispatches between:
  - remote SSH + `sudo systemctl` (`deploy` target)
  - local Linux `sudo systemctl` (`deploy -l` or `build` on Linux)
  - `nohup` + PID file under `~/.slv/bot/runtime/<name>.{pid,log}` (`build` on macOS)
- New **Typical flows** recipes for macOS dev, remote VPS, single-host Linux.
- Fixed a small error: `slv b` is an alias for `slv bot` (the subcommand root), not for `slv bot list`.

## Test plan

- [x] Entries match `cli/src/bot/index.ts` (options, defaults, descriptions)
- [x] Backend matrix matches `cli/src/bot/execUtil.ts` + `cli/src/bot/localProc.ts`
- [ ] Visual read-through on GitHub render

🤖 Generated with [Claude Code](https://claude.com/claude-code)