### PR TITLE
feat(ai): cancel in-flight LLM streams on Ctrl+C (Tier 3 Phase 1 part)

### DIFF
--- a/cli/lib/isAbortError.ts
+++ b/cli/lib/isAbortError.ts
@@ -1,0 +1,17 @@
+/**
+ * Recognize the various shapes of "stream was aborted via AbortSignal"
+ * thrown by Anthropic / OpenAI SDKs and Deno's own fetch / stream APIs.
+ * Matching on `.name === 'AbortError'` alone misses:
+ *   - Anthropic SDK's `APIUserAbortError` (different name)
+ *   - DOMException with code 20 (browser fetch)
+ *   - Generic TypeError with message 'The operation was aborted.'
+ */
+export const isAbortLikeError = (e: unknown): boolean => {
+  if (!e || typeof e !== 'object') return false
+  const err = e as { name?: string; message?: string; code?: unknown }
+  if (err.name === 'AbortError' || err.name === 'APIUserAbortError') return true
+  if (typeof err.message === 'string' && /aborted/i.test(err.message)) {
+    return true
+  }
+  return false
+}

--- a/cli/src/ai/console/providers/anthropic.ts
+++ b/cli/src/ai/console/providers/anthropic.ts
@@ -1,10 +1,12 @@
 import Anthropic from '@anthropic-ai/sdk'
 import {
   executeTool,
+  getAbortSignal,
   getActiveTools,
   shouldAbortAfterTools,
   type ToolDefinition,
 } from '@/ai/console/tools.ts'
+import { isAbortLikeError } from '/lib/isAbortError.ts'
 import { DEFAULT_MAX_TOKENS } from '@/ai/config.ts'
 import type { ChatCallbacks } from '@/ai/console/consoleAction.ts'
 import { getModuleContent } from '@/ai/console/systemPrompt.ts'
@@ -49,13 +51,18 @@ export class AnthropicProvider {
     this.messages.push({ role: 'user', content: userMessage })
 
     while (true) {
-      const stream = this.client.messages.stream({
-        model: this.model,
-        max_tokens: DEFAULT_MAX_TOKENS,
-        system: this.systemPrompt + getModuleContent(),
-        messages: this.messages,
-        tools: toAnthropicTools(getActiveTools()),
-      })
+      const stream = this.client.messages.stream(
+        {
+          model: this.model,
+          max_tokens: DEFAULT_MAX_TOKENS,
+          system: this.systemPrompt + getModuleContent(),
+          messages: this.messages,
+          tools: toAnthropicTools(getActiveTools()),
+        },
+        // Ctrl+C aborts this signal — cancels the in-flight HTTP stream
+        // immediately instead of waiting for the model's next token.
+        { signal: getAbortSignal() },
+      )
 
       let assistantText = ''
       const toolUseBlocks: {
@@ -70,7 +77,19 @@ export class AnthropicProvider {
         this.callbacks.onStream(assistantText)
       })
 
-      const response = await stream.finalMessage()
+      let response
+      try {
+        response = await stream.finalMessage()
+      } catch (err) {
+        // The SDK throws APIUserAbortError / AbortError when the signal
+        // fires. Exit the loop cleanly so the TUI returns to an input-
+        // ready state instead of surfacing the abort as a red error.
+        if (isAbortLikeError(err)) {
+          this.callbacks.onComplete()
+          return
+        }
+        throw err
+      }
 
       // Collect tool_use blocks from the final message
       for (const block of response.content) {

--- a/cli/src/ai/console/providers/openai.ts
+++ b/cli/src/ai/console/providers/openai.ts
@@ -1,10 +1,12 @@
 import OpenAI from 'openai'
 import {
   executeTool,
+  getAbortSignal,
   getActiveTools,
   shouldAbortAfterTools,
   type ToolDefinition,
 } from '@/ai/console/tools.ts'
+import { isAbortLikeError } from '/lib/isAbortError.ts'
 import type { ChatCallbacks } from '@/ai/console/consoleAction.ts'
 import { getModuleContent } from '@/ai/console/systemPrompt.ts'
 
@@ -63,12 +65,25 @@ export class OpenAIProvider {
         content: this.systemPrompt + getModuleContent(),
       }
 
-      const stream = await this.client.chat.completions.create({
-        model: this.model,
-        messages: this.messages,
-        tools: toOpenAITools(getActiveTools()),
-        stream: true,
-      })
+      let stream
+      try {
+        stream = await this.client.chat.completions.create(
+          {
+            model: this.model,
+            messages: this.messages,
+            tools: toOpenAITools(getActiveTools()),
+            stream: true,
+          },
+          // Ctrl+C cancels the in-flight HTTP stream immediately.
+          { signal: getAbortSignal() },
+        )
+      } catch (err) {
+        if (isAbortLikeError(err)) {
+          this.callbacks.onComplete()
+          return
+        }
+        throw err
+      }
 
       let assistantContent = ''
       const toolCalls: {
@@ -77,31 +92,39 @@ export class OpenAIProvider {
         arguments: string
       }[] = []
 
-      for await (const chunk of stream) {
-        const delta = chunk.choices[0]?.delta
+      try {
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta
 
-        if (delta?.content) {
-          const text = delta.content
-          assistantContent += text
-          this.callbacks.onStream(assistantContent)
-        }
+          if (delta?.content) {
+            const text = delta.content
+            assistantContent += text
+            this.callbacks.onStream(assistantContent)
+          }
 
-        if (delta?.tool_calls) {
-          for (const tc of delta.tool_calls) {
-            if (tc.index !== undefined) {
-              while (toolCalls.length <= tc.index) {
-                toolCalls.push({ id: '', name: '', arguments: '' })
-              }
-              if (tc.id) toolCalls[tc.index].id = tc.id
-              if (tc.function?.name) {
-                toolCalls[tc.index].name = tc.function.name
-              }
-              if (tc.function?.arguments) {
-                toolCalls[tc.index].arguments += tc.function.arguments
+          if (delta?.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              if (tc.index !== undefined) {
+                while (toolCalls.length <= tc.index) {
+                  toolCalls.push({ id: '', name: '', arguments: '' })
+                }
+                if (tc.id) toolCalls[tc.index].id = tc.id
+                if (tc.function?.name) {
+                  toolCalls[tc.index].name = tc.function.name
+                }
+                if (tc.function?.arguments) {
+                  toolCalls[tc.index].arguments += tc.function.arguments
+                }
               }
             }
           }
         }
+      } catch (err) {
+        if (isAbortLikeError(err)) {
+          this.callbacks.onComplete()
+          return
+        }
+        throw err
       }
 
       if (toolCalls.length === 0) {

--- a/cli/src/ai/console/providers/slv.ts
+++ b/cli/src/ai/console/providers/slv.ts
@@ -1,9 +1,11 @@
 import {
   executeTool,
+  getAbortSignal,
   getActiveTools,
   shouldAbortAfterTools,
   type ToolDefinition,
 } from '@/ai/console/tools.ts'
+import { isAbortLikeError } from '/lib/isAbortError.ts'
 import { DEFAULT_MAX_TOKENS } from '@/ai/config.ts'
 import {
   fetchAuthorizationStatus,
@@ -182,21 +184,37 @@ export class SLVProvider {
     this.messages.push({ role: 'user', content: userMessage })
 
     while (true) {
-      const response = await fetch('https://user-api.erpc.global/v3/ai/chat', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${this.apiKey}`,
-        },
-        body: JSON.stringify({
-          model: this.model,
-          max_tokens: DEFAULT_MAX_TOKENS,
-          system: this.systemPrompt + getModuleContent(),
-          messages: this.messages,
-          tools: toAnthropicTools(getActiveTools()),
-        }),
-        signal: AbortSignal.timeout(120_000),
-      })
+      // Combine the per-request 120s timeout with the user-abort signal
+      // so Ctrl+C cancels the HTTP call immediately instead of waiting
+      // for the timeout.
+      const signal = AbortSignal.any([
+        AbortSignal.timeout(120_000),
+        getAbortSignal(),
+      ])
+      let response
+      try {
+        response = await fetch('https://user-api.erpc.global/v3/ai/chat', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${this.apiKey}`,
+          },
+          body: JSON.stringify({
+            model: this.model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            system: this.systemPrompt + getModuleContent(),
+            messages: this.messages,
+            tools: toAnthropicTools(getActiveTools()),
+          }),
+          signal,
+        })
+      } catch (err) {
+        if (isAbortLikeError(err)) {
+          this.callbacks.onComplete()
+          return
+        }
+        throw err
+      }
 
       if (!response.ok) {
         const errorText = await response.text()

--- a/cli/src/ai/console/tools.ts
+++ b/cli/src/ai/console/tools.ts
@@ -39,12 +39,17 @@ let activeChildProcess: Deno.ChildProcess | null = null
 let onCommandComplete: (() => void) | null = null
 let onAnsibleTaskUpdate: ((taskName: string) => void) | null = null
 
-// Abort flag: set by Ctrl+C (killActiveProcess). Provider loops check
-// isAborted() after each tool call; if true they break out of the
-// tool-use loop instead of requesting another LLM turn, so the user
-// stays in control of the conversation. Cleared by clearAbort() at the
-// start of each new user turn.
-let aborted = false
+// Abort infrastructure. Ctrl+C aborts the AbortController, which:
+//   (a) cancels any in-flight LLM streaming HTTP request (provider.chat
+//       passes `signal` to the SDK), so a stalled Anthropic/OpenAI
+//       stream unblocks immediately instead of waiting for timeout;
+//   (b) fires SIGTERM at the active child process;
+//   (c) flips `signal.aborted` so the provider tool-use loop (via
+//       shouldAbortAfterTools) breaks instead of requesting another
+//       turn.
+// AbortController is single-shot — clearAbort() creates a fresh one at
+// the start of each new user turn.
+let abortController = new AbortController()
 
 export function setCommandOutputCallback(
   cb: ((line: string) => void) | null,
@@ -57,7 +62,7 @@ export function setCommandOutputCallback(
 }
 
 export function killActiveProcess() {
-  aborted = true
+  abortController.abort()
   if (activeChildProcess) {
     try {
       activeChildProcess.kill('SIGTERM')
@@ -67,11 +72,21 @@ export function killActiveProcess() {
 }
 
 export function isAborted(): boolean {
-  return aborted
+  return abortController.signal.aborted
+}
+
+/**
+ * AbortSignal to pass into LLM SDK calls (Anthropic `messages.stream`,
+ * OpenAI `chat.completions.create`). Aborting this signal cancels the
+ * in-flight HTTP stream so Ctrl+C is immediate even while the model is
+ * still generating its first token.
+ */
+export function getAbortSignal(): AbortSignal {
+  return abortController.signal
 }
 
 export function clearAbort() {
-  aborted = false
+  abortController = new AbortController()
 }
 
 /**
@@ -84,7 +99,7 @@ export function clearAbort() {
 export function shouldAbortAfterTools(
   onComplete: () => void,
 ): boolean {
-  if (!aborted) return false
+  if (!abortController.signal.aborted) return false
   onComplete()
   return true
 }
@@ -636,7 +651,7 @@ async function executeRunCommand(command: string): Promise<string> {
     // Aborted by user (Ctrl+C). Return a clear marker so the LLM knows the
     // command didn't complete — and the provider loop sees isAborted() and
     // stops requesting further turns.
-    if (aborted) {
+    if (abortController.signal.aborted) {
       activeChildProcess = null
       if (onCommandComplete) onCommandComplete()
       return `Command aborted by user (Ctrl+C).\nPartial stdout (last 1000 chars):\n${


### PR DESCRIPTION
## Context

After #297 landed, some users still saw \`slv c\` "hang" on Ctrl+C — this PR explains why and fixes it.

**The remaining failure mode:** Ctrl+C killed the active child process and broke the provider's tool-use loop, but the in-flight LLM **streaming HTTP request itself** kept running until it completed or timed out. If the model was slow, the Anthropic/OpenAI endpoint was stalled, or the user hit Ctrl+C during the first-token wait, the conversation sat frozen even though the interrupt message had been shown.

This is open question #5 on #298 (LLM stream cancellation) — identified in the Tier 3 plan but not yet done. Shipping it as a focused change ahead of the larger Session-core refactor because it's the piece most likely to eliminate the residual "会話が途切れる" complaint, and it's prerequisite to nothing else in Phase 1.

## Fix

Replaced the module-level \`aborted: boolean\` in \`cli/src/ai/console/tools.ts\` with an **\`AbortController\`** surfaced via \`getAbortSignal()\`:

- \`killActiveProcess()\` now aborts the controller (tripping \`signal.aborted\` + any consumer holding the signal).
- \`clearAbort()\` creates a fresh controller at the start of each new user turn (AbortController is single-shot).
- \`isAborted()\` / \`shouldAbortAfterTools()\` delegate to \`signal.aborted\` — existing call-sites unchanged.

Threaded the signal into **every provider's LLM call**:

| Provider | Call site | Wiring |
|---|---|---|
| Anthropic | \`client.messages.stream(params, { signal })\` | SDK native signal support |
| OpenAI | \`client.chat.completions.create(params, { signal })\` | SDK native signal support |
| SLV | \`fetch(..., { signal: AbortSignal.any([timeout, userAbort]) })\` | Merges existing 120s timeout with user abort so either fires |

Each provider wraps the initial request AND the streaming consume loop in try/catch and recognizes abort errors via a new shared helper (\`cli/lib/isAbortError.ts\`) that handles:
- \`AbortError\` (standard DOM)
- \`APIUserAbortError\` (Anthropic SDK's flavor)
- Any error with \`/aborted/i\` in its message (OpenAI SDK variant)

On abort, the provider fires \`onComplete()\` and returns cleanly — the TUI goes back to input-ready instead of surfacing the abort as a red error.

## No behavior change for the happy path

The AbortController is created fresh at each \`clearAbort()\` call (top of every new user turn). Normal runs never trip the signal; it's a no-op for successful conversations.

## Files

- \`cli/src/ai/console/tools.ts\` — AbortController + \`getAbortSignal\`
- \`cli/src/ai/console/providers/anthropic.ts\` — pass signal, catch abort
- \`cli/src/ai/console/providers/openai.ts\` — pass signal, catch abort (request + stream)
- \`cli/src/ai/console/providers/slv.ts\` — merge with timeout signal, catch abort
- \`cli/lib/isAbortError.ts\` — NEW, shared abort-error recognizer

## Test plan

- [x] \`deno check\` clean across all touched files
- [x] \`slv bot build < /dev/null\` still fails fast in 0.24s with exit 1 (regression check)
- [x] \`slv c --help\` renders
- [x] \`AbortSignal.any()\` works in Deno runtime
- [ ] Manual: \`slv c\` → long prompt → Ctrl+C during first-token wait → TUI returns to input-ready within ~100ms (before: could sit for many seconds)
- [ ] Manual: Ctrl+C during a mid-stream Anthropic response → same

## Relation to #298 (Tier 3 plan)

This is a subset of Phase 1 focused on the one open question most likely to fix the user-visible residual issue. Remaining Phase 1 work (Session class extraction, \`toolRunner.ts\` split, typed event bus) tracked on #298 for the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)