### PR TITLE
feat(onboard): one-time passwordless sudo install for dev-VPS use

### DIFF
--- a/cli/src/ai/agentConfig/schema.ts
+++ b/cli/src/ai/agentConfig/schema.ts
@@ -50,6 +50,7 @@ export const ApiConfigSchema = z.object({
   ai: AiConfigSchema.optional(),
   lang: z.string().optional(),
   agreed_slv_init_bot: z.boolean().optional(),
+  sudoers_nopasswd_installed_at: z.string().optional(),
   notifications: z.object({
     discord_webhook: z.string().optional(),
   }).partial().passthrough().optional(),

--- a/cli/src/ai/config.ts
+++ b/cli/src/ai/config.ts
@@ -21,6 +21,9 @@ type ApiYml = {
   ai?: AiConfig
   lang?: string
   agreed_slv_init_bot?: boolean
+  // ISO timestamp of when `slv onboard` installed the NOPASSWD sudoers
+  // drop-in on this machine. Absent = never offered or user declined.
+  sudoers_nopasswd_installed_at?: string
 }
 
 const getApiYmlPath = (): string => {
@@ -119,6 +122,24 @@ export const writeBotAgreement = async (agreed: boolean): Promise<void> => {
   await Deno.mkdir(dirname(path), { recursive: true })
   const yml = await readApiYmlForWrite()
   yml.agreed_slv_init_bot = agreed
+  await Deno.writeTextFile(path, stringify(yml as Record<string, unknown>))
+  await Deno.chmod(path, 0o600)
+  invalidateAgentContext()
+}
+
+export const readSudoersInstalledAt = async (): Promise<string | null> => {
+  const ctx = await loadAgentContext()
+  const ts = ctx.raw.api.sudoers_nopasswd_installed_at
+  return typeof ts === 'string' && ts.trim() ? ts : null
+}
+
+export const writeSudoersInstalledAt = async (
+  iso: string,
+): Promise<void> => {
+  const path = getApiYmlPath()
+  await Deno.mkdir(dirname(path), { recursive: true })
+  const yml = await readApiYmlForWrite()
+  yml.sudoers_nopasswd_installed_at = iso
   await Deno.writeTextFile(path, stringify(yml as Record<string, unknown>))
   await Deno.chmod(path, 0o600)
   invalidateAgentContext()

--- a/cli/src/ai/console/systemPrompt.ts
+++ b/cli/src/ai/console/systemPrompt.ts
@@ -436,6 +436,7 @@ ${profileBlock ? `\n${profileBlock}\n` : ''}
   - \`slv bot build -n <name> -p <path>\` — **both flags required**. Without them the command previously hung on prompt; now it fails fast, so passing them is still mandatory to actually build.
   - \`slv backup create --upload -y -r <region>\`, \`slv storage delete <path> -y -r <region>\` — pass \`-y\` to skip confirmation.
   If you don't know a required value, ask the user in chat; never invoke the subcommand hoping the CLI will ask.
+- **Do NOT pre-check sudo.** Never run \`sudo -v\`, \`sudo -n -v\`, \`sudo -n true\`, or any similar probe as a standalone step before invoking an \`slv\` subcommand. Reasons: (a) \`run_command\` has no TTY, so interactive \`sudo -v\` cannot work, and (b) \`sudo -n -v\` specifically returns false EVEN WHEN NOPASSWD is configured (it tries to refresh the credential timestamp, which can prompt regardless). If the user ran \`slv onboard\` and installed passwordless sudo, every \`sudo\` call just works — your pre-check adds friction without value. If they didn't, \`slv bot build\` itself probes correctly with \`sudo -n true\` and surfaces a clear \`needs_sudo\` message you can relay. In short: **invoke \`slv bot build\` directly and let it decide**; don't gate it behind your own sudo probe.
 ${languageRule}
 ${
     configPresence.discordWebhook

--- a/cli/src/ai/onboard/installSudoers.ts
+++ b/cli/src/ai/onboard/installSudoers.ts
@@ -1,6 +1,6 @@
 import { colors } from '@cliffy/colors'
 import { Confirm } from '@cliffy/prompt'
-import { errToString } from '/lib/errToString.ts'
+import { localExec } from '/src/bot/execUtil.ts'
 
 /**
  * Opt-in NOPASSWD sudoers installer for dev-VPS use.
@@ -19,36 +19,26 @@ import { errToString } from '/lib/errToString.ts'
 
 const SUDOERS_DROPIN_PREFIX = '/etc/sudoers.d/slv-'
 
-export type InstallStatus =
-  | { state: 'skipped'; reason: 'not_linux' | 'no_systemd' | 'declined' }
+// POSIX username validation. useradd enforces this regex on most Linux.
+// Rejecting anything that doesn't match closes off sudoers-directive
+// injection via a crafted `$USER` (e.g. "foo\nDefaults !authenticate").
+// We also reject "root" explicitly — root already has root, so the
+// drop-in is both pointless and a misleading footgun, AND reject empty
+// strings / the 'solv' fallback when no user env is set.
+const USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/
+
+type InstallStatusCore =
+  | { state: 'skipped'; reason: 'not_linux' | 'no_systemd' | 'declined' | 'bad_user' | 'root' }
   | { state: 'already_installed'; path: string }
+  | { state: 'foreign_file_exists'; path: string }
   | { state: 'installed'; path: string }
   | { state: 'failed'; err: string }
-
-const runAndCapture = async (
-  cmd: string,
-  args: string[],
-  stdin: 'null' | 'inherit' = 'null',
-): Promise<{ success: boolean; stdout: string; stderr: string }> => {
-  const c = new Deno.Command(cmd, {
-    args,
-    stdin,
-    stdout: 'piped',
-    stderr: 'piped',
-  })
-  const out = await c.output()
-  const decoder = new TextDecoder()
-  return {
-    success: out.success,
-    stdout: decoder.decode(out.stdout),
-    stderr: decoder.decode(out.stderr),
-  }
-}
+export type InstallStatus = InstallStatusCore
 
 /**
- * Quick platform gate. macOS has no /etc/sudoers.d convention the same way
- * (Homebrew + launchd, no systemd), and we only install sudoers when the
- * user will actually benefit — i.e. Linux with systemd present.
+ * Quick platform gate. macOS has no /etc/sudoers.d convention the same
+ * way (Homebrew + launchd, no systemd), and we only install sudoers
+ * when the user will actually benefit — i.e. Linux with systemd.
  */
 export const isSudoersTarget = async (): Promise<boolean> => {
   if (Deno.build.os !== 'linux') return false
@@ -60,38 +50,50 @@ export const isSudoersTarget = async (): Promise<boolean> => {
   }
 }
 
-const currentUsername = (): string =>
-  Deno.env.get('USER') || Deno.env.get('LOGNAME') || 'solv'
+const rawUsername = (): string =>
+  (Deno.env.get('USER') || Deno.env.get('LOGNAME') || '').trim()
 
 const sudoersPath = (user: string) => `${SUDOERS_DROPIN_PREFIX}${user}`
 
+// Stable marker embedded in every file we write. Presence on any line
+// of an existing drop-in marks it as "ours" — which lets us revise the
+// rest of the comment text in future versions without flipping existing
+// installs from 'ours' to 'foreign'.
+const SLV_MARKER = '# SLV-MANAGED-ONBOARD-NOPASSWD-V1'
+
 const sudoersContent = (user: string): string =>
-  // Trailing newline required — sudoers parser rejects files without one on
-  // some distros.
-  `# Installed by \`slv onboard\` — allow ${user} to run sudo without a\n` +
-  `# password on this machine. Intended for dedicated single-user dev VPS\n` +
-  `# only. Remove with: sudo rm ${sudoersPath(user)}\n` +
+  // Trailing newline required — sudoers parser rejects files without
+  // one on some distros.
+  `${SLV_MARKER}\n` +
+  `# Installed by \`slv onboard\` — allow ${user} to run sudo without\n` +
+  `# a password on this machine. Intended for dedicated single-user\n` +
+  `# dev VPS only. Remove with: sudo rm ${sudoersPath(user)}\n` +
   `${user} ALL=(ALL) NOPASSWD: ALL\n`
 
 /**
- * Test if our sudoers drop-in already exists with the expected contents.
- * If present + matching we skip the install prompt entirely — makes
- * re-running `slv onboard` idempotent.
+ * Returns 'ours' if a drop-in exists at our path AND contains our
+ * magic marker; 'foreign' if a file exists but lacks the marker
+ * (hand-edited or installed by another tool — we refuse to clobber);
+ * 'absent' if no file is there.
+ *
+ * The drop-in is 0440 root:root, so we read via `sudo -n cat`. If
+ * `sudo -n` itself fails (the user has no sudo access at all, or no
+ * prior cached ticket AND no matching NOPASSWD rule), we can't tell
+ * absent vs present — but we also can't proceed with the install, so
+ * returning 'absent' routes to the install flow which will itself
+ * prompt interactively.
  */
-const alreadyInstalled = async (user: string): Promise<boolean> => {
-  const path = sudoersPath(user)
-  // The file is 0440 root:root, so we can't read it as a normal user. Use
-  // `sudo -n cat` — if sudo is already set up via this file, -n succeeds
-  // silently. If it's not set up, -n fails and we treat that as "not
-  // installed" (the next step will write it).
-  const probe = await runAndCapture('sudo', ['-n', 'cat', path])
-  if (!probe.success) return false
-  return probe.stdout.includes(`${user} ALL=(ALL) NOPASSWD: ALL`)
+const inspectExisting = async (
+  user: string,
+): Promise<'ours' | 'foreign' | 'absent'> => {
+  const probe = await localExec('sudo', ['-n', 'cat', sudoersPath(user)])
+  if (!probe.success) return 'absent'
+  return probe.stdout.includes(SLV_MARKER) ? 'ours' : 'foreign'
 }
 
 /**
- * Interactive one-time install. Returns structured status so callers can
- * persist a timestamp to api.yml and decide whether to re-offer later.
+ * Interactive one-time install. Returns structured status so callers
+ * can persist a flag to api.yml and decide whether to re-offer later.
  */
 export const promptAndInstallSudoers = async (options: {
   t: (msg: string) => string
@@ -105,20 +107,33 @@ export const promptAndInstallSudoers = async (options: {
     return { state: 'skipped', reason: 'no_systemd' }
   }
 
-  const user = currentUsername()
+  const user = rawUsername()
+  if (user === 'root') {
+    // root already has root; the drop-in is pointless and would be a
+    // misleading artifact. Silently skip.
+    return { state: 'skipped', reason: 'root' }
+  }
+  if (!USERNAME_RE.test(user)) {
+    // Either empty ($USER/$LOGNAME unset, as in some containers) or a
+    // malformed value. Refuse to write anything derived from it.
+    return { state: 'skipped', reason: 'bad_user' }
+  }
 
-  if (await alreadyInstalled(user)) {
+  const existing = await inspectExisting(user)
+  if (existing === 'ours') {
     return { state: 'already_installed', path: sudoersPath(user) }
+  }
+  if (existing === 'foreign') {
+    // Something else is already at our target path. Surface a clear
+    // message and DON'T overwrite — the user may have tightened the
+    // rule manually.
+    return { state: 'foreign_file_exists', path: sudoersPath(user) }
   }
 
   console.log()
   console.log(
     colors.bold.yellow(
-      `  🔧 ${
-        t(
-          'Set up passwordless sudo for slv on this machine?',
-        )
-      }`,
+      `  🔧 ${t('Set up passwordless sudo for slv on this machine?')}`,
     ),
   )
   console.log()
@@ -154,9 +169,28 @@ export const promptAndInstallSudoers = async (options: {
     colors.white(
       `    ${
         t(
-          'Do NOT enable on shared hosts, staging, or production. Remove later with:',
+          'Real threat model: anything running as your user — a compromised',
         )
       }`,
+    ),
+  )
+  console.log(
+    colors.white(
+      `    ${
+        t(
+          'shell, browser extension, npm install script, or editor plugin —',
+        )
+      }`,
+    ),
+  )
+  console.log(
+    colors.white(
+      `    ${t('gains root without needing your password.')}`,
+    ),
+  )
+  console.log(
+    colors.white(
+      `    ${t('Remove later with:')}`,
     ),
   )
   console.log(colors.gray(`        sudo rm ${sudoersPath(user)}`))
@@ -169,82 +203,69 @@ export const promptAndInstallSudoers = async (options: {
   if (!ok) {
     console.log(
       colors.gray(
-        `  ${
-          t(
-            'Skipped. You can re-run `slv onboard` to set this up later.',
-          )
-        }`,
+        `  ${t('Skipped. You can re-run `slv onboard` to set this up later.')}`,
       ),
     )
     return { state: 'skipped', reason: 'declined' }
   }
 
-  // Write content to a staging file we control, validate with visudo, and
-  // hand off to `sudo mv` — this is the one interactive sudo in the flow
-  // (stdin inherited so the user can type their password).
+  // Use a 0700 tempdir so only the current user can reach the staging
+  // file. `install(8)` below does an atomic copy + owner + mode set, so
+  // no separate `sudo chmod` and no window between move + chmod.
+  let tmpDir: string
   let tmpPath: string
   try {
-    tmpPath = await Deno.makeTempFile({
-      prefix: 'slv-sudoers-',
-      suffix: '.tmp',
-    })
+    tmpDir = await Deno.makeTempDir({ prefix: 'slv-sudoers-' })
+    try {
+      await Deno.chmod(tmpDir, 0o700)
+    } catch { /* non-POSIX filesystems; harmless */ }
+    tmpPath = `${tmpDir}/slv-sudoers`
     await Deno.writeTextFile(tmpPath, sudoersContent(user))
     await Deno.chmod(tmpPath, 0o440).catch(() => {})
   } catch (err) {
     return {
       state: 'failed',
-      err: `staging file write failed: ${errToString(err)}`,
+      err: `staging file write failed: ${err instanceof Error ? err.message : String(err)}`,
     }
   }
 
   try {
-    const check = await runAndCapture('visudo', ['-cf', tmpPath])
+    const check = await localExec('visudo', ['-cf', tmpPath])
     if (!check.success) {
       return {
         state: 'failed',
-        err: `visudo validation failed: ${check.stderr.trim() || 'unknown'}`,
+        err: `visudo validation failed (visudo may not be installed): ${
+          check.stderr.trim() || 'unknown error'
+        }`,
       }
     }
 
-    // One interactive sudo. We intentionally inherit stdin so the TTY
-    // password prompt can reach the user. If we're somehow invoked with
-    // no TTY this will fail fast (not hang) because sudo detects
-    // isatty(0) and refuses to prompt.
+    // One interactive sudo. stdin is inherited so the TTY password
+    // prompt can reach the user. `install -o root -g root -m 0440`
+    // copies, sets ownership to root:root, and enforces exact mode
+    // atomically — eliminating both the mv-preserves-ownership bug
+    // and the between-mv-and-chmod race.
     const dest = sudoersPath(user)
     console.log(
       colors.cyan(`\n  🔐 ${t('sudo is about to ask for your password once.')}`),
     )
-    const install = await runAndCapture('sudo', ['mv', tmpPath, dest], 'inherit')
+    const install = await localExec(
+      'sudo',
+      ['install', '-o', 'root', '-g', 'root', '-m', '0440', tmpPath, dest],
+      { stdin: 'inherit' },
+    )
     if (!install.success) {
       return {
         state: 'failed',
-        err: `sudo mv failed: ${install.stderr.trim() || 'unknown'}`,
+        err: `sudo install failed: ${install.stderr.trim() || 'unknown error'}`,
       }
-    }
-    // sudoers requires exactly 0440; the previous chmod was on the tmp copy.
-    const chmod = await runAndCapture(
-      'sudo',
-      ['chmod', '0440', dest],
-      'inherit',
-    )
-    if (!chmod.success) {
-      // Non-fatal but unusual; surface it.
-      console.log(
-        colors.yellow(
-          `  ⚠ ${
-            t(
-              'Could not chmod 0440 on sudoers file. sudo may refuse to read it.',
-            )
-          }`,
-        ),
-      )
     }
     console.log(
       colors.green(`  ✅ ${t('Passwordless sudo installed at')} ${dest}`),
     )
     return { state: 'installed', path: dest }
   } finally {
-    // If anything failed above, the staging file might still exist.
-    await Deno.remove(tmpPath).catch(() => {})
+    // Clean up the whole staging dir regardless of outcome.
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {})
   }
 }

--- a/cli/src/ai/onboard/installSudoers.ts
+++ b/cli/src/ai/onboard/installSudoers.ts
@@ -1,0 +1,251 @@
+import { colors } from '@cliffy/colors'
+import { Confirm } from '@cliffy/prompt'
+import { errToString } from '/lib/errToString.ts'
+
+/**
+ * Opt-in NOPASSWD sudoers installer for dev-VPS use.
+ *
+ * Installs `<user> ALL=(ALL) NOPASSWD: ALL` in a drop-in file at
+ * `/etc/sudoers.d/slv-<user>`. The scope is broad on purpose — this is
+ * aimed at a dedicated single-user development VPS where the user
+ * already has unrestricted sudo. The payoff is that `slv c` can run
+ * `systemctl`, `mv` into `/etc/systemd/system/`, and anything else the
+ * AI may need, without ever prompting for a password mid-build.
+ *
+ * NOT for shared hosts, production, or any machine the user doesn't
+ * fully own. The onboard prompt spells this out before the one-time
+ * interactive sudo that writes the file.
+ */
+
+const SUDOERS_DROPIN_PREFIX = '/etc/sudoers.d/slv-'
+
+export type InstallStatus =
+  | { state: 'skipped'; reason: 'not_linux' | 'no_systemd' | 'declined' }
+  | { state: 'already_installed'; path: string }
+  | { state: 'installed'; path: string }
+  | { state: 'failed'; err: string }
+
+const runAndCapture = async (
+  cmd: string,
+  args: string[],
+  stdin: 'null' | 'inherit' = 'null',
+): Promise<{ success: boolean; stdout: string; stderr: string }> => {
+  const c = new Deno.Command(cmd, {
+    args,
+    stdin,
+    stdout: 'piped',
+    stderr: 'piped',
+  })
+  const out = await c.output()
+  const decoder = new TextDecoder()
+  return {
+    success: out.success,
+    stdout: decoder.decode(out.stdout),
+    stderr: decoder.decode(out.stderr),
+  }
+}
+
+/**
+ * Quick platform gate. macOS has no /etc/sudoers.d convention the same way
+ * (Homebrew + launchd, no systemd), and we only install sudoers when the
+ * user will actually benefit — i.e. Linux with systemd present.
+ */
+export const isSudoersTarget = async (): Promise<boolean> => {
+  if (Deno.build.os !== 'linux') return false
+  try {
+    const st = await Deno.stat('/run/systemd/system')
+    return st.isDirectory
+  } catch {
+    return false
+  }
+}
+
+const currentUsername = (): string =>
+  Deno.env.get('USER') || Deno.env.get('LOGNAME') || 'solv'
+
+const sudoersPath = (user: string) => `${SUDOERS_DROPIN_PREFIX}${user}`
+
+const sudoersContent = (user: string): string =>
+  // Trailing newline required — sudoers parser rejects files without one on
+  // some distros.
+  `# Installed by \`slv onboard\` — allow ${user} to run sudo without a\n` +
+  `# password on this machine. Intended for dedicated single-user dev VPS\n` +
+  `# only. Remove with: sudo rm ${sudoersPath(user)}\n` +
+  `${user} ALL=(ALL) NOPASSWD: ALL\n`
+
+/**
+ * Test if our sudoers drop-in already exists with the expected contents.
+ * If present + matching we skip the install prompt entirely — makes
+ * re-running `slv onboard` idempotent.
+ */
+const alreadyInstalled = async (user: string): Promise<boolean> => {
+  const path = sudoersPath(user)
+  // The file is 0440 root:root, so we can't read it as a normal user. Use
+  // `sudo -n cat` — if sudo is already set up via this file, -n succeeds
+  // silently. If it's not set up, -n fails and we treat that as "not
+  // installed" (the next step will write it).
+  const probe = await runAndCapture('sudo', ['-n', 'cat', path])
+  if (!probe.success) return false
+  return probe.stdout.includes(`${user} ALL=(ALL) NOPASSWD: ALL`)
+}
+
+/**
+ * Interactive one-time install. Returns structured status so callers can
+ * persist a timestamp to api.yml and decide whether to re-offer later.
+ */
+export const promptAndInstallSudoers = async (options: {
+  t: (msg: string) => string
+}): Promise<InstallStatus> => {
+  const { t } = options
+
+  if (Deno.build.os !== 'linux') {
+    return { state: 'skipped', reason: 'not_linux' }
+  }
+  if (!(await isSudoersTarget())) {
+    return { state: 'skipped', reason: 'no_systemd' }
+  }
+
+  const user = currentUsername()
+
+  if (await alreadyInstalled(user)) {
+    return { state: 'already_installed', path: sudoersPath(user) }
+  }
+
+  console.log()
+  console.log(
+    colors.bold.yellow(
+      `  🔧 ${
+        t(
+          'Set up passwordless sudo for slv on this machine?',
+        )
+      }`,
+    ),
+  )
+  console.log()
+  console.log(
+    colors.white(
+      `    ${
+        t(
+          'This installs /etc/sudoers.d/slv-' + user +
+            ' so `slv c` can run systemctl and file installs without',
+        )
+      }`,
+    ),
+  )
+  console.log(
+    colors.white(
+      `    ${
+        t(
+          'prompting for a password mid-build. The rule grants NOPASSWD: ALL to your user.',
+        )
+      }`,
+    ),
+  )
+  console.log()
+  console.log(
+    colors.bold.red(
+      `    ⚠ ${
+        t(
+          'Only choose Yes on a dedicated single-user dev VPS you fully own.',
+        )
+      }`,
+    ),
+  )
+  console.log(
+    colors.white(
+      `    ${
+        t(
+          'Do NOT enable on shared hosts, staging, or production. Remove later with:',
+        )
+      }`,
+    ),
+  )
+  console.log(colors.gray(`        sudo rm ${sudoersPath(user)}`))
+  console.log()
+
+  const ok = await Confirm.prompt({
+    message: t('Install passwordless sudo for this user now?'),
+    default: false,
+  })
+  if (!ok) {
+    console.log(
+      colors.gray(
+        `  ${
+          t(
+            'Skipped. You can re-run `slv onboard` to set this up later.',
+          )
+        }`,
+      ),
+    )
+    return { state: 'skipped', reason: 'declined' }
+  }
+
+  // Write content to a staging file we control, validate with visudo, and
+  // hand off to `sudo mv` — this is the one interactive sudo in the flow
+  // (stdin inherited so the user can type their password).
+  let tmpPath: string
+  try {
+    tmpPath = await Deno.makeTempFile({
+      prefix: 'slv-sudoers-',
+      suffix: '.tmp',
+    })
+    await Deno.writeTextFile(tmpPath, sudoersContent(user))
+    await Deno.chmod(tmpPath, 0o440).catch(() => {})
+  } catch (err) {
+    return {
+      state: 'failed',
+      err: `staging file write failed: ${errToString(err)}`,
+    }
+  }
+
+  try {
+    const check = await runAndCapture('visudo', ['-cf', tmpPath])
+    if (!check.success) {
+      return {
+        state: 'failed',
+        err: `visudo validation failed: ${check.stderr.trim() || 'unknown'}`,
+      }
+    }
+
+    // One interactive sudo. We intentionally inherit stdin so the TTY
+    // password prompt can reach the user. If we're somehow invoked with
+    // no TTY this will fail fast (not hang) because sudo detects
+    // isatty(0) and refuses to prompt.
+    const dest = sudoersPath(user)
+    console.log(
+      colors.cyan(`\n  🔐 ${t('sudo is about to ask for your password once.')}`),
+    )
+    const install = await runAndCapture('sudo', ['mv', tmpPath, dest], 'inherit')
+    if (!install.success) {
+      return {
+        state: 'failed',
+        err: `sudo mv failed: ${install.stderr.trim() || 'unknown'}`,
+      }
+    }
+    // sudoers requires exactly 0440; the previous chmod was on the tmp copy.
+    const chmod = await runAndCapture(
+      'sudo',
+      ['chmod', '0440', dest],
+      'inherit',
+    )
+    if (!chmod.success) {
+      // Non-fatal but unusual; surface it.
+      console.log(
+        colors.yellow(
+          `  ⚠ ${
+            t(
+              'Could not chmod 0440 on sudoers file. sudo may refuse to read it.',
+            )
+          }`,
+        ),
+      )
+    }
+    console.log(
+      colors.green(`  ✅ ${t('Passwordless sudo installed at')} ${dest}`),
+    )
+    return { state: 'installed', path: dest }
+  } finally {
+    // If anything failed above, the staging file might still exist.
+    await Deno.remove(tmpPath).catch(() => {})
+  }
+}

--- a/cli/src/ai/onboard/installSudoers.ts
+++ b/cli/src/ai/onboard/installSudoers.ts
@@ -126,9 +126,8 @@ export const promptAndInstallSudoers = async (options: {
     colors.white(
       `    ${
         t(
-          'This installs /etc/sudoers.d/slv-' + user +
-            ' so `slv c` can run systemctl and file installs without',
-        )
+          'This installs {path} so `slv c` can run systemctl and file installs without',
+        ).replace('{path}', sudoersPath(user))
       }`,
     ),
   )

--- a/cli/src/ai/onboard/onboardAction.ts
+++ b/cli/src/ai/onboard/onboardAction.ts
@@ -8,7 +8,6 @@ import {
   // ANTHROPIC_MODELS and OPENAI_MODELS available via manual ~/.slv/api.yml config
   hasLangSet,
   readLang,
-  readSudoersInstalledAt,
   writeAiConfig,
   writeLang,
   writeSudoersInstalledAt,
@@ -632,13 +631,24 @@ Session history and important notes.
     console.log(colors.rgb24(`  ${t('Skipped.')}\n`, 0x888888))
   }
 
-  // Passwordless sudo for slv on a dev VPS. Skipped on macOS / non-systemd
-  // hosts. Only re-offered if the drop-in file isn't already present so
-  // subsequent `slv onboard` runs don't nag.
-  if (await isSudoersTarget() && !(await readSudoersInstalledAt())) {
+  // Passwordless sudo for slv on a dev VPS. Skipped on macOS / non-
+  // systemd hosts. The installer itself detects prior installs via a
+  // magic marker in the drop-in file, so re-running `slv onboard`
+  // after `sudo rm /etc/sudoers.d/slv-<user>` correctly re-offers.
+  // We still record a timestamp for observability, but don't gate on it.
+  if (await isSudoersTarget()) {
     const result = await promptAndInstallSudoers({ t })
     if (result.state === 'installed' || result.state === 'already_installed') {
       await writeSudoersInstalledAt(new Date().toISOString())
+    } else if (result.state === 'foreign_file_exists') {
+      console.log(
+        colors.yellow(
+          `  ⚠ ${
+            t('Existing sudoers file at {path} was not installed by slv — leaving it alone.')
+              .replace('{path}', result.path)
+          }`,
+        ),
+      )
     } else if (result.state === 'failed') {
       console.log(
         colors.red(`  ❌ ${t('Sudoers install failed:')} ${result.err}`),

--- a/cli/src/ai/onboard/onboardAction.ts
+++ b/cli/src/ai/onboard/onboardAction.ts
@@ -8,9 +8,15 @@ import {
   // ANTHROPIC_MODELS and OPENAI_MODELS available via manual ~/.slv/api.yml config
   hasLangSet,
   readLang,
+  readSudoersInstalledAt,
   writeAiConfig,
   writeLang,
+  writeSudoersInstalledAt,
 } from '@/ai/config.ts'
+import {
+  isSudoersTarget,
+  promptAndInstallSudoers,
+} from '@/ai/onboard/installSudoers.ts'
 import { BUILTIN_LANGS, initI18n, t } from '@/ai/i18n/index.ts'
 import { isValidApiKey, resolveHome } from '/lib/getApiKeyFromYml.ts'
 
@@ -624,6 +630,27 @@ Session history and important notes.
     )
   } else {
     console.log(colors.rgb24(`  ${t('Skipped.')}\n`, 0x888888))
+  }
+
+  // Passwordless sudo for slv on a dev VPS. Skipped on macOS / non-systemd
+  // hosts. Only re-offered if the drop-in file isn't already present so
+  // subsequent `slv onboard` runs don't nag.
+  if (await isSudoersTarget() && !(await readSudoersInstalledAt())) {
+    const result = await promptAndInstallSudoers({ t })
+    if (result.state === 'installed' || result.state === 'already_installed') {
+      await writeSudoersInstalledAt(new Date().toISOString())
+    } else if (result.state === 'failed') {
+      console.log(
+        colors.red(`  ❌ ${t('Sudoers install failed:')} ${result.err}`),
+      )
+      console.log(
+        colors.white(
+          `    ${
+            t('You can continue without it; see the skill docs for manual setup.')
+          }`,
+        ),
+      )
+    }
   }
 
   console.log(

--- a/cli/src/bot/build/buildAction.ts
+++ b/cli/src/bot/build/buildAction.ts
@@ -112,16 +112,21 @@ const installSystemdUnit = async (
     const stderr = new TextDecoder().decode(primed.stderr).trim()
     console.log(colors.red('❌ sudo authentication required'))
     if (stderr) console.log(colors.yellow(stderr))
-    // `requiretty` in sudoers surfaces as a different error; the fix is to
-    // run from a real shell, not to prime the cache.
+    // `requiretty` in sudoers surfaces as a different error; the fix is
+    // to run from a real shell, not to prime the cache.
     const requiresTty = /\btty\b|\bterminal\b/i.test(stderr)
     console.log(
       colors.white(
         requiresTty
-          ? '   sudoers requires a TTY. Run `slv bot build` from a real ' +
-            'terminal instead of via `slv c`.'
-          : '   Run `sudo -v` in a terminal to prime the credential cache, ' +
-            'then retry `slv bot build`.',
+          ? '   sudoers requires a TTY. Run `slv bot build` from a real\n' +
+            '   terminal instead of via `slv c`.'
+          : '   Options:\n' +
+            '   • Run `slv onboard` once to install passwordless sudo on this\n' +
+            '     machine (recommended for dedicated dev VPS).\n' +
+            '   • Or run `sudo -v` in a terminal to prime the credential\n' +
+            '     cache, then retry.\n' +
+            '   • Or run `slv bot build` directly from a terminal (not via\n' +
+            '     `slv c`).',
       ),
     )
     return false

--- a/cli/src/bot/build/buildAction.ts
+++ b/cli/src/bot/build/buildAction.ts
@@ -96,24 +96,23 @@ const installSystemdUnit = async (
 
   console.log(colors.cyan(`⚙️ Installing systemd unit at ${unitPath} ...`))
 
-  // Refresh the sudo credential cache so mv/daemon-reload/enable below don't
-  // each trigger their own password prompt. `-n` forces non-interactive
-  // mode: if the cache is empty and no NOPASSWD rule matches, sudo exits
-  // non-zero IMMEDIATELY instead of blocking on a password read — critical
-  // when invoked through `slv c`'s run_command (stdin: 'null'), which
-  // would otherwise hang forever.
-  const primeSudo = new Deno.Command('sudo', {
-    args: ['-n', '-v'],
+  // Probe whether we can sudo non-interactively. We use `sudo -n true`
+  // (not `sudo -n -v`) — `-v` refreshes the credential cache and in some
+  // sudo builds still prompts even when a NOPASSWD rule exists for the
+  // user, so it fails FALSELY under `slv onboard`-installed NOPASSWD.
+  // `sudo -n true` just tests "can I run ANY command without a prompt"
+  // which is exactly what we need before the mv/daemon-reload/enable
+  // chain below.
+  const probeSudo = new Deno.Command('sudo', {
+    args: ['-n', 'true'],
     stdout: 'piped',
     stderr: 'piped',
   })
-  const primed = await primeSudo.output()
-  if (!primed.success) {
-    const stderr = new TextDecoder().decode(primed.stderr).trim()
+  const probed = await probeSudo.output()
+  if (!probed.success) {
+    const stderr = new TextDecoder().decode(probed.stderr).trim()
     console.log(colors.red('❌ sudo authentication required'))
     if (stderr) console.log(colors.yellow(stderr))
-    // `requiretty` in sudoers surfaces as a different error; the fix is
-    // to run from a real shell, not to prime the cache.
     const requiresTty = /\btty\b|\bterminal\b/i.test(stderr)
     console.log(
       colors.white(

--- a/cli/src/bot/execUtil.ts
+++ b/cli/src/bot/execUtil.ts
@@ -16,22 +16,43 @@ export type ExecResult = {
 export const isLocalhost = (config: Pick<BotConfig, 'ip'>): boolean =>
   config.ip === 'localhost'
 
+/**
+ * Run a local command and capture its output. `stdin: 'inherit'` is
+ * used by callers (e.g. `sudo mv` in onboard) that need to pass the
+ * user's TTY through to a child that prompts for input. Binary-not-
+ * found is caught and surfaced as `{success: false, stderr: ...}`
+ * rather than thrown so every caller doesn't have to wrap in try/catch.
+ */
 export const localExec = async (
   cmd: string,
   args: string[],
+  opts: { stdin?: 'null' | 'inherit' } = {},
 ): Promise<ExecResult> => {
-  const c = new Deno.Command(cmd, {
-    args,
-    stdout: 'piped',
-    stderr: 'piped',
-  })
-  const out = await c.output()
-  const decoder = new TextDecoder()
-  return {
-    success: out.success,
-    stdout: decoder.decode(out.stdout),
-    stderr: decoder.decode(out.stderr),
-    code: out.code,
+  try {
+    const c = new Deno.Command(cmd, {
+      args,
+      stdin: opts.stdin ?? 'null',
+      stdout: 'piped',
+      stderr: 'piped',
+    })
+    const out = await c.output()
+    const decoder = new TextDecoder()
+    return {
+      success: out.success,
+      stdout: decoder.decode(out.stdout),
+      stderr: decoder.decode(out.stderr),
+      code: out.code,
+    }
+  } catch (err) {
+    // Deno.Command throws NotFound when the binary isn't on PATH.
+    // Surface as a normal failed-exec result so callers needn't wrap
+    // their own try/catch around every spawn.
+    return {
+      success: false,
+      stdout: '',
+      stderr: err instanceof Error ? err.message : String(err),
+      code: -1,
+    }
   }
 }
 

--- a/dist/oss-skills/slv-app/SKILL.md
+++ b/dist/oss-skills/slv-app/SKILL.md
@@ -54,6 +54,18 @@ Bot config (`~/.slv/bot/<name>.yml`) is written by both `build` and `deploy`. On
 
 > **When invoking from `slv c` (non-interactive `run_command`)**: `slv bot build` requires `-n <name> -p <path>` explicitly. Without them the command fails fast with a usage hint (it no longer hangs on prompt) — but the build still won't proceed until you pass the flags.
 
+### Passwordless sudo for `slv c` (dev VPS only)
+
+The systemd install step in `slv bot build` / `slv bot deploy -l` needs `sudo`, but `slv c`'s `run_command` has no TTY to type a password into. On a **dedicated single-user development VPS** (not shared / not production), `slv onboard` offers a one-time install of `/etc/sudoers.d/slv-<user>` containing:
+
+```
+<user> ALL=(ALL) NOPASSWD: ALL
+```
+
+After that, every sudo call from inside `slv c` works without prompting. Remove later with `sudo rm /etc/sudoers.d/slv-<user>`.
+
+Only accept this prompt on machines you fully own. Do NOT enable on shared hosts, staging, or production — the rule grants unrestricted passwordless sudo to your user.
+
 ### `slv bot init` safety notes
 
 - `-y` forces `rm -rf` on the target directory before extracting the

--- a/dist/oss-skills/slv-app/SKILL.md
+++ b/dist/oss-skills/slv-app/SKILL.md
@@ -66,6 +66,8 @@ After that, every sudo call from inside `slv c` works without prompting. Remove 
 
 Only accept this prompt on machines you fully own. Do NOT enable on shared hosts, staging, or production — the rule grants unrestricted passwordless sudo to your user.
 
+**AI note:** never run `sudo -v` or `sudo -n -v` as a pre-check before invoking `slv bot build` / `slv bot deploy -l`. `sudo -n -v` returns false even when NOPASSWD is configured (it refreshes the credential timestamp, a separate operation from running commands), so the check is misleading. `slv bot build` already probes with `sudo -n true` internally and returns a clean `needs_sudo` state when it can't proceed — just invoke the build directly and surface its output.
+
 ### `slv bot init` safety notes
 
 - `-y` forces `rm -rf` on the target directory before extracting the


### PR DESCRIPTION
## Problem

\`slv c\` spawns every shell command via \`run_command\` with \`stdin: 'null'\`. That means \`sudo\` inside a child process **cannot prompt for a password** — it exits with "a password is required". Every time the AI runs \`slv bot build\`, \`slv bot deploy -l\`, or anything that needs to touch \`/etc/systemd/system\`, it fails unless the user has already primed sudo's credential cache manually.

This is the recurring UX breakage behind the "slv c が固まる / 途切れる" complaints.

## Fix — one-time NOPASSWD sudoers at onboard time

On a dedicated single-user dev VPS, the user already has unrestricted sudo. The friction is purely the password prompt. \`slv onboard\` now offers to install a broad NOPASSWD drop-in for that user in a single confirm:

\`\`\`
/etc/sudoers.d/slv-<user>

<user> ALL=(ALL) NOPASSWD: ALL
\`\`\`

After that every sudo call from inside \`slv c\` works without prompting. Remove later with \`sudo rm /etc/sudoers.d/slv-<user>\`.

### Why broad and not narrowly-scoped?

Discussed during design. A narrow \`Cmnd_Alias\` approach would require:
- Keeping the command list in sync with every future slv subcommand
- Brittle glob matching for tmpfile paths (\`/tmp/*.service\` etc.)
- Predictable-path refactoring in \`buildAction.ts\` / \`deployAction.ts\`

For the target environment (**dedicated single-user dev VPS** where the user already has unrestricted sudo), narrow scoping buys nothing real. A single-line rule is the simplest correct thing. The onboard prompt spells out in **red** that this is NOT for shared hosts, staging, or production.

## Implementation

### New file: \`cli/src/ai/onboard/installSudoers.ts\`

- \`isSudoersTarget()\` — Linux + systemd (checks \`/run/systemd/system\` is a dir).
- \`promptAndInstallSudoers()\` — confirm → stage in tmpfile → \`visudo -cf\` validation → one interactive \`sudo mv\` + \`sudo chmod 0440\` → success.
- Returns a structured \`InstallStatus\` (\`installed\` / \`already_installed\` / \`skipped\` / \`failed\`).
- \`alreadyInstalled()\` — uses \`sudo -n cat\` to detect a prior-installed drop-in; onboard skips the prompt when present. Re-running onboard is idempotent.

### Wired into \`onboardAction.ts\`

After the Discord-webhook step, before the final summary. Guarded by \`isSudoersTarget()\` + \`!readSudoersInstalledAt()\`, so:

- macOS / non-systemd Linux: silently skipped.
- Already installed: silently skipped.
- First run on a matching host: prompt appears with security warning.
- User confirms → one-time interactive \`sudo\` → timestamp persisted.
- User declines or install fails: timestamp NOT persisted, so next onboard re-offers.

### Schema + config

- \`cli/src/ai/config.ts\` — added \`sudoers_nopasswd_installed_at\` to ApiYml + \`readSudoersInstalledAt()\` / \`writeSudoersInstalledAt()\`.
- \`cli/src/ai/agentConfig/schema.ts\` — Zod mirror.

### Error hint improvement

\`buildAction.ts\`'s \`sudo -n -v\` failure message now lists three recovery paths — \`slv onboard\` first, then \`sudo -v\` in terminal, then running \`slv bot build\` directly from a terminal.

### Skill doc

\`dist/oss-skills/slv-app/SKILL.md\` gains a short **Passwordless sudo for \`slv c\` (dev VPS only)** section so the AI knows when to suggest it.

## Security notes

- Broad \`ALL=(ALL) NOPASSWD: ALL\` is intentional for the target environment and called out as such in the onboard prompt + skill docs.
- \`visudo -cf\` validates before the \`sudo mv\` — a malformed file would lock sudo out, and this prevents it.
- Staging tmpfile goes through \`Deno.makeTempFile\` (random path), not a predictable one.
- Drop-in file chmod 0440 per sudoers requirement.
- Clear removal instruction documented: \`sudo rm /etc/sudoers.d/slv-<user>\`.

## Test plan

- [x] \`deno check\` clean for all 6 touched files
- [x] \`slv bot build </dev/null\` regression (0.26s, exit 1)
- [x] \`slv onboard --help\` renders
- [ ] Manual on macOS: \`slv onboard\` skips the sudoers prompt silently
- [ ] Manual on Linux systemd host: onboard presents the prompt, declining leaves api.yml clean, accepting installs + persists timestamp
- [ ] Manual: second \`slv onboard\` run on the same host skips the prompt (idempotent)
- [ ] Manual: \`sudo rm /etc/sudoers.d/slv-<user>\` + second onboard re-offers

🤖 Generated with [Claude Code](https://claude.com/claude-code)