### PR TITLE
feat(gateway): Phase 1A — foreground runner scaffold

### DIFF
--- a/cli/lib/randomHex.ts
+++ b/cli/lib/randomHex.ts
@@ -1,0 +1,10 @@
+/**
+ * Generate `byteCount` bytes of cryptographic randomness and return
+ * them as a lowercase hex string. 32 bytes → 64 hex chars = 256 bits
+ * of entropy, suitable for auth tokens and API keys.
+ */
+export const randomHex = (byteCount: number): string => {
+  const buf = new Uint8Array(byteCount)
+  crypto.getRandomValues(buf)
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('')
+}

--- a/cli/src/gateway/config.ts
+++ b/cli/src/gateway/config.ts
@@ -1,5 +1,9 @@
 import { dirname } from '@std/path'
-import { gatewayConfigPath, GATEWAY_DEFAULT_PORT } from '/src/gateway/paths.ts'
+import {
+  gatewayConfigPath,
+  GATEWAY_DEFAULT_PORT,
+} from '/src/gateway/paths.ts'
+import { randomHex } from '/lib/randomHex.ts'
 
 /**
  * Gateway config persisted at ~/.slv/gateway/gateway.json.
@@ -21,19 +25,12 @@ export type GatewayConfig = {
   mode: GatewayMode
 }
 
-// 256 bits of entropy → 64 hex chars. Enforced both on write (below)
-// and on read (`TOKEN_MIN_LEN` check in readOrCreate).
+// 256 bits of entropy → 64 hex chars.
 const TOKEN_MIN_LEN = 64
-
-const randomToken = (): string => {
-  const buf = new Uint8Array(32)
-  crypto.getRandomValues(buf)
-  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('')
-}
 
 const defaults = (): GatewayConfig => ({
   port: GATEWAY_DEFAULT_PORT,
-  token: randomToken(),
+  token: randomHex(32),
   mode: 'local',
 })
 
@@ -48,17 +45,63 @@ export class GatewayEnvPortError extends Error {
 }
 
 /**
- * Load the on-disk config. If the file is missing, writes a fresh one
- * (with a random token) and returns it. If the file exists but is
- * malformed, throws — callers should `Deno.exit(78)` (EX_CONFIG).
- *
- * `SLV_GATEWAY_PORT` env var overrides the persisted port at runtime
- * (handy for local testing when the default 18789 is taken). Token
- * and mode are always read from the file.
+ * Atomic write: stage to `<path>.tmp.<pid>` then `rename` onto the
+ * target. On POSIX `rename` is atomic within the same filesystem, so
+ * a SIGKILL mid-write leaves either the old file or the new one —
+ * never a half-written one. Critical for first-run: a crashed write
+ * would otherwise wedge the gateway in EX_CONFIG on every retry.
  */
-export const loadOrInitGatewayConfig = async (): Promise<GatewayConfig> => {
-  const path = gatewayConfigPath()
-  const base = await readOrCreate(path)
+const atomicWrite = async (path: string, text: string): Promise<void> => {
+  await Deno.mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp.${Deno.pid}`
+  try {
+    await Deno.writeTextFile(tmp, text, { mode: 0o600 })
+    await Deno.rename(tmp, path)
+  } catch (err) {
+    await Deno.remove(tmp).catch(() => {})
+    throw err
+  }
+}
+
+/**
+ * Read the on-disk config. Throws {@link Deno.errors.NotFound} if the
+ * file doesn't exist — callers use {@link ensureGatewayConfig} to
+ * create-on-miss.
+ */
+export const loadGatewayConfig = async (): Promise<GatewayConfig> => {
+  const raw = await Deno.readTextFile(gatewayConfigPath)
+  const parsed = JSON.parse(raw) as Partial<GatewayConfig>
+  if (typeof parsed.port !== 'number' || !Number.isInteger(parsed.port)) {
+    throw new Error('gateway.json: port must be an integer')
+  }
+  if (
+    typeof parsed.token !== 'string' ||
+    parsed.token.length < TOKEN_MIN_LEN
+  ) {
+    throw new Error(
+      `gateway.json: token missing or shorter than ${TOKEN_MIN_LEN} chars (256-bit)`,
+    )
+  }
+  if (parsed.mode !== 'local') {
+    throw new Error(`gateway.json: mode must be 'local' (got ${parsed.mode})`)
+  }
+  return { port: parsed.port, token: parsed.token, mode: parsed.mode }
+}
+
+/**
+ * Return the persisted config, writing a fresh one with a random
+ * token if the file doesn't exist yet. Applies the
+ * `SLV_GATEWAY_PORT` env override last.
+ */
+export const ensureGatewayConfig = async (): Promise<GatewayConfig> => {
+  let base: GatewayConfig
+  try {
+    base = await loadGatewayConfig()
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err
+    base = defaults()
+    await atomicWrite(gatewayConfigPath, JSON.stringify(base, null, 2) + '\n')
+  }
   const envPort = parseEnvPort(Deno.env.get('SLV_GATEWAY_PORT'))
   return envPort === null ? base : { ...base, port: envPort }
 }
@@ -72,35 +115,5 @@ const parseEnvPort = (raw: string | undefined): number | null => {
     )
   }
   return n
-}
-
-const readOrCreate = async (path: string): Promise<GatewayConfig> => {
-  try {
-    const raw = await Deno.readTextFile(path)
-    const parsed = JSON.parse(raw) as Partial<GatewayConfig>
-    if (typeof parsed.port !== 'number' || !Number.isInteger(parsed.port)) {
-      throw new Error('gateway.json: port must be an integer')
-    }
-    if (typeof parsed.token !== 'string' || parsed.token.length < TOKEN_MIN_LEN) {
-      throw new Error(
-        `gateway.json: token missing or shorter than ${TOKEN_MIN_LEN} chars (256-bit)`,
-      )
-    }
-    if (parsed.mode !== 'local') {
-      throw new Error(`gateway.json: mode must be 'local' (got ${parsed.mode})`)
-    }
-    return {
-      port: parsed.port,
-      token: parsed.token,
-      mode: parsed.mode,
-    }
-  } catch (err) {
-    if (!(err instanceof Deno.errors.NotFound)) throw err
-    const fresh = defaults()
-    await Deno.mkdir(dirname(path), { recursive: true })
-    await Deno.writeTextFile(path, JSON.stringify(fresh, null, 2) + '\n')
-    await Deno.chmod(path, 0o600).catch(() => {})
-    return fresh
-  }
 }
 

--- a/cli/src/gateway/config.ts
+++ b/cli/src/gateway/config.ts
@@ -1,0 +1,92 @@
+import { dirname } from '@std/path'
+import { gatewayConfigPath, GATEWAY_DEFAULT_PORT } from '/src/gateway/paths.ts'
+
+/**
+ * Gateway config persisted at ~/.slv/gateway/gateway.json.
+ *
+ * - `port` defaults to 18789 (matches OpenClaw for documentation parity).
+ * - `token` is a 256-bit random hex string generated on first run. Clients
+ *   (TUI, future web UI) read this to authenticate WS connections.
+ * - `mode: 'local'` is a hard gate — the gateway refuses to start if
+ *   missing, so misconfigured instances can't accidentally bind to a
+ *   public interface. Future modes like `lan` or `tailnet` would bypass
+ *   the loopback bind.
+ *
+ * Stored as JSON rather than YAML to match OpenClaw's precedent and
+ * because web clients will need to read it too.
+ */
+export type GatewayMode = 'local'
+
+export type GatewayConfig = {
+  port: number
+  token: string
+  mode: GatewayMode
+}
+
+const randomToken = (): string => {
+  const buf = new Uint8Array(32)
+  crypto.getRandomValues(buf)
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+const defaults = (): GatewayConfig => ({
+  port: GATEWAY_DEFAULT_PORT,
+  token: randomToken(),
+  mode: 'local',
+})
+
+/**
+ * Load the on-disk config. If the file is missing, writes a fresh one
+ * (with a random token) and returns it. If the file exists but is
+ * malformed, throws — callers should `Deno.exit(78)` (EX_CONFIG).
+ *
+ * `SLV_GATEWAY_PORT` env var overrides the persisted port at runtime
+ * (handy for local testing when the default 18789 is taken). Token
+ * and mode are always read from the file.
+ */
+export const loadOrInitGatewayConfig = async (): Promise<GatewayConfig> => {
+  const path = gatewayConfigPath()
+  const base = await readOrCreate(path)
+  const envPort = parseEnvPort(Deno.env.get('SLV_GATEWAY_PORT'))
+  return envPort === null ? base : { ...base, port: envPort }
+}
+
+const parseEnvPort = (raw: string | undefined): number | null => {
+  if (!raw) return null
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(
+      `SLV_GATEWAY_PORT must be a valid port (1-65535), got "${raw}"`,
+    )
+  }
+  return n
+}
+
+const readOrCreate = async (path: string): Promise<GatewayConfig> => {
+  try {
+    const raw = await Deno.readTextFile(path)
+    const parsed = JSON.parse(raw) as Partial<GatewayConfig>
+    if (typeof parsed.port !== 'number' || !Number.isInteger(parsed.port)) {
+      throw new Error('gateway.json: port must be an integer')
+    }
+    if (typeof parsed.token !== 'string' || parsed.token.length < 32) {
+      throw new Error('gateway.json: token missing or too short')
+    }
+    if (parsed.mode !== 'local') {
+      throw new Error(`gateway.json: mode must be 'local' (got ${parsed.mode})`)
+    }
+    return {
+      port: parsed.port,
+      token: parsed.token,
+      mode: parsed.mode,
+    }
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err
+    const fresh = defaults()
+    await Deno.mkdir(dirname(path), { recursive: true })
+    await Deno.writeTextFile(path, JSON.stringify(fresh, null, 2) + '\n')
+    await Deno.chmod(path, 0o600).catch(() => {})
+    return fresh
+  }
+}
+

--- a/cli/src/gateway/config.ts
+++ b/cli/src/gateway/config.ts
@@ -4,16 +4,14 @@ import { gatewayConfigPath, GATEWAY_DEFAULT_PORT } from '/src/gateway/paths.ts'
 /**
  * Gateway config persisted at ~/.slv/gateway/gateway.json.
  *
- * - `port` defaults to 18789 (matches OpenClaw for documentation parity).
- * - `token` is a 256-bit random hex string generated on first run. Clients
- *   (TUI, future web UI) read this to authenticate WS connections.
+ * - `port` defaults to {@link GATEWAY_DEFAULT_PORT} (20026).
+ * - `token` is a 256-bit random hex string (64 chars) generated on
+ *   first run. Clients (TUI, future web UI) read this to authenticate
+ *   WS connections.
  * - `mode: 'local'` is a hard gate — the gateway refuses to start if
  *   missing, so misconfigured instances can't accidentally bind to a
- *   public interface. Future modes like `lan` or `tailnet` would bypass
- *   the loopback bind.
- *
- * Stored as JSON rather than YAML to match OpenClaw's precedent and
- * because web clients will need to read it too.
+ *   public interface. Future modes like `lan` or `tailnet` would
+ *   bypass the loopback bind.
  */
 export type GatewayMode = 'local'
 
@@ -22,6 +20,10 @@ export type GatewayConfig = {
   token: string
   mode: GatewayMode
 }
+
+// 256 bits of entropy → 64 hex chars. Enforced both on write (below)
+// and on read (`TOKEN_MIN_LEN` check in readOrCreate).
+const TOKEN_MIN_LEN = 64
 
 const randomToken = (): string => {
   const buf = new Uint8Array(32)
@@ -34,6 +36,16 @@ const defaults = (): GatewayConfig => ({
   token: randomToken(),
   mode: 'local',
 })
+
+/**
+ * Thrown by {@link parseEnvPort} when `SLV_GATEWAY_PORT` is malformed.
+ * Separate class so runForeground can give a targeted error message
+ * instead of pointing the user at gateway.json (which isn't the
+ * problem).
+ */
+export class GatewayEnvPortError extends Error {
+  override name = 'GatewayEnvPortError'
+}
 
 /**
  * Load the on-disk config. If the file is missing, writes a fresh one
@@ -55,7 +67,7 @@ const parseEnvPort = (raw: string | undefined): number | null => {
   if (!raw) return null
   const n = Number(raw)
   if (!Number.isInteger(n) || n < 1 || n > 65535) {
-    throw new Error(
+    throw new GatewayEnvPortError(
       `SLV_GATEWAY_PORT must be a valid port (1-65535), got "${raw}"`,
     )
   }
@@ -69,8 +81,10 @@ const readOrCreate = async (path: string): Promise<GatewayConfig> => {
     if (typeof parsed.port !== 'number' || !Number.isInteger(parsed.port)) {
       throw new Error('gateway.json: port must be an integer')
     }
-    if (typeof parsed.token !== 'string' || parsed.token.length < 32) {
-      throw new Error('gateway.json: token missing or too short')
+    if (typeof parsed.token !== 'string' || parsed.token.length < TOKEN_MIN_LEN) {
+      throw new Error(
+        `gateway.json: token missing or shorter than ${TOKEN_MIN_LEN} chars (256-bit)`,
+      )
     }
     if (parsed.mode !== 'local') {
       throw new Error(`gateway.json: mode must be 'local' (got ${parsed.mode})`)

--- a/cli/src/gateway/index.ts
+++ b/cli/src/gateway/index.ts
@@ -1,0 +1,31 @@
+import { Command } from '@cliffy'
+import { runGatewayForeground } from '/src/gateway/runForeground.ts'
+
+/**
+ * `slv gateway` — WebSocket gateway daemon for the SLV AI stack.
+ *
+ * Phase 1A (this PR): `run` (foreground) only.
+ * Phase 1B: `install` / `start` / `stop` / `restart` / `status` via
+ *           launchd (macOS) or systemd --user (Linux).
+ * Phase 2:  WS upgrade + session core + event protocol.
+ */
+export const gatewayCmd = new Command()
+  .description(
+    `🌐 SLV Gateway — WebSocket daemon for the AI console and future web UI.
+
+Runs a loopback HTTP/WS server on 127.0.0.1:18789 (default) with a
+token-authed protocol shared by every UI adapter. Phase 1A ships the
+foreground runner only.`,
+  )
+  .action(() => {
+    gatewayCmd.showHelp()
+  })
+
+gatewayCmd.command('run')
+  .description(
+    'Run the gateway in the foreground (for manual testing or as systemd ExecStart)',
+  )
+  .action(async () => {
+    const code = await runGatewayForeground()
+    if (code !== 0) Deno.exit(code)
+  })

--- a/cli/src/gateway/index.ts
+++ b/cli/src/gateway/index.ts
@@ -1,21 +1,14 @@
 import { Command } from '@cliffy'
 import { runGatewayForeground } from '/src/gateway/runForeground.ts'
+import { GATEWAY_DEFAULT_PORT } from '/src/gateway/paths.ts'
 
-/**
- * `slv gateway` — WebSocket gateway daemon for the SLV AI stack.
- *
- * Phase 1A (this PR): `run` (foreground) only.
- * Phase 1B: `install` / `start` / `stop` / `restart` / `status` via
- *           launchd (macOS) or systemd --user (Linux).
- * Phase 2:  WS upgrade + session core + event protocol.
- */
 export const gatewayCmd = new Command()
   .description(
     `🌐 SLV Gateway — WebSocket daemon for the AI console and future web UI.
 
-Runs a loopback HTTP/WS server on 127.0.0.1:18789 (default) with a
-token-authed protocol shared by every UI adapter. Phase 1A ships the
-foreground runner only.`,
+Runs a loopback HTTP/WS server on 127.0.0.1:${GATEWAY_DEFAULT_PORT} (override with
+SLV_GATEWAY_PORT). Every UI adapter (TUI, future web UI) speaks the same
+token-authed protocol against this single gateway instance.`,
   )
   .action(() => {
     gatewayCmd.showHelp()
@@ -23,7 +16,7 @@ foreground runner only.`,
 
 gatewayCmd.command('run')
   .description(
-    'Run the gateway in the foreground (for manual testing or as systemd ExecStart)',
+    'Run the gateway in the foreground (for manual testing or as the systemd ExecStart)',
   )
   .action(async () => {
     const code = await runGatewayForeground()

--- a/cli/src/gateway/lock.ts
+++ b/cli/src/gateway/lock.ts
@@ -23,12 +23,22 @@ import { errToString } from '/lib/errToString.ts'
 export type LockRecord = {
   pid: number
   startedAt: string // ISO timestamp
-  linuxStartTime?: string // /proc/<pid>/stat field 22 (clock ticks since boot)
+  // Opaque string identifying the process's boot-relative start time:
+  // /proc/<pid>/stat field 22 on Linux, `ps -o lstart=` output on
+  // macOS. Used to detect PID recycling within a single system uptime
+  // (an ISO timestamp alone can't — PID+ISO get a fresh value on
+  // every lock write).
+  procStartTime?: string
   port: number
 }
 
+const readProcStartTime = async (pid: number): Promise<string | null> => {
+  if (Deno.build.os === 'linux') return readLinuxStartTime(pid)
+  if (Deno.build.os === 'darwin') return readDarwinStartTime(pid)
+  return null
+}
+
 const readLinuxStartTime = async (pid: number): Promise<string | null> => {
-  if (Deno.build.os !== 'linux') return null
   try {
     const stat = await Deno.readTextFile(`/proc/${pid}/stat`)
     // /proc/<pid>/stat fields are space-separated, but field 2 (comm)
@@ -40,6 +50,26 @@ const readLinuxStartTime = async (pid: number): Promise<string | null> => {
     if (tailStart < 0) return null
     const tail = stat.slice(tailStart + 2).trim().split(/\s+/)
     return tail[19] ?? null
+  } catch {
+    return null
+  }
+}
+
+const readDarwinStartTime = async (pid: number): Promise<string | null> => {
+  // `ps -o lstart=` prints the process's absolute start time in a
+  // locale-independent format (e.g. "Mon Apr 22 12:00:00 2026").
+  // That's enough to distinguish a recycled PID within a single boot
+  // — two processes with the same PID cannot have the exact same
+  // start second.
+  try {
+    const out = await new Deno.Command('ps', {
+      args: ['-o', 'lstart=', '-p', String(pid)],
+      stdout: 'piped',
+      stderr: 'null',
+    }).output()
+    if (!out.success) return null
+    const s = new TextDecoder().decode(out.stdout).trim()
+    return s.length > 0 ? s : null
   } catch {
     return null
   }
@@ -66,7 +96,7 @@ const isProcessAlive = (pid: number): boolean => {
 
 const readExistingLock = async (): Promise<LockRecord | null> => {
   try {
-    const raw = await Deno.readTextFile(gatewayPidPath())
+    const raw = await Deno.readTextFile(gatewayPidPath)
     return JSON.parse(raw) as LockRecord
   } catch {
     return null
@@ -74,7 +104,7 @@ const readExistingLock = async (): Promise<LockRecord | null> => {
 }
 
 const writeLock = async (rec: LockRecord): Promise<void> => {
-  const path = gatewayPidPath()
+  const path = gatewayPidPath
   await Deno.mkdir(dirname(path), { recursive: true })
   const file = await Deno.open(path, {
     createNew: true,
@@ -105,63 +135,61 @@ export type AcquireOutcome =
 export const acquireGatewayLock = async (
   port: number,
 ): Promise<AcquireOutcome> => {
-  const myStartTime = await readLinuxStartTime(Deno.pid)
+  const myStartTime = await readProcStartTime(Deno.pid)
   const record: LockRecord = {
     pid: Deno.pid,
     startedAt: new Date().toISOString(),
-    linuxStartTime: myStartTime ?? undefined,
+    procStartTime: myStartTime ?? undefined,
     port,
   }
 
-  try {
-    await writeLock(record)
-    return { state: 'acquired', record }
-  } catch (err) {
-    if (!(err instanceof Deno.errors.AlreadyExists)) {
-      return { state: 'failed', err: errToString(err) }
+  // Bounded-retry loop so two concurrent `slv gateway run` invocations
+  // that both see a stale lock don't both return `failed` — the loser
+  // re-checks and, if the winner is now alive, gets a clean `held`
+  // result instead of a confusing "lost race" error.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      await writeLock(record)
+      return { state: 'acquired', record }
+    } catch (err) {
+      if (!(err instanceof Deno.errors.AlreadyExists)) {
+        return { state: 'failed', err: errToString(err) }
+      }
     }
-  }
 
-  // Lock file exists — inspect it to decide stale vs live.
-  const existing = await readExistingLock()
-  if (existing === null) {
-    // File exists but couldn't be parsed. Treat as stale and overwrite.
-    return await replaceStaleAndClaim(record)
-  }
-
-  if (!isProcessAlive(existing.pid)) {
-    return await replaceStaleAndClaim(record)
-  }
-
-  // PID is alive. If we have a Linux start time and it matches, it IS
-  // the same gateway process — definitely held. If start times don't
-  // match, the PID was recycled and the live process is unrelated.
-  if (existing.linuxStartTime) {
-    const nowStart = await readLinuxStartTime(existing.pid)
-    if (nowStart && nowStart !== existing.linuxStartTime) {
-      return await replaceStaleAndClaim(record)
+    const existing = await readExistingLock()
+    if (existing === null) {
+      // File exists but couldn't be parsed. Treat as stale and
+      // retry — the O_EXCL create on next iteration handles the
+      // race cleanly.
+      await Deno.remove(gatewayPidPath).catch(() => {})
+      continue
     }
-    return { state: 'held', holder: existing, reason: 'linux_start_time_match' }
+
+    if (!isProcessAlive(existing.pid)) {
+      await Deno.remove(gatewayPidPath).catch(() => {})
+      continue
+    }
+
+    // PID is alive. If we captured a boot-relative start time and it
+    // matches the current /proc or `ps` readout, this is the same
+    // gateway process — definitely held. If start times differ the
+    // PID was recycled and the live process is unrelated; replace.
+    if (existing.procStartTime) {
+      const nowStart = await readProcStartTime(existing.pid)
+      if (nowStart && nowStart !== existing.procStartTime) {
+        await Deno.remove(gatewayPidPath).catch(() => {})
+        continue
+      }
+      return { state: 'held', holder: existing, reason: 'linux_start_time_match' }
+    }
+
+    return { state: 'held', holder: existing, reason: 'alive' }
   }
 
-  return { state: 'held', holder: existing, reason: 'alive' }
-}
-
-const replaceStaleAndClaim = async (
-  record: LockRecord,
-): Promise<AcquireOutcome> => {
-  await Deno.remove(gatewayPidPath()).catch(() => {})
-  try {
-    await writeLock(record)
-    return { state: 'acquired', record }
-  } catch (err) {
-    // If a concurrent `slv gateway run` won the race for the stale
-    // slot, we land here. The real holder will succeed; we bail with
-    // a clear error so the caller can surface it.
-    return {
-      state: 'failed',
-      err: `lost race to claim stale lock: ${errToString(err)}`,
-    }
+  return {
+    state: 'failed',
+    err: 'acquire retry limit exceeded — concurrent gateway lock churn',
   }
 }
 
@@ -173,5 +201,5 @@ const replaceStaleAndClaim = async (
 export const releaseGatewayLock = async (): Promise<void> => {
   const existing = await readExistingLock()
   if (!existing || existing.pid !== Deno.pid) return
-  await Deno.remove(gatewayPidPath()).catch(() => {})
+  await Deno.remove(gatewayPidPath).catch(() => {})
 }

--- a/cli/src/gateway/lock.ts
+++ b/cli/src/gateway/lock.ts
@@ -1,0 +1,157 @@
+import { dirname } from '@std/path'
+import { gatewayPidPath } from '/src/gateway/paths.ts'
+import { errToString } from '/lib/errToString.ts'
+
+/**
+ * Single-instance enforcement for the gateway daemon.
+ *
+ * The pidfile at ~/.slv/gateway/gateway.pid is opened with O_EXCL so two
+ * concurrent `slv gateway run` invocations can't both claim the slot —
+ * the second one sees AlreadyExists and has to decide whether to bail or
+ * take over a stale lock. Stale detection combines:
+ *
+ *   1. Is `pid` alive at all? (`Deno.kill(pid, 'SIGCONT')` probe)
+ *   2. On Linux, does `/proc/<pid>/stat`'s start time match what we
+ *      recorded? — PID recycling is real on long-uptime dev VPSes.
+ *
+ * If both checks agree the old process is gone, we atomically replace
+ * the stale file and take the lock. Otherwise we refuse to start.
+ */
+
+export type LockRecord = {
+  pid: number
+  startedAt: string // ISO timestamp
+  linuxStartTime?: string // /proc/<pid>/stat field 22 (clock ticks since boot)
+  port: number
+}
+
+const readLinuxStartTime = async (pid: number): Promise<string | null> => {
+  if (Deno.build.os !== 'linux') return null
+  try {
+    const stat = await Deno.readTextFile(`/proc/${pid}/stat`)
+    // /proc/<pid>/stat fields are space-separated, but field 2 (comm)
+    // can contain spaces — strip it out by cutting between the last ')'
+    // and the rest. Field 22 (starttime) is then index 19 in the tail.
+    const tailStart = stat.lastIndexOf(')')
+    if (tailStart < 0) return null
+    const tail = stat.slice(tailStart + 2).split(/\s+/)
+    return tail[19] ?? null
+  } catch {
+    return null
+  }
+}
+
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    Deno.kill(pid, 'SIGCONT')
+    return true
+  } catch {
+    return false
+  }
+}
+
+const readExistingLock = async (): Promise<LockRecord | null> => {
+  try {
+    const raw = await Deno.readTextFile(gatewayPidPath())
+    return JSON.parse(raw) as LockRecord
+  } catch {
+    return null
+  }
+}
+
+const writeLock = async (rec: LockRecord): Promise<void> => {
+  const path = gatewayPidPath()
+  await Deno.mkdir(dirname(path), { recursive: true })
+  const file = await Deno.open(path, {
+    createNew: true,
+    write: true,
+  })
+  try {
+    await file.write(new TextEncoder().encode(JSON.stringify(rec) + '\n'))
+  } finally {
+    file.close()
+  }
+}
+
+export type AcquireOutcome =
+  | { state: 'acquired'; record: LockRecord }
+  | {
+    state: 'held'
+    holder: LockRecord
+    reason: 'alive' | 'linux_start_time_match'
+  }
+  | { state: 'failed'; err: string }
+
+/**
+ * Attempt to claim the gateway lock. Stale locks (dead holder process,
+ * or Linux start-time mismatch → PID recycled) are silently replaced.
+ * Live holders cause `state: 'held'` — caller decides whether to
+ * --force kill or bail.
+ */
+export const acquireGatewayLock = async (
+  port: number,
+): Promise<AcquireOutcome> => {
+  const myStartTime = await readLinuxStartTime(Deno.pid)
+  const record: LockRecord = {
+    pid: Deno.pid,
+    startedAt: new Date().toISOString(),
+    linuxStartTime: myStartTime ?? undefined,
+    port,
+  }
+
+  try {
+    await writeLock(record)
+    return { state: 'acquired', record }
+  } catch (err) {
+    if (!(err instanceof Deno.errors.AlreadyExists)) {
+      return { state: 'failed', err: errToString(err) }
+    }
+  }
+
+  // Lock file exists — inspect it to decide stale vs live.
+  const existing = await readExistingLock()
+  if (existing === null) {
+    // File exists but couldn't be parsed. Treat as stale and overwrite.
+    await Deno.remove(gatewayPidPath()).catch(() => {})
+    try {
+      await writeLock(record)
+      return { state: 'acquired', record }
+    } catch (err2) {
+      return { state: 'failed', err: errToString(err2) }
+    }
+  }
+
+  if (!isProcessAlive(existing.pid)) {
+    await Deno.remove(gatewayPidPath()).catch(() => {})
+    try {
+      await writeLock(record)
+      return { state: 'acquired', record }
+    } catch (err2) {
+      return { state: 'failed', err: errToString(err2) }
+    }
+  }
+
+  // PID is alive. If we have a Linux start time and it matches, it IS
+  // the same gateway process — definitely held. If start times don't
+  // match, the PID was recycled and the live process is unrelated.
+  if (existing.linuxStartTime) {
+    const nowStart = await readLinuxStartTime(existing.pid)
+    if (nowStart && nowStart !== existing.linuxStartTime) {
+      await Deno.remove(gatewayPidPath()).catch(() => {})
+      try {
+        await writeLock(record)
+        return { state: 'acquired', record }
+      } catch (err2) {
+        return { state: 'failed', err: errToString(err2) }
+      }
+    }
+    return { state: 'held', holder: existing, reason: 'linux_start_time_match' }
+  }
+
+  return { state: 'held', holder: existing, reason: 'alive' }
+}
+
+/** Best-effort cleanup on graceful shutdown. */
+export const releaseGatewayLock = async (): Promise<void> => {
+  await Deno.remove(gatewayPidPath()).catch(() => {})
+}

--- a/cli/src/gateway/lock.ts
+++ b/cli/src/gateway/lock.ts
@@ -7,10 +7,12 @@ import { errToString } from '/lib/errToString.ts'
  *
  * The pidfile at ~/.slv/gateway/gateway.pid is opened with O_EXCL so two
  * concurrent `slv gateway run` invocations can't both claim the slot —
- * the second one sees AlreadyExists and has to decide whether to bail or
- * take over a stale lock. Stale detection combines:
+ * the second one sees AlreadyExists and has to decide whether to bail
+ * or take over a stale lock. Stale detection combines:
  *
- *   1. Is `pid` alive at all? (`Deno.kill(pid, 'SIGCONT')` probe)
+ *   1. Is `pid` alive at all? (probed via `Deno.kill(pid, 'SIGCONT')`,
+ *      with EPERM treated as "alive, owned by someone else" rather
+ *      than "dead" — see isProcessAlive below).
  *   2. On Linux, does `/proc/<pid>/stat`'s start time match what we
  *      recorded? — PID recycling is real on long-uptime dev VPSes.
  *
@@ -30,22 +32,34 @@ const readLinuxStartTime = async (pid: number): Promise<string | null> => {
   try {
     const stat = await Deno.readTextFile(`/proc/${pid}/stat`)
     // /proc/<pid>/stat fields are space-separated, but field 2 (comm)
-    // can contain spaces — strip it out by cutting between the last ')'
-    // and the rest. Field 22 (starttime) is then index 19 in the tail.
+    // can contain spaces and `)`, so cut at the LAST `)`. After that
+    // delimiter the layout is: state ppid pgrp ... starttime ...
+    // starttime is field 22, which is index 19 in the tail array
+    // (fields 3-22 = indices 0-19).
     const tailStart = stat.lastIndexOf(')')
     if (tailStart < 0) return null
-    const tail = stat.slice(tailStart + 2).split(/\s+/)
+    const tail = stat.slice(tailStart + 2).trim().split(/\s+/)
     return tail[19] ?? null
   } catch {
     return null
   }
 }
 
+/**
+ * True if a process with this PID exists and we can signal it.
+ * Important semantic: we DO treat `PermissionDenied` (EPERM) as alive
+ * rather than dead. EPERM means the PID exists but is owned by another
+ * user (e.g. a root-started gateway probed by an unprivileged user);
+ * treating it as dead would lead us to unlink that user's valid
+ * pidfile and claim the slot, only to fail with EADDRINUSE when we
+ * try to bind. Safer to refuse.
+ */
 const isProcessAlive = (pid: number): boolean => {
   try {
     Deno.kill(pid, 'SIGCONT')
     return true
-  } catch {
+  } catch (err) {
+    if (err instanceof Deno.errors.PermissionDenied) return true
     return false
   }
 }
@@ -112,23 +126,11 @@ export const acquireGatewayLock = async (
   const existing = await readExistingLock()
   if (existing === null) {
     // File exists but couldn't be parsed. Treat as stale and overwrite.
-    await Deno.remove(gatewayPidPath()).catch(() => {})
-    try {
-      await writeLock(record)
-      return { state: 'acquired', record }
-    } catch (err2) {
-      return { state: 'failed', err: errToString(err2) }
-    }
+    return await replaceStaleAndClaim(record)
   }
 
   if (!isProcessAlive(existing.pid)) {
-    await Deno.remove(gatewayPidPath()).catch(() => {})
-    try {
-      await writeLock(record)
-      return { state: 'acquired', record }
-    } catch (err2) {
-      return { state: 'failed', err: errToString(err2) }
-    }
+    return await replaceStaleAndClaim(record)
   }
 
   // PID is alive. If we have a Linux start time and it matches, it IS
@@ -137,13 +139,7 @@ export const acquireGatewayLock = async (
   if (existing.linuxStartTime) {
     const nowStart = await readLinuxStartTime(existing.pid)
     if (nowStart && nowStart !== existing.linuxStartTime) {
-      await Deno.remove(gatewayPidPath()).catch(() => {})
-      try {
-        await writeLock(record)
-        return { state: 'acquired', record }
-      } catch (err2) {
-        return { state: 'failed', err: errToString(err2) }
-      }
+      return await replaceStaleAndClaim(record)
     }
     return { state: 'held', holder: existing, reason: 'linux_start_time_match' }
   }
@@ -151,7 +147,31 @@ export const acquireGatewayLock = async (
   return { state: 'held', holder: existing, reason: 'alive' }
 }
 
-/** Best-effort cleanup on graceful shutdown. */
+const replaceStaleAndClaim = async (
+  record: LockRecord,
+): Promise<AcquireOutcome> => {
+  await Deno.remove(gatewayPidPath()).catch(() => {})
+  try {
+    await writeLock(record)
+    return { state: 'acquired', record }
+  } catch (err) {
+    // If a concurrent `slv gateway run` won the race for the stale
+    // slot, we land here. The real holder will succeed; we bail with
+    // a clear error so the caller can surface it.
+    return {
+      state: 'failed',
+      err: `lost race to claim stale lock: ${errToString(err)}`,
+    }
+  }
+}
+
+/**
+ * Release the pidfile ONLY if it still refers to us. Defends against
+ * removing a foreign daemon's lock if it somehow got swapped in
+ * underneath us.
+ */
 export const releaseGatewayLock = async (): Promise<void> => {
+  const existing = await readExistingLock()
+  if (!existing || existing.pid !== Deno.pid) return
   await Deno.remove(gatewayPidPath()).catch(() => {})
 }

--- a/cli/src/gateway/paths.ts
+++ b/cli/src/gateway/paths.ts
@@ -6,8 +6,8 @@ import { configRoot } from '@cmn/constants/path.ts'
 // lookup points for every other gateway subcommand and for clients
 // (TUI / future web UI) that need to discover the running instance.
 
-// 20026: non-registered, and avoids OpenClaw's 18789 so both daemons
-// can coexist on the same host during dogfooding.
+// 20026: non-registered port, and avoids OpenClaw's 18789 so both
+// daemons can coexist on the same host during dogfooding.
 export const GATEWAY_DEFAULT_PORT = 20026
 
 // Identifier served at `GET /` so clients can verify they're actually
@@ -16,13 +16,9 @@ export const GATEWAY_DEFAULT_PORT = 20026
 export const GATEWAY_SERVICE_ID = 'slv-gateway'
 export const GATEWAY_PROTOCOL_VERSION = '1'
 
-export const gatewayStateDir = (): string => join(configRoot, 'gateway')
-export const gatewayConfigPath = (): string =>
-  join(gatewayStateDir(), 'gateway.json')
-export const gatewayPidPath = (): string =>
-  join(gatewayStateDir(), 'gateway.pid')
-export const gatewayLogDir = (): string => join(gatewayStateDir(), 'logs')
-export const gatewayLogPath = (): string =>
-  join(gatewayLogDir(), 'gateway.log')
-export const gatewayErrLogPath = (): string =>
-  join(gatewayLogDir(), 'gateway.err.log')
+export const gatewayStateDir = join(configRoot, 'gateway')
+export const gatewayConfigPath = join(gatewayStateDir, 'gateway.json')
+export const gatewayPidPath = join(gatewayStateDir, 'gateway.pid')
+export const gatewayLogDir = join(gatewayStateDir, 'logs')
+export const gatewayLogPath = join(gatewayLogDir, 'gateway.log')
+export const gatewayErrLogPath = join(gatewayLogDir, 'gateway.err.log')

--- a/cli/src/gateway/paths.ts
+++ b/cli/src/gateway/paths.ts
@@ -6,7 +6,15 @@ import { configRoot } from '@cmn/constants/path.ts'
 // lookup points for every other gateway subcommand and for clients
 // (TUI / future web UI) that need to discover the running instance.
 
-export const GATEWAY_DEFAULT_PORT = 18789
+// 20026: non-registered, and avoids OpenClaw's 18789 so both daemons
+// can coexist on the same host during dogfooding.
+export const GATEWAY_DEFAULT_PORT = 20026
+
+// Identifier served at `GET /` so clients can verify they're actually
+// talking to an slv gateway (not some other service that happened to
+// bind this port). Bumped with any breaking protocol change.
+export const GATEWAY_SERVICE_ID = 'slv-gateway'
+export const GATEWAY_PROTOCOL_VERSION = '1'
 
 export const gatewayStateDir = (): string => join(configRoot, 'gateway')
 export const gatewayConfigPath = (): string =>

--- a/cli/src/gateway/paths.ts
+++ b/cli/src/gateway/paths.ts
@@ -1,0 +1,20 @@
+import { join } from '@std/path'
+import { configRoot } from '@cmn/constants/path.ts'
+
+// All gateway state lives under ~/.slv/gateway/. The dir is created on
+// first `slv gateway run`; the files listed here are the authoritative
+// lookup points for every other gateway subcommand and for clients
+// (TUI / future web UI) that need to discover the running instance.
+
+export const GATEWAY_DEFAULT_PORT = 18789
+
+export const gatewayStateDir = (): string => join(configRoot, 'gateway')
+export const gatewayConfigPath = (): string =>
+  join(gatewayStateDir(), 'gateway.json')
+export const gatewayPidPath = (): string =>
+  join(gatewayStateDir(), 'gateway.pid')
+export const gatewayLogDir = (): string => join(gatewayStateDir(), 'logs')
+export const gatewayLogPath = (): string =>
+  join(gatewayLogDir(), 'gateway.log')
+export const gatewayErrLogPath = (): string =>
+  join(gatewayLogDir(), 'gateway.err.log')

--- a/cli/src/gateway/runForeground.ts
+++ b/cli/src/gateway/runForeground.ts
@@ -1,0 +1,146 @@
+import { colors } from '@cliffy/colors'
+import { Hono } from '@hono/hono'
+import { loadOrInitGatewayConfig } from '/src/gateway/config.ts'
+import {
+  acquireGatewayLock,
+  releaseGatewayLock,
+} from '/src/gateway/lock.ts'
+import { gatewayConfigPath, gatewayPidPath } from '/src/gateway/paths.ts'
+
+// Exit codes align with sysexits.h so a future systemd unit can set
+// RestartPreventExitStatus=78 to avoid crash-looping on a bad config.
+const EX_CONFIG = 78
+const EX_TEMPFAIL = 75
+const EX_UNAVAILABLE = 69
+
+type RunOptions = {
+  force?: boolean // future: --force to evict a live holder
+}
+
+/**
+ * Foreground gateway runner. Phase 1A scope: bind loopback HTTP with a
+ * /healthz endpoint, acquire the pidfile lock, install signal handlers
+ * for graceful shutdown. WS upgrade + session core come in Phase 1B.
+ *
+ * Intended as the ExecStart of a future launchd/systemd unit — the
+ * process runs in the foreground, logs to stdout/stderr, and exits
+ * cleanly on SIGTERM/SIGINT.
+ */
+export const runGatewayForeground = async (
+  _options: RunOptions = {},
+): Promise<number> => {
+  let config
+  try {
+    config = await loadOrInitGatewayConfig()
+  } catch (err) {
+    console.error(
+      colors.red(
+        `❌ gateway config is invalid: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      ),
+    )
+    console.error(
+      colors.white(`   Fix or delete ${gatewayConfigPath()} and retry.`),
+    )
+    return EX_CONFIG
+  }
+
+  const lock = await acquireGatewayLock(config.port)
+  if (lock.state === 'held') {
+    console.error(
+      colors.red(
+        `❌ gateway is already running (pid=${lock.holder.pid}, ` +
+          `since ${lock.holder.startedAt}, port=${lock.holder.port}).`,
+      ),
+    )
+    console.error(
+      colors.white(
+        `   Stop it with \`slv gateway stop\` (Phase 1B) or \`kill ${lock.holder.pid}\`.`,
+      ),
+    )
+    return EX_TEMPFAIL
+  }
+  if (lock.state === 'failed') {
+    console.error(colors.red(`❌ failed to acquire gateway lock: ${lock.err}`))
+    return EX_UNAVAILABLE
+  }
+
+  const app = new Hono()
+  app.get('/healthz', (c) =>
+    c.json({
+      ok: true,
+      pid: Deno.pid,
+      port: config.port,
+      startedAt: lock.record.startedAt,
+    }))
+
+  // Root endpoint returns a stub so clients probing the port can tell
+  // this is an slv gateway (not some other service that happens to
+  // share 18789).
+  app.get('/', (c) =>
+    c.json({
+      service: 'slv-gateway',
+      version: '1',
+      note: 'WS endpoints arrive in Phase 1B',
+    }))
+
+  // Start listening on loopback explicitly. Deno.serve defaults to
+  // 0.0.0.0 — which would be a serious security footgun for a process
+  // that executes shell tools on the host.
+  let server: { shutdown: () => Promise<void>; finished: Promise<void> }
+  try {
+    server = Deno.serve(
+      { port: config.port, hostname: '127.0.0.1' },
+      app.fetch,
+    )
+  } catch (err) {
+    await releaseGatewayLock()
+    // EADDRINUSE at the OS level — pidfile didn't know about whoever
+    // owns the port. Rare but possible (someone started a non-slv
+    // server on 18789). Surface clearly.
+    console.error(
+      colors.red(
+        `❌ failed to bind 127.0.0.1:${config.port}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      ),
+    )
+    return EX_TEMPFAIL
+  }
+
+  console.log(
+    colors.green(
+      `✅ slv gateway running on http://127.0.0.1:${config.port} (pid=${Deno.pid})`,
+    ),
+  )
+  console.log(colors.gray(`   config:  ${gatewayConfigPath()}`))
+  console.log(colors.gray(`   pidfile: ${gatewayPidPath()}`))
+  console.log(colors.gray(`   healthz: curl http://127.0.0.1:${config.port}/healthz`))
+
+  // Graceful shutdown. We listen for both SIGTERM (service managers)
+  // and SIGINT (Ctrl+C in foreground). Either signal stops the HTTP
+  // listener, waits for the `finished` promise to settle, removes the
+  // pidfile, and exits 0. If the signal fires twice, the second one
+  // hits the Deno default handler which is an immediate exit.
+  let shuttingDown = false
+  const gracefulShutdown = async (signal: string) => {
+    if (shuttingDown) return
+    shuttingDown = true
+    console.log(
+      colors.yellow(`\n⏸  received ${signal}, shutting down...`),
+    )
+    try {
+      await server.shutdown()
+    } catch { /* ignore */ }
+    await releaseGatewayLock()
+    console.log(colors.green('✅ gateway stopped'))
+    Deno.exit(0)
+  }
+  Deno.addSignalListener('SIGTERM', () => void gracefulShutdown('SIGTERM'))
+  Deno.addSignalListener('SIGINT', () => void gracefulShutdown('SIGINT'))
+
+  await server.finished
+  await releaseGatewayLock()
+  return 0
+}

--- a/cli/src/gateway/runForeground.ts
+++ b/cli/src/gateway/runForeground.ts
@@ -1,21 +1,26 @@
 import { colors } from '@cliffy/colors'
 import { Hono } from '@hono/hono'
-import { loadOrInitGatewayConfig } from '/src/gateway/config.ts'
+import {
+  GatewayEnvPortError,
+  loadOrInitGatewayConfig,
+} from '/src/gateway/config.ts'
 import {
   acquireGatewayLock,
   releaseGatewayLock,
 } from '/src/gateway/lock.ts'
-import { gatewayConfigPath, gatewayPidPath } from '/src/gateway/paths.ts'
+import {
+  gatewayConfigPath,
+  gatewayPidPath,
+  GATEWAY_PROTOCOL_VERSION,
+  GATEWAY_SERVICE_ID,
+} from '/src/gateway/paths.ts'
+import { errToString } from '/lib/errToString.ts'
 
 // Exit codes align with sysexits.h so a future systemd unit can set
 // RestartPreventExitStatus=78 to avoid crash-looping on a bad config.
 const EX_CONFIG = 78
 const EX_TEMPFAIL = 75
 const EX_UNAVAILABLE = 69
-
-type RunOptions = {
-  force?: boolean // future: --force to evict a live holder
-}
 
 /**
  * Foreground gateway runner. Phase 1A scope: bind loopback HTTP with a
@@ -26,25 +31,9 @@ type RunOptions = {
  * process runs in the foreground, logs to stdout/stderr, and exits
  * cleanly on SIGTERM/SIGINT.
  */
-export const runGatewayForeground = async (
-  _options: RunOptions = {},
-): Promise<number> => {
-  let config
-  try {
-    config = await loadOrInitGatewayConfig()
-  } catch (err) {
-    console.error(
-      colors.red(
-        `❌ gateway config is invalid: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      ),
-    )
-    console.error(
-      colors.white(`   Fix or delete ${gatewayConfigPath()} and retry.`),
-    )
-    return EX_CONFIG
-  }
+export const runGatewayForeground = async (): Promise<number> => {
+  const config = await loadConfigOrFail()
+  if (typeof config === 'number') return config
 
   const lock = await acquireGatewayLock(config.port)
   if (lock.state === 'held') {
@@ -66,6 +55,46 @@ export const runGatewayForeground = async (
     return EX_UNAVAILABLE
   }
 
+  // Signal handlers MUST be in place before we spend time binding the
+  // HTTP listener — otherwise a SIGTERM during the bind window would
+  // hit Deno's default handler and exit without releasing the pidfile,
+  // stranding the lock. The `serverRef` box lets the handler observe
+  // whether the listener is live yet.
+  const serverRef: {
+    server:
+      | { shutdown: () => Promise<void>; finished: Promise<void> }
+      | null
+  } = { server: null }
+  let shuttingDown = false
+  const gracefulShutdown = (signal: string) => {
+    if (shuttingDown) return
+    shuttingDown = true
+    console.log(colors.yellow(`\n⏸  received ${signal}, shutting down...`))
+    // If the listener isn't up yet, release the lock directly. The
+    // main flow's bind attempt will see `shuttingDown` via the server
+    // ref and bail.
+    if (serverRef.server === null) {
+      releaseGatewayLock()
+        .catch(() => {})
+        .finally(() => Deno.exit(0))
+      return
+    }
+    // Listener is up — tell it to stop accepting. `finished` will
+    // resolve, the main flow reaches the releaseGatewayLock + return 0
+    // path naturally, and the process exits via program.parse
+    // settling.
+    serverRef.server.shutdown().catch(() => {})
+  }
+  Deno.addSignalListener('SIGTERM', () => gracefulShutdown('SIGTERM'))
+  Deno.addSignalListener('SIGINT', () => gracefulShutdown('SIGINT'))
+
+  if (shuttingDown) {
+    // A signal fired between addSignalListener calls and here.
+    // Release the lock and bail cleanly.
+    await releaseGatewayLock()
+    return 0
+  }
+
   const app = new Hono()
   app.get('/healthz', (c) =>
     c.json({
@@ -74,36 +103,25 @@ export const runGatewayForeground = async (
       port: config.port,
       startedAt: lock.record.startedAt,
     }))
-
-  // Root endpoint returns a stub so clients probing the port can tell
-  // this is an slv gateway (not some other service that happens to
-  // share 18789).
   app.get('/', (c) =>
     c.json({
-      service: 'slv-gateway',
-      version: '1',
+      service: GATEWAY_SERVICE_ID,
+      version: GATEWAY_PROTOCOL_VERSION,
       note: 'WS endpoints arrive in Phase 1B',
     }))
 
-  // Start listening on loopback explicitly. Deno.serve defaults to
-  // 0.0.0.0 — which would be a serious security footgun for a process
-  // that executes shell tools on the host.
-  let server: { shutdown: () => Promise<void>; finished: Promise<void> }
+  // Bind loopback explicitly. Deno.serve defaults to 0.0.0.0 — a
+  // serious footgun for a process that executes shell tools.
   try {
-    server = Deno.serve(
+    serverRef.server = Deno.serve(
       { port: config.port, hostname: '127.0.0.1' },
       app.fetch,
     )
   } catch (err) {
     await releaseGatewayLock()
-    // EADDRINUSE at the OS level — pidfile didn't know about whoever
-    // owns the port. Rare but possible (someone started a non-slv
-    // server on 18789). Surface clearly.
     console.error(
       colors.red(
-        `❌ failed to bind 127.0.0.1:${config.port}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+        `❌ failed to bind 127.0.0.1:${config.port}: ${errToString(err)}`,
       ),
     )
     return EX_TEMPFAIL
@@ -116,31 +134,38 @@ export const runGatewayForeground = async (
   )
   console.log(colors.gray(`   config:  ${gatewayConfigPath()}`))
   console.log(colors.gray(`   pidfile: ${gatewayPidPath()}`))
-  console.log(colors.gray(`   healthz: curl http://127.0.0.1:${config.port}/healthz`))
+  console.log(
+    colors.gray(`   healthz: curl http://127.0.0.1:${config.port}/healthz`),
+  )
 
-  // Graceful shutdown. We listen for both SIGTERM (service managers)
-  // and SIGINT (Ctrl+C in foreground). Either signal stops the HTTP
-  // listener, waits for the `finished` promise to settle, removes the
-  // pidfile, and exits 0. If the signal fires twice, the second one
-  // hits the Deno default handler which is an immediate exit.
-  let shuttingDown = false
-  const gracefulShutdown = async (signal: string) => {
-    if (shuttingDown) return
-    shuttingDown = true
-    console.log(
-      colors.yellow(`\n⏸  received ${signal}, shutting down...`),
-    )
-    try {
-      await server.shutdown()
-    } catch { /* ignore */ }
-    await releaseGatewayLock()
-    console.log(colors.green('✅ gateway stopped'))
-    Deno.exit(0)
-  }
-  Deno.addSignalListener('SIGTERM', () => void gracefulShutdown('SIGTERM'))
-  Deno.addSignalListener('SIGINT', () => void gracefulShutdown('SIGINT'))
-
-  await server.finished
+  await serverRef.server.finished
   await releaseGatewayLock()
+  console.log(colors.green('✅ gateway stopped'))
   return 0
+}
+
+/**
+ * Load the persisted config with focused error reporting:
+ * - Bad `SLV_GATEWAY_PORT` → targeted env-var message (don't blame
+ *   the file the user didn't touch).
+ * - Anything else → EX_CONFIG pointing at the real config file.
+ */
+const loadConfigOrFail = async (): Promise<
+  Awaited<ReturnType<typeof loadOrInitGatewayConfig>> | number
+> => {
+  try {
+    return await loadOrInitGatewayConfig()
+  } catch (err) {
+    if (err instanceof GatewayEnvPortError) {
+      console.error(colors.red(`❌ ${err.message}`))
+      return EX_CONFIG
+    }
+    console.error(
+      colors.red(`❌ gateway config is invalid: ${errToString(err)}`),
+    )
+    console.error(
+      colors.white(`   Fix or delete ${gatewayConfigPath()} and retry.`),
+    )
+    return EX_CONFIG
+  }
 }

--- a/cli/src/gateway/runForeground.ts
+++ b/cli/src/gateway/runForeground.ts
@@ -1,8 +1,8 @@
 import { colors } from '@cliffy/colors'
 import { Hono } from '@hono/hono'
 import {
+  ensureGatewayConfig,
   GatewayEnvPortError,
-  loadOrInitGatewayConfig,
 } from '/src/gateway/config.ts'
 import {
   acquireGatewayLock,
@@ -85,12 +85,25 @@ export const runGatewayForeground = async (): Promise<number> => {
     // settling.
     serverRef.server.shutdown().catch(() => {})
   }
-  Deno.addSignalListener('SIGTERM', () => gracefulShutdown('SIGTERM'))
-  Deno.addSignalListener('SIGINT', () => gracefulShutdown('SIGINT'))
+  // Capture the bound callbacks so we can remove them on clean exit —
+  // matters if this function is ever called twice in one process
+  // (hot reload, integration test harness) where leaked listeners
+  // would race `Deno.exit(0)`.
+  const sigtermHandler = () => gracefulShutdown('SIGTERM')
+  const sigintHandler = () => gracefulShutdown('SIGINT')
+  Deno.addSignalListener('SIGTERM', sigtermHandler)
+  Deno.addSignalListener('SIGINT', sigintHandler)
+  const removeSignalHandlers = () => {
+    try {
+      Deno.removeSignalListener('SIGTERM', sigtermHandler)
+      Deno.removeSignalListener('SIGINT', sigintHandler)
+    } catch { /* already removed / process exiting */ }
+  }
 
   if (shuttingDown) {
     // A signal fired between addSignalListener calls and here.
     // Release the lock and bail cleanly.
+    removeSignalHandlers()
     await releaseGatewayLock()
     return 0
   }
@@ -118,6 +131,7 @@ export const runGatewayForeground = async (): Promise<number> => {
       app.fetch,
     )
   } catch (err) {
+    removeSignalHandlers()
     await releaseGatewayLock()
     console.error(
       colors.red(
@@ -132,13 +146,14 @@ export const runGatewayForeground = async (): Promise<number> => {
       `✅ slv gateway running on http://127.0.0.1:${config.port} (pid=${Deno.pid})`,
     ),
   )
-  console.log(colors.gray(`   config:  ${gatewayConfigPath()}`))
-  console.log(colors.gray(`   pidfile: ${gatewayPidPath()}`))
+  console.log(colors.gray(`   config:  ${gatewayConfigPath}`))
+  console.log(colors.gray(`   pidfile: ${gatewayPidPath}`))
   console.log(
     colors.gray(`   healthz: curl http://127.0.0.1:${config.port}/healthz`),
   )
 
   await serverRef.server.finished
+  removeSignalHandlers()
   await releaseGatewayLock()
   console.log(colors.green('✅ gateway stopped'))
   return 0
@@ -151,10 +166,10 @@ export const runGatewayForeground = async (): Promise<number> => {
  * - Anything else → EX_CONFIG pointing at the real config file.
  */
 const loadConfigOrFail = async (): Promise<
-  Awaited<ReturnType<typeof loadOrInitGatewayConfig>> | number
+  Awaited<ReturnType<typeof ensureGatewayConfig>> | number
 > => {
   try {
-    return await loadOrInitGatewayConfig()
+    return await ensureGatewayConfig()
   } catch (err) {
     if (err instanceof GatewayEnvPortError) {
       console.error(colors.red(`❌ ${err.message}`))
@@ -164,7 +179,7 @@ const loadConfigOrFail = async (): Promise<
       colors.red(`❌ gateway config is invalid: ${errToString(err)}`),
     )
     console.error(
-      colors.white(`   Fix or delete ${gatewayConfigPath()} and retry.`),
+      colors.white(`   Fix or delete ${gatewayConfigPath} and retry.`),
     )
     return EX_CONFIG
   }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -23,6 +23,7 @@ import { authCmd } from '@/auth/index.ts'
 import { airdropCmd } from '@/airdrop/index.ts'
 import { disableCmd } from '@/disable/index.ts'
 import { addSshCmd } from '@/addSsh/index.ts'
+import { gatewayCmd } from '@/gateway/index.ts'
 import { prepareLocalDb } from '@db/dbInit.ts'
 
 const program = new Command()
@@ -123,5 +124,8 @@ program
 
 program
   .command('add:ssh', addSshCmd)
+
+program
+  .command('gateway', gatewayCmd)
 
 await program.parse(Deno.args)

--- a/cli/test/integration/gateway_foreground.test.ts
+++ b/cli/test/integration/gateway_foreground.test.ts
@@ -1,0 +1,304 @@
+import { assert, assertEquals, assertMatch } from '@std/assert'
+import { join } from '@std/path'
+
+// Integration tests for `slv gateway run`. Each test spawns the CLI as
+// a subprocess with an isolated HOME + port so they don't pollute the
+// developer's real ~/.slv/gateway/ nor collide with each other. Tests
+// interact via HTTP /healthz, the JSON pidfile on disk, and exit codes.
+//
+// Deno's resource/op sanitizers flag subprocess streams as leaks even
+// when we fully manage them, so each test opts out (sanitizeResources
+// and sanitizeOps both false). We still cancel streams + await status
+// in the shared cleanup helper, so nothing actually leaks at the OS
+// level.
+
+const CLI_ENTRY = new URL('../../src/index.ts', import.meta.url).pathname
+
+const pickPort = (): number => 30000 + Math.floor(Math.random() * 10000)
+
+type Proc = {
+  child: Deno.ChildProcess
+  home: string
+  port: number
+  stderr: Promise<string> // eagerly-drained stderr text
+}
+
+const spawnGateway = async (
+  opts: {
+    port?: number
+    homeSeed?: (home: string) => void | Promise<void>
+    envPort?: string // override SLV_GATEWAY_PORT literally (bad-port tests)
+  } = {},
+): Promise<Proc> => {
+  const home = await Deno.makeTempDir({ prefix: 'slv-gw-it-' })
+  if (opts.homeSeed) await opts.homeSeed(home)
+  const port = opts.port ?? pickPort()
+  const env: Record<string, string> = {
+    HOME: home,
+    PATH: Deno.env.get('PATH') ?? '/usr/bin:/bin',
+    SLV_GATEWAY_PORT: opts.envPort ?? String(port),
+  }
+  const child = new Deno.Command(Deno.execPath(), {
+    args: ['run', '-A', '--no-check', CLI_ENTRY, 'gateway', 'run'],
+    env,
+    stdin: 'null',
+    stdout: 'piped',
+    stderr: 'piped',
+  }).spawn()
+  // Eagerly drain stdout so the subprocess can't block on a full pipe
+  // during tests that don't care about it. The stderr future is
+  // returned for tests that assert on it.
+  const drain = async (s: ReadableStream<Uint8Array>): Promise<string> => {
+    const chunks: Uint8Array[] = []
+    const reader = s.getReader()
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      if (value) chunks.push(value)
+    }
+    const total = chunks.reduce((n, c) => n + c.length, 0)
+    const out = new Uint8Array(total)
+    let o = 0
+    for (const c of chunks) {
+      out.set(c, o)
+      o += c.length
+    }
+    return new TextDecoder().decode(out)
+  }
+  drain(child.stdout).catch(() => {})
+  const stderr = drain(child.stderr).catch(() => '')
+  return { child, home, port, stderr }
+}
+
+const waitForHealthz = async (
+  port: number,
+  timeoutMs = 10_000,
+): Promise<{ ok: boolean; pid: number; port: number; startedAt: string }> => {
+  const deadline = Date.now() + timeoutMs
+  let lastErr: unknown
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/healthz`)
+      if (res.ok) return await res.json()
+      await res.body?.cancel()
+    } catch (err) {
+      lastErr = err
+    }
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error(
+    `gateway did not become healthy on :${port} within ${timeoutMs}ms${
+      lastErr ? ` (last: ${lastErr})` : ''
+    }`,
+  )
+}
+
+const cleanup = async (p: Proc) => {
+  try {
+    p.child.kill('SIGTERM')
+  } catch { /* already dead */ }
+  await p.child.status.catch(() => {})
+  await p.stderr // ensure stderr drain has completed
+  await Deno.remove(p.home, { recursive: true }).catch(() => {})
+}
+
+// Shared options for every subprocess test: subprocess streams are
+// owned by the helper + drained; Deno's sanitizer doesn't know that.
+const sub = { sanitizeResources: false, sanitizeOps: false } as const
+
+Deno.test(
+  'gateway run: fresh start writes config + pidfile, /healthz works, SIGTERM cleans up',
+  sub,
+  async () => {
+    const p = await spawnGateway()
+    try {
+      const body = await waitForHealthz(p.port)
+      assertEquals(body.ok, true)
+      assertEquals(body.port, p.port)
+      assert(typeof body.pid === 'number' && body.pid > 0)
+      assertMatch(body.startedAt, /^\d{4}-\d{2}-\d{2}T/)
+
+      // Config written with 256-bit token. Note: SLV_GATEWAY_PORT
+      // overrides at runtime but does NOT persist — the file stores
+      // the default port and env overrides are layered on at load
+      // time. So we check port is a valid integer, not the env value.
+      const cfg = JSON.parse(
+        await Deno.readTextFile(join(p.home, '.slv/gateway/gateway.json')),
+      )
+      assert(Number.isInteger(cfg.port) && cfg.port > 0 && cfg.port <= 65535)
+      assertEquals(cfg.mode, 'local')
+      assertMatch(cfg.token, /^[0-9a-f]{64}$/)
+
+      // Pidfile present with matching pid
+      const pidRaw = await Deno.readTextFile(
+        join(p.home, '.slv/gateway/gateway.pid'),
+      )
+      const pid = JSON.parse(pidRaw)
+      assertEquals(pid.pid, body.pid)
+      assertEquals(pid.port, p.port)
+
+      // SIGTERM → graceful shutdown → pidfile removed → exit status is
+      // either 0 (clean exit) or signal=SIGTERM (OS reaped us). Both
+      // mean our handler did its cleanup job; pidfile absence is the
+      // authoritative check.
+      p.child.kill('SIGTERM')
+      const status = await p.child.status
+      assert(
+        status.code === 0 || status.signal === 'SIGTERM',
+        `unexpected exit: code=${status.code} signal=${status.signal}`,
+      )
+      const pidExists = await Deno.stat(
+        join(p.home, '.slv/gateway/gateway.pid'),
+      ).then(() => true).catch(() => false)
+      assertEquals(
+        pidExists,
+        false,
+        'pidfile should be removed on graceful exit',
+      )
+    } finally {
+      await cleanup(p)
+    }
+  },
+)
+
+Deno.test(
+  'gateway run: bad SLV_GATEWAY_PORT exits EX_CONFIG with targeted message',
+  sub,
+  async () => {
+    const p = await spawnGateway({ envPort: 'abc' })
+    try {
+      const status = await p.child.status
+      const err = await p.stderr
+      assertEquals(status.code, 78) // EX_CONFIG
+      assertMatch(err, /SLV_GATEWAY_PORT/)
+      // Must NOT blame gateway.json — user didn't touch it
+      assert(
+        !/Fix or delete .*gateway\.json/.test(err),
+        `bad env port should not blame gateway.json: ${err}`,
+      )
+    } finally {
+      await cleanup(p)
+    }
+  },
+)
+
+Deno.test(
+  'gateway run: second instance on same pidfile rejected with kill hint',
+  sub,
+  async () => {
+    const first = await spawnGateway()
+    try {
+      await waitForHealthz(first.port)
+      const firstPid = first.child.pid
+
+      // Second run with a different HOME but sharing the first's
+      // gateway dir (via symlink) — exercises the PIDFILE collision
+      // path, not the port-bind path. Uses a different port to isolate.
+      const secondPort = pickPort()
+      const second = await spawnGateway({
+        port: secondPort,
+        homeSeed: async (home) => {
+          await Deno.mkdir(join(home, '.slv'), { recursive: true })
+          await Deno.symlink(
+            join(first.home, '.slv/gateway'),
+            join(home, '.slv/gateway'),
+          )
+        },
+      })
+      try {
+        const status = await second.child.status
+        const err = await second.stderr
+        assertEquals(status.code, 75) // EX_TEMPFAIL
+        assertMatch(err, /already running/)
+        assertMatch(err, new RegExp(`kill ${firstPid}`))
+      } finally {
+        await cleanup(second)
+      }
+    } finally {
+      await cleanup(first)
+    }
+  },
+)
+
+Deno.test(
+  'gateway run: stale pidfile (dead pid) is auto-replaced',
+  sub,
+  async () => {
+    const p = await spawnGateway({
+      homeSeed: async (home) => {
+        const dir = join(home, '.slv/gateway')
+        await Deno.mkdir(dir, { recursive: true })
+        // Seed pidfile with a PID that's definitively dead: spawn a
+        // no-op child, wait for it to exit, grab its pid. Within a
+        // few ms, nothing else will have recycled that pid.
+        const tomb = new Deno.Command('true', {
+          stdin: 'null',
+          stdout: 'null',
+          stderr: 'null',
+        }).spawn()
+        const deadPid = tomb.pid
+        await tomb.status
+        await Deno.writeTextFile(
+          join(dir, 'gateway.pid'),
+          JSON.stringify({
+            pid: deadPid,
+            startedAt: '1970-01-01T00:00:00Z',
+            port: 99999,
+          }),
+        )
+      },
+    })
+    try {
+      const body = await waitForHealthz(p.port)
+      assertEquals(body.ok, true)
+      // Lock was replaced with our fresh pid
+      const pid = JSON.parse(
+        await Deno.readTextFile(join(p.home, '.slv/gateway/gateway.pid')),
+      )
+      assertEquals(pid.pid, body.pid)
+      assertEquals(pid.port, p.port)
+    } finally {
+      await cleanup(p)
+    }
+  },
+)
+
+Deno.test(
+  'gateway run: malformed gateway.json exits EX_CONFIG pointing at the file',
+  sub,
+  async () => {
+    const p = await spawnGateway({
+      homeSeed: async (home) => {
+        const dir = join(home, '.slv/gateway')
+        await Deno.mkdir(dir, { recursive: true })
+        await Deno.writeTextFile(join(dir, 'gateway.json'), '{partial')
+      },
+    })
+    try {
+      const status = await p.child.status
+      const err = await p.stderr
+      assertEquals(status.code, 78) // EX_CONFIG
+      assertMatch(err, /gateway\.json/)
+      assertMatch(err, /config is invalid/i)
+    } finally {
+      await cleanup(p)
+    }
+  },
+)
+
+Deno.test(
+  'gateway run: / endpoint identifies service + protocol version',
+  sub,
+  async () => {
+    const p = await spawnGateway()
+    try {
+      await waitForHealthz(p.port)
+      const res = await fetch(`http://127.0.0.1:${p.port}/`)
+      const body = await res.json()
+      assertEquals(body.service, 'slv-gateway')
+      assertEquals(body.version, '1')
+    } finally {
+      await cleanup(p)
+    }
+  },
+)

--- a/cli/test/unit/randomHex.test.ts
+++ b/cli/test/unit/randomHex.test.ts
@@ -1,0 +1,24 @@
+import { assertEquals, assertMatch } from '@std/assert'
+import { randomHex } from '/lib/randomHex.ts'
+
+Deno.test('randomHex returns the requested byte count as 2x hex chars', () => {
+  assertEquals(randomHex(1).length, 2)
+  assertEquals(randomHex(16).length, 32)
+  assertEquals(randomHex(32).length, 64)
+})
+
+Deno.test('randomHex uses only lowercase 0-9a-f', () => {
+  for (let i = 0; i < 20; i++) {
+    assertMatch(randomHex(32), /^[0-9a-f]+$/)
+  }
+})
+
+Deno.test('randomHex produces distinct outputs for back-to-back calls', () => {
+  const seen = new Set<string>()
+  for (let i = 0; i < 100; i++) {
+    seen.add(randomHex(16))
+  }
+  // 128 bits of entropy × 100 calls — the chance of a collision is
+  // vanishingly small; if this fails, crypto.getRandomValues is broken.
+  assertEquals(seen.size, 100)
+})


### PR DESCRIPTION
## Context

Kicks off **Tier 3 Phase 1** from #298. Ships just the process shape so the daemon wrapper (launchd/systemd), WS protocol, and session core can stack on top without re-deciding file layout / lifecycle / paths.

OpenClaw research adopted the battle-tested patterns: loopback default, 18789 port, atomic pidfile with Linux start-time validation, sysexits.h exit codes, \`gateway.mode=local\` gate against accidental public binding.

## What ships in this PR

\`slv gateway run\` — foreground only, no daemonize yet:

| Feature | Detail |
|---|---|
| Loopback HTTP | Hono + \`Deno.serve({hostname:'127.0.0.1'})\` on port 18789 default |
| \`/healthz\` | Returns \`{ok, pid, port, startedAt}\` JSON |
| \`/\` | Service identifier \`{service:'slv-gateway', version:'1', ...}\` |
| Token | 32-byte random hex auto-generated on first run |
| Config | \`~/.slv/gateway/gateway.json\` (chmod 0600), \`mode:'local'\` required — refuses to start without it |
| Port override | \`SLV_GATEWAY_PORT\` env var (dev convenience) |
| Pidfile | \`~/.slv/gateway/gateway.pid\`, atomic \`O_EXCL\` acquire |
| Stale-lock detection | PID alive probe + Linux \`/proc/<pid>/stat\` start-time match to defeat PID recycling |
| Second-instance | Clear error with actionable \`kill <pid>\` hint |
| Graceful shutdown | SIGTERM/SIGINT → HTTP listener shutdown → release lock → exit 0 |
| Exit codes | 78 (EX_CONFIG) for bad config, 75 (EX_TEMPFAIL) for port conflict — reserved for future systemd \`RestartPreventExitStatus=78\` |

## What is deliberately NOT in this PR

- WS upgrade + token auth (Phase 1B)
- Session core + typed event protocol (Phase 2)
- \`slv gateway install/start/stop/restart/status\` via launchd (macOS) / systemd --user (Linux) (Phase 1B)
- \`slv gateway logs --follow\` (Phase 1B)
- \`--force\` flag to evict a live holder (Phase 1B)

Each of those stacks cleanly on Phase 1A's shape. Keeping this PR small so the design is reviewable before the next 3 layers land.

## Files

- \`cli/src/gateway/paths.ts\` — \`~/.slv/gateway/\` path helpers + \`GATEWAY_DEFAULT_PORT = 18789\`
- \`cli/src/gateway/config.ts\` — \`loadOrInitGatewayConfig()\` (auto-creates with random token), \`SLV_GATEWAY_PORT\` override
- \`cli/src/gateway/lock.ts\` — atomic pidfile with Linux start-time PID-recycle defense
- \`cli/src/gateway/runForeground.ts\` — the runner itself (Hono, signal handlers, graceful shutdown)
- \`cli/src/gateway/index.ts\` — \`gatewayCmd\` with \`run\` subcommand
- \`cli/src/index.ts\` — register \`slv gateway\`

## Test plan (local macOS, verified)

\`\`\`
SLV_GATEWAY_PORT=18790 slv gateway run &
curl http://127.0.0.1:18790/healthz
# → {"ok":true,"pid":96144,"port":18790,"startedAt":"..."}
cat ~/.slv/gateway/gateway.pid
# → {"pid":96144,"startedAt":"...","port":18790}

# Second instance on same port → rejected cleanly
SLV_GATEWAY_PORT=18790 slv gateway run
# → ❌ gateway is already running (pid=96144, ...). Stop it with ... or kill 96144.

# Graceful shutdown
kill -TERM 96144
# → pidfile removed, process exit 0
\`\`\`

- [x] \`deno check\` clean for all 6 touched files
- [x] Config auto-generation with random token (verified not committed to repo)
- [x] Loopback-only bind verified (curl from localhost works)
- [x] Pidfile atomicity: second instance rejected
- [x] Graceful SIGTERM removes pidfile
- [ ] Linux \`/proc/<pid>/stat\` path — to be exercised on remote dev VPS
- [ ] Test what happens when the pidfile exists but refers to a dead PID (stale-lock auto-clean)

## Relation to #298

Phase 1A of Tier 3. Next in the issue's Phase 1: service abstraction (\`GatewayService\` interface with launchd/systemd impls) + \`slv gateway install/start/stop/restart/status\` CLI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)