### PR TITLE
feat(gateway): Phase 1B — service abstraction + install/start/stop/restart/status/logs

### DIFF
--- a/cli/src/gateway/index.ts
+++ b/cli/src/gateway/index.ts
@@ -1,6 +1,10 @@
 import { Command } from '@cliffy'
 import { runGatewayForeground } from '/src/gateway/runForeground.ts'
 import { GATEWAY_DEFAULT_PORT } from '/src/gateway/paths.ts'
+import { installAction, uninstallAction } from '/src/gateway/install.ts'
+import { runLifecycle } from '/src/gateway/lifecycle.ts'
+import { statusAction } from '/src/gateway/status.ts'
+import { logsAction } from '/src/gateway/logs.ts'
 
 export const gatewayCmd = new Command()
   .description(
@@ -16,9 +20,66 @@ token-authed protocol against this single gateway instance.`,
 
 gatewayCmd.command('run')
   .description(
-    'Run the gateway in the foreground (for manual testing or as the systemd ExecStart)',
+    'Run the gateway in the foreground (for manual testing or as the service ExecStart)',
   )
   .action(async () => {
     const code = await runGatewayForeground()
     if (code !== 0) Deno.exit(code)
+  })
+
+gatewayCmd.command('install')
+  .description(
+    'Install the gateway as a user-level launchd (macOS) or systemd --user (Linux) service',
+  )
+  .action(async () => {
+    const ok = await installAction()
+    if (!ok) Deno.exit(1)
+  })
+
+gatewayCmd.command('uninstall')
+  .description('Remove the user-level service unit/plist (idempotent)')
+  .action(async () => {
+    const ok = await uninstallAction()
+    if (!ok) Deno.exit(1)
+  })
+
+gatewayCmd.command('start')
+  .description('Start the installed gateway service')
+  .action(async () => {
+    const ok = await runLifecycle('start')
+    if (!ok) Deno.exit(1)
+  })
+
+gatewayCmd.command('stop')
+  .description('Stop the installed gateway service')
+  .action(async () => {
+    const ok = await runLifecycle('stop')
+    if (!ok) Deno.exit(1)
+  })
+
+gatewayCmd.command('restart')
+  .description('Restart the installed gateway service')
+  .action(async () => {
+    const ok = await runLifecycle('restart')
+    if (!ok) Deno.exit(1)
+  })
+
+gatewayCmd.command('status')
+  .description(
+    'Show gateway service state, pidfile, config, and log paths',
+  )
+  .action(async () => {
+    const ok = await statusAction()
+    if (!ok) Deno.exit(1)
+  })
+
+gatewayCmd.command('logs')
+  .description('Tail the gateway stdout + stderr log files')
+  .option('-f, --follow', 'Follow the log (like `tail -F`)', { default: false })
+  .option('-n, --lines <lines:number>', 'Number of lines to show', {
+    default: 100,
+  })
+  .action(async (opts: { follow?: boolean; lines?: number }) => {
+    const ok = await logsAction(opts)
+    if (!ok) Deno.exit(1)
   })

--- a/cli/src/gateway/install.ts
+++ b/cli/src/gateway/install.ts
@@ -1,0 +1,121 @@
+import { colors } from '@cliffy/colors'
+import { pickGatewayService } from '/src/gateway/service/pick.ts'
+import {
+  gatewayErrLogPath,
+  gatewayLogDir,
+  gatewayLogPath,
+} from '/src/gateway/paths.ts'
+import { errToString } from '/lib/errToString.ts'
+
+/**
+ * Find the absolute path to the `slv` binary so we can put it in the
+ * service unit's ExecStart / ProgramArguments. Three cases:
+ *
+ *   1. Compiled `slv` binary on PATH — Deno.execPath() returns the
+ *      slv binary itself. Use it directly.
+ *   2. `deno run -A src/index.ts gateway run` (dev mode) —
+ *      Deno.execPath() returns the `deno` binary, and we need to
+ *      reconstruct the full `deno run` invocation.
+ *   3. Compiled binary NOT on PATH — user installed somewhere
+ *      non-standard. We refuse to install rather than guess.
+ */
+const resolveExec = async (): Promise<
+  { execPath: string; execArgs: string[] }
+> => {
+  const exec = Deno.execPath()
+  const basename = exec.split('/').pop() ?? ''
+  // Case 1: compiled slv binary — execPath ends with 'slv' (or
+  // 'slv.exe'; not supported today but future-proofed).
+  if (basename === 'slv' || basename === 'slv.exe') {
+    return { execPath: exec, execArgs: ['gateway', 'run'] }
+  }
+  // Case 2: dev mode — Deno.execPath is `deno`, so we need the
+  // script path too. Prefer an installed `slv` on PATH; if none,
+  // refuse with a clear message.
+  const which = new Deno.Command('sh', {
+    args: ['-c', 'command -v slv'],
+    stdout: 'piped',
+    stderr: 'null',
+  })
+  const out = await which.output()
+  if (out.success) {
+    const path = new TextDecoder().decode(out.stdout).trim()
+    if (path) return { execPath: path, execArgs: ['gateway', 'run'] }
+  }
+  throw new Error(
+    `Cannot locate an 'slv' binary to put in the service ExecStart.\n` +
+      `Install slv onto PATH first (so 'which slv' resolves), or run the gateway\n` +
+      `manually with 'slv gateway run' instead of using the daemon wrappers.`,
+  )
+}
+
+export const installAction = async (): Promise<boolean> => {
+  let service
+  try {
+    service = pickGatewayService()
+  } catch (err) {
+    console.error(colors.red(`❌ ${errToString(err)}`))
+    return false
+  }
+
+  let exec
+  try {
+    exec = await resolveExec()
+  } catch (err) {
+    console.error(colors.red(`❌ ${errToString(err)}`))
+    return false
+  }
+
+  // Create log dir with parents so the service unit's append: path
+  // never fails on missing directory.
+  await Deno.mkdir(gatewayLogDir, { recursive: true })
+  // Touch log files so `slv gateway logs` doesn't fail with "file
+  // not found" before the service has written its first line.
+  await Deno.writeTextFile(gatewayLogPath, '', { append: true }).catch(() => {})
+  await Deno.writeTextFile(gatewayErrLogPath, '', { append: true }).catch(() => {})
+
+  console.log(colors.cyan(`⚙️  Installing ${service.name} unit...`))
+  console.log(colors.gray(`    ExecStart: ${exec.execPath} ${exec.execArgs.join(' ')}`))
+  console.log(colors.gray(`    stdout:    ${gatewayLogPath}`))
+  console.log(colors.gray(`    stderr:    ${gatewayErrLogPath}`))
+
+  try {
+    await service.install({
+      execPath: exec.execPath,
+      execArgs: exec.execArgs,
+      stdoutLog: gatewayLogPath,
+      stderrLog: gatewayErrLogPath,
+    })
+  } catch (err) {
+    console.error(colors.red(`❌ install failed: ${errToString(err)}`))
+    return false
+  }
+
+  console.log(colors.green('✅ gateway service installed and enabled'))
+  console.log(colors.gray(`    start:  slv gateway start`))
+  console.log(colors.gray(`    status: slv gateway status`))
+  console.log(colors.gray(`    logs:   slv gateway logs -f`))
+  return true
+}
+
+export const uninstallAction = async (): Promise<boolean> => {
+  let service
+  try {
+    service = pickGatewayService()
+  } catch (err) {
+    console.error(colors.red(`❌ ${errToString(err)}`))
+    return false
+  }
+  console.log(colors.cyan(`⚙️  Uninstalling ${service.name} unit...`))
+  try {
+    await service.uninstall()
+  } catch (err) {
+    console.error(colors.red(`❌ uninstall failed: ${errToString(err)}`))
+    return false
+  }
+  console.log(colors.green('✅ gateway service uninstalled'))
+  console.log(
+    colors.gray(`    (logs at ${gatewayLogPath} were kept for reference)`),
+  )
+  return true
+}

--- a/cli/src/gateway/lifecycle.ts
+++ b/cli/src/gateway/lifecycle.ts
@@ -3,6 +3,14 @@ import { pickGatewayService } from '/src/gateway/service/pick.ts'
 import { errToString } from '/lib/errToString.ts'
 
 type Verb = 'start' | 'stop' | 'restart'
+// English doubles the final consonant for stop→stopping (CVC rule) but
+// not for start/restart (both end in consonant clusters). Explicit table
+// keeps this out of the hot path.
+const verbToIng: Record<Verb, string> = {
+  start: 'starting',
+  stop: 'stopping',
+  restart: 'restarting',
+}
 const verbToPast: Record<Verb, string> = {
   start: 'started',
   stop: 'stopped',
@@ -17,7 +25,9 @@ export const runLifecycle = async (verb: Verb): Promise<boolean> => {
     console.error(colors.red(`❌ ${errToString(err)}`))
     return false
   }
-  console.log(colors.cyan(`⚙️  ${verb}ing gateway via ${service.name}...`))
+  console.log(
+    colors.cyan(`⚙️  ${verbToIng[verb]} gateway via ${service.name}...`),
+  )
   try {
     await service[verb]()
   } catch (err) {

--- a/cli/src/gateway/lifecycle.ts
+++ b/cli/src/gateway/lifecycle.ts
@@ -1,0 +1,34 @@
+import { colors } from '@cliffy/colors'
+import { pickGatewayService } from '/src/gateway/service/pick.ts'
+import { errToString } from '/lib/errToString.ts'
+
+type Verb = 'start' | 'stop' | 'restart'
+const verbToPast: Record<Verb, string> = {
+  start: 'started',
+  stop: 'stopped',
+  restart: 'restarted',
+}
+
+export const runLifecycle = async (verb: Verb): Promise<boolean> => {
+  let service
+  try {
+    service = pickGatewayService()
+  } catch (err) {
+    console.error(colors.red(`❌ ${errToString(err)}`))
+    return false
+  }
+  console.log(colors.cyan(`⚙️  ${verb}ing gateway via ${service.name}...`))
+  try {
+    await service[verb]()
+  } catch (err) {
+    console.error(colors.red(`❌ ${verb} failed: ${errToString(err)}`))
+    console.error(
+      colors.white(
+        `   Run 'slv gateway install' first if this is a fresh machine.`,
+      ),
+    )
+    return false
+  }
+  console.log(colors.green(`✅ gateway ${verbToPast[verb]}`))
+  return true
+}

--- a/cli/src/gateway/logs.ts
+++ b/cli/src/gateway/logs.ts
@@ -1,0 +1,56 @@
+import { colors } from '@cliffy/colors'
+import {
+  gatewayErrLogPath,
+  gatewayLogPath,
+} from '/src/gateway/paths.ts'
+import { errToString } from '/lib/errToString.ts'
+
+export const logsAction = async (
+  opts: { follow?: boolean; lines?: number },
+): Promise<boolean> => {
+  const lines = opts.lines ?? 100
+  const args: string[] = ['-n', String(lines)]
+  if (opts.follow) args.push('-F')
+  // Feed BOTH log files to tail so stdout + stderr are interleaved.
+  // If either doesn't exist yet, create an empty one so `tail` doesn't
+  // error out — on a fresh install the service may not have produced
+  // output yet.
+  for (const path of [gatewayLogPath, gatewayErrLogPath]) {
+    await Deno.writeTextFile(path, '', { append: true }).catch(() => {})
+  }
+  args.push(gatewayLogPath, gatewayErrLogPath)
+
+  console.log(
+    colors.gray(
+      `# tailing ${gatewayLogPath} + ${gatewayErrLogPath} (last ${lines} lines${
+        opts.follow ? ', follow' : ''
+      })`,
+    ),
+  )
+  try {
+    const child = new Deno.Command('tail', {
+      args,
+      stdin: 'null',
+      stdout: 'inherit',
+      stderr: 'inherit',
+    }).spawn()
+    // Forward Ctrl+C through to tail so the user can quit cleanly.
+    const onSigint = () => {
+      try {
+        child.kill('SIGINT')
+      } catch { /* already gone */ }
+    }
+    Deno.addSignalListener('SIGINT', onSigint)
+    try {
+      const status = await child.status
+      return status.success
+    } finally {
+      try {
+        Deno.removeSignalListener('SIGINT', onSigint)
+      } catch { /* ignore */ }
+    }
+  } catch (err) {
+    console.error(colors.red(`❌ tail failed: ${errToString(err)}`))
+    return false
+  }
+}

--- a/cli/src/gateway/service/launchd.ts
+++ b/cli/src/gateway/service/launchd.ts
@@ -1,0 +1,168 @@
+import { dirname, join } from '@std/path'
+import { localExec } from '/src/bot/execUtil.ts'
+import type {
+  GatewayService,
+  InstallOptions,
+  ServiceStatus,
+} from '/src/gateway/service/service.ts'
+
+export const LAUNCHD_LABEL = 'global.slv.gateway'
+
+const launchAgentDir = (): string =>
+  join(Deno.env.get('HOME') ?? '.', 'Library/LaunchAgents')
+
+export const launchdPlistPath = (): string =>
+  join(launchAgentDir(), `${LAUNCHD_LABEL}.plist`)
+
+/**
+ * Render the LaunchAgent plist. Notes:
+ *
+ * - `RunAtLoad=true` + `KeepAlive=true` — launchd starts us at user
+ *   login and respawns on exit.
+ * - `ThrottleInterval=5` + `ExitTimeOut=30` — if we crash fast,
+ *   launchd waits 5s before respawning. If we ignore SIGTERM for
+ *   30s, launchd sends SIGKILL.
+ * - `StandardOutPath` / `StandardErrorPath` — direct stdio to the
+ *   log files `slv gateway logs` tails.
+ * - We purposely DON'T ship a `UserName` key: this is a
+ *   LaunchAgent (per-user), not a LaunchDaemon. The invoking user
+ *   owns the process; no root required.
+ */
+export const renderLaunchdPlist = (opts: InstallOptions): string => {
+  const args = [opts.execPath, ...opts.execArgs].map(xmlEscape)
+  const argLines = args.map((a) => `    <string>${a}</string>`).join('\n')
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCHD_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${argLines}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+  <key>ExitTimeOut</key>
+  <integer>30</integer>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(opts.stdoutLog)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(opts.stderrLog)}</string>
+</dict>
+</plist>
+`
+}
+
+const xmlEscape = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+
+const userGuiTarget = async (): Promise<string> => {
+  // bootstrap/bootout/kickstart all need a domain target. `gui/<uid>`
+  // is the modern per-user GUI domain launchd uses for LaunchAgents.
+  const out = await localExec('id', ['-u'])
+  const uid = out.stdout.trim()
+  return `gui/${uid}`
+}
+
+const launchctl = async (
+  ...args: string[]
+): Promise<{ success: boolean; stdout: string; stderr: string }> => {
+  const out = await localExec('launchctl', args)
+  return { success: out.success, stdout: out.stdout, stderr: out.stderr }
+}
+
+export class LaunchdService implements GatewayService {
+  readonly name = 'launchd'
+
+  async install(opts: InstallOptions): Promise<void> {
+    const path = launchdPlistPath()
+    await Deno.mkdir(dirname(path), { recursive: true })
+    await Deno.writeTextFile(path, renderLaunchdPlist(opts))
+
+    // `bootstrap` is the modern launchctl verb; `load -w` is the
+    // deprecated but still common alternative. We try bootstrap
+    // first and fall back to load for older macOS.
+    const target = await userGuiTarget()
+    const bootstrap = await launchctl('bootstrap', target, path)
+    if (!bootstrap.success) {
+      // If the unit is already loaded, bootstrap returns non-zero
+      // with stderr containing 'service already loaded' — harmless
+      // idempotent path.
+      const already = /already loaded|already bootstrapped/i.test(
+        bootstrap.stderr,
+      )
+      if (!already) {
+        const load = await launchctl('load', '-w', path)
+        if (!load.success) {
+          throw new Error(
+            `launchctl bootstrap/load failed: ${
+              bootstrap.stderr.trim() || load.stderr.trim() || 'unknown'
+            }`,
+          )
+        }
+      }
+    }
+    // Ensure enabled (bootstrap sets this automatically on recent
+    // launchctl; belt-and-suspenders for older versions).
+    await launchctl('enable', `${target}/${LAUNCHD_LABEL}`)
+  }
+
+  async uninstall(): Promise<void> {
+    const target = await userGuiTarget()
+    // Best-effort disable + bootout; ignore errors for idempotency.
+    await launchctl('bootout', `${target}/${LAUNCHD_LABEL}`)
+    await launchctl('unload', '-w', launchdPlistPath())
+    await Deno.remove(launchdPlistPath()).catch(() => {})
+  }
+
+  async start(): Promise<void> {
+    const target = await userGuiTarget()
+    // kickstart is idempotent — starts if not running, no-op if it is.
+    const r = await launchctl('kickstart', `${target}/${LAUNCHD_LABEL}`)
+    if (!r.success) {
+      throw new Error(`launchctl kickstart failed: ${r.stderr.trim()}`)
+    }
+  }
+
+  async stop(): Promise<void> {
+    const target = await userGuiTarget()
+    const r = await launchctl('kill', 'SIGTERM', `${target}/${LAUNCHD_LABEL}`)
+    if (!r.success) {
+      throw new Error(`launchctl kill failed: ${r.stderr.trim()}`)
+    }
+  }
+
+  async restart(): Promise<void> {
+    const target = await userGuiTarget()
+    // `kickstart -k` restarts by killing + relaunching.
+    const r = await launchctl(
+      'kickstart',
+      '-k',
+      `${target}/${LAUNCHD_LABEL}`,
+    )
+    if (!r.success) {
+      throw new Error(`launchctl kickstart -k failed: ${r.stderr.trim()}`)
+    }
+  }
+
+  async status(): Promise<ServiceStatus> {
+    const loaded = await Deno.stat(launchdPlistPath()).then(() => true)
+      .catch(() => false)
+    const target = await userGuiTarget()
+    const print = await launchctl('print', `${target}/${LAUNCHD_LABEL}`)
+    // `launchctl print` exits 113 when the service isn't loaded, 0 when
+    // it is. stdout shows `state = running | spawning | not running`.
+    const running = /\bstate = running\b/.test(print.stdout)
+    return {
+      loaded,
+      running,
+      details: print.stdout || print.stderr,
+    }
+  }
+}

--- a/cli/src/gateway/service/pick.ts
+++ b/cli/src/gateway/service/pick.ts
@@ -1,0 +1,22 @@
+import type { GatewayService } from '/src/gateway/service/service.ts'
+import { LaunchdService } from '/src/gateway/service/launchd.ts'
+import { SystemdUserService } from '/src/gateway/service/systemd.ts'
+
+/**
+ * Select the gateway service backend for the current OS. Throws on
+ * unsupported platforms (Windows, BSD) with a clear message so CLI
+ * handlers can surface it verbatim.
+ */
+export const pickGatewayService = (): GatewayService => {
+  switch (Deno.build.os) {
+    case 'darwin':
+      return new LaunchdService()
+    case 'linux':
+      return new SystemdUserService()
+    default:
+      throw new Error(
+        `slv gateway install/start/stop is only supported on macOS and Linux; got ${Deno.build.os}. ` +
+          `You can still run the gateway manually with 'slv gateway run'.`,
+      )
+  }
+}

--- a/cli/src/gateway/service/service.ts
+++ b/cli/src/gateway/service/service.ts
@@ -1,0 +1,54 @@
+/**
+ * Platform-agnostic service backend contract for the gateway daemon.
+ *
+ * Two implementations: `launchd.ts` (macOS LaunchAgent) and
+ * `systemd.ts` (Linux `systemctl --user`). Pick the right one at
+ * runtime via `pick.ts`. Every gateway lifecycle subcommand
+ * (`install / uninstall / start / stop / restart / status`) goes
+ * through this interface, so the CLI handlers stay identical across
+ * OSes.
+ */
+
+export type ServiceStatus = {
+  // True if the OS service manager knows about our unit (installed +
+  // enabled). False if never installed or cleanly uninstalled.
+  loaded: boolean
+  // True if the service manager believes the process is currently
+  // running. Note: a pid-alive check via gateway.pid is a more
+  // authoritative runtime-state signal — the service manager may
+  // think it's running just because it's supposed to auto-restart.
+  running: boolean
+  // Extra platform-specific lines to show in `slv gateway status`.
+  // E.g. `launchctl print` output or `systemctl --user status` tail.
+  details: string
+}
+
+export type InstallOptions = {
+  // Absolute path to the slv binary. Required so the service unit
+  // can ExecStart it without depending on $PATH (systemd unit files
+  // don't inherit the user's PATH; launchd plists don't either).
+  execPath: string
+  // Arguments to pass: typically ['gateway', 'run'].
+  execArgs: string[]
+  // Destinations for stdout / stderr. Service managers redirect our
+  // streams here; `slv gateway logs` tails them.
+  stdoutLog: string
+  stderrLog: string
+}
+
+export interface GatewayService {
+  /** Human-readable backend label, e.g. 'launchd' or 'systemd --user'. */
+  readonly name: string
+
+  /** Write the unit/plist file + register with the service manager. */
+  install(opts: InstallOptions): Promise<void>
+
+  /** Remove the unit/plist file + deregister. Safe when not installed. */
+  uninstall(): Promise<void>
+
+  start(): Promise<void>
+  stop(): Promise<void>
+  restart(): Promise<void>
+
+  status(): Promise<ServiceStatus>
+}

--- a/cli/src/gateway/service/systemd.ts
+++ b/cli/src/gateway/service/systemd.ts
@@ -1,0 +1,148 @@
+import { dirname, join } from '@std/path'
+import { localExec } from '/src/bot/execUtil.ts'
+import type {
+  GatewayService,
+  InstallOptions,
+  ServiceStatus,
+} from '/src/gateway/service/service.ts'
+
+export const SYSTEMD_UNIT_NAME = 'slv-gateway.service'
+
+const userUnitDir = (): string => {
+  const home = Deno.env.get('HOME') ?? '.'
+  const xdg = Deno.env.get('XDG_CONFIG_HOME')
+  const base = xdg && xdg.length > 0 ? xdg : join(home, '.config')
+  return join(base, 'systemd/user')
+}
+
+export const systemdUnitPath = (): string =>
+  join(userUnitDir(), SYSTEMD_UNIT_NAME)
+
+/**
+ * Render the systemd --user unit. Notes on choices:
+ *
+ * - `Restart=always` + `RestartPreventExitStatus=78` — restart on
+ *   any exit EXCEPT `EX_CONFIG` (78), so a misconfigured gateway
+ *   doesn't crash-loop until the user intervenes.
+ * - `KillMode=control-group` — so when the user-level systemd kills
+ *   us, any tool-call shell children we've spawned also get SIGTERM.
+ *   Important because the gateway can execute arbitrary commands.
+ * - `StandardOutput=append:` / `StandardError=append:` — stream our
+ *   stdio directly to the log files `slv gateway logs` tails.
+ *   Requires systemd 240+ (Ubuntu 20.04+). On older systemd this
+ *   fails at daemon-reload and we fall back to journald via the
+ *   error path.
+ * - `WantedBy=default.target` — user-target so it starts on user
+ *   login. Does NOT require system-level sudo; everything is
+ *   scoped to the invoking user.
+ */
+export const renderSystemdUnit = (opts: InstallOptions): string => {
+  const argv = [opts.execPath, ...opts.execArgs].map(shellQuote).join(' ')
+  return `[Unit]
+Description=SLV Gateway WebSocket daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${argv}
+Restart=always
+RestartSec=5
+RestartPreventExitStatus=78
+KillMode=control-group
+TimeoutStopSec=30
+StandardOutput=append:${opts.stdoutLog}
+StandardError=append:${opts.stderrLog}
+
+[Install]
+WantedBy=default.target
+`
+}
+
+// Minimal shell quoter for unit files. Systemd's ExecStart tokenizer
+// is shell-like but not a full shell, so we wrap each arg in double
+// quotes and escape `"` + `\` + `$`. No path we generate contains
+// these characters today, but defend against future callers.
+const shellQuote = (s: string): string => {
+  if (/^[A-Za-z0-9_\-./@:=+]+$/.test(s)) return s
+  return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(
+    /\$/g,
+    '\\$',
+  ) + '"'
+}
+
+const systemctl = async (
+  ...args: string[]
+): Promise<{ success: boolean; stdout: string; stderr: string }> => {
+  const out = await localExec('systemctl', ['--user', ...args])
+  return { success: out.success, stdout: out.stdout, stderr: out.stderr }
+}
+
+export class SystemdUserService implements GatewayService {
+  readonly name = 'systemd --user'
+
+  async install(opts: InstallOptions): Promise<void> {
+    const path = systemdUnitPath()
+    await Deno.mkdir(dirname(path), { recursive: true })
+    await Deno.writeTextFile(path, renderSystemdUnit(opts))
+    const reload = await systemctl('daemon-reload')
+    if (!reload.success) {
+      throw new Error(
+        `systemctl --user daemon-reload failed: ${
+          reload.stderr.trim() || 'unknown'
+        }`,
+      )
+    }
+    const enable = await systemctl('enable', SYSTEMD_UNIT_NAME)
+    if (!enable.success) {
+      throw new Error(
+        `systemctl --user enable ${SYSTEMD_UNIT_NAME} failed: ${
+          enable.stderr.trim() || 'unknown'
+        }`,
+      )
+    }
+  }
+
+  async uninstall(): Promise<void> {
+    // Best-effort stop+disable; ignore "not loaded" errors so
+    // uninstall is idempotent.
+    await systemctl('disable', '--now', SYSTEMD_UNIT_NAME)
+    await Deno.remove(systemdUnitPath()).catch(() => {})
+    await systemctl('daemon-reload')
+  }
+
+  async start(): Promise<void> {
+    const r = await systemctl('start', SYSTEMD_UNIT_NAME)
+    if (!r.success) {
+      throw new Error(`systemctl start failed: ${r.stderr.trim()}`)
+    }
+  }
+
+  async stop(): Promise<void> {
+    const r = await systemctl('stop', SYSTEMD_UNIT_NAME)
+    if (!r.success) {
+      throw new Error(`systemctl stop failed: ${r.stderr.trim()}`)
+    }
+  }
+
+  async restart(): Promise<void> {
+    const r = await systemctl('restart', SYSTEMD_UNIT_NAME)
+    if (!r.success) {
+      throw new Error(`systemctl restart failed: ${r.stderr.trim()}`)
+    }
+  }
+
+  async status(): Promise<ServiceStatus> {
+    const loaded = await Deno.stat(systemdUnitPath()).then(() => true)
+      .catch(() => false)
+    const active = await systemctl('is-active', SYSTEMD_UNIT_NAME)
+    // is-active exits 0 if active, 3 if inactive, 4 if no such unit.
+    const running = active.stdout.trim() === 'active'
+    const details = await systemctl('status', SYSTEMD_UNIT_NAME, '--no-pager')
+    return {
+      loaded,
+      running,
+      details: details.stdout || details.stderr,
+    }
+  }
+}

--- a/cli/src/gateway/status.ts
+++ b/cli/src/gateway/status.ts
@@ -1,0 +1,77 @@
+import { colors } from '@cliffy/colors'
+import { pickGatewayService } from '/src/gateway/service/pick.ts'
+import { loadGatewayConfig } from '/src/gateway/config.ts'
+import {
+  gatewayConfigPath,
+  gatewayErrLogPath,
+  gatewayLogPath,
+  gatewayPidPath,
+} from '/src/gateway/paths.ts'
+import { errToString } from '/lib/errToString.ts'
+
+type PidfileView = {
+  pid: number
+  startedAt: string
+  port: number
+}
+
+const readPidfile = async (): Promise<PidfileView | null> => {
+  try {
+    const raw = await Deno.readTextFile(gatewayPidPath)
+    return JSON.parse(raw) as PidfileView
+  } catch {
+    return null
+  }
+}
+
+export const statusAction = async (): Promise<boolean> => {
+  let service
+  try {
+    service = pickGatewayService()
+  } catch (err) {
+    console.error(colors.red(`❌ ${errToString(err)}`))
+    return false
+  }
+
+  const [svc, pid] = await Promise.all([
+    service.status().catch((err) => ({
+      loaded: false,
+      running: false,
+      details: `status check failed: ${errToString(err)}`,
+    })),
+    readPidfile(),
+  ])
+
+  console.log(colors.bold(`slv gateway (${service.name})`))
+  console.log(
+    colors.white(`  installed:  ${svc.loaded ? 'yes' : 'no'}`),
+  )
+  console.log(
+    colors.white(
+      `  running:    ${svc.running ? colors.green('yes') : colors.gray('no')}`,
+    ),
+  )
+  if (pid) {
+    console.log(colors.white(`  pidfile:    pid=${pid.pid} port=${pid.port}`))
+    console.log(colors.white(`              started ${pid.startedAt}`))
+  } else {
+    console.log(colors.white(`  pidfile:    absent`))
+  }
+  try {
+    const cfg = await loadGatewayConfig()
+    console.log(colors.white(`  config:     ${gatewayConfigPath}`))
+    console.log(colors.white(`              port=${cfg.port} mode=${cfg.mode}`))
+  } catch {
+    console.log(
+      colors.white(`  config:     ${gatewayConfigPath} (absent or invalid)`),
+    )
+  }
+  console.log(colors.white(`  logs:       ${gatewayLogPath}`))
+  console.log(colors.white(`              ${gatewayErrLogPath}`))
+
+  if (svc.details.trim()) {
+    console.log()
+    console.log(colors.gray(svc.details.trim()))
+  }
+  return true
+}

--- a/cli/test/unit/gateway_service_render.test.ts
+++ b/cli/test/unit/gateway_service_render.test.ts
@@ -1,0 +1,110 @@
+import { assert, assertEquals, assertStringIncludes } from '@std/assert'
+import { renderSystemdUnit } from '/src/gateway/service/systemd.ts'
+import {
+  LAUNCHD_LABEL,
+  renderLaunchdPlist,
+} from '/src/gateway/service/launchd.ts'
+
+// Golden-ish tests for the generated unit/plist files. We don't snap
+// the entire output (comment tweaks would be churn) — we assert the
+// invariants that MATTER for the service manager to accept the file
+// and for the gateway to run correctly under it.
+
+const baseOpts = {
+  execPath: '/usr/local/bin/slv',
+  execArgs: ['gateway', 'run'],
+  stdoutLog: '/home/u/.slv/gateway/logs/gateway.log',
+  stderrLog: '/home/u/.slv/gateway/logs/gateway.err.log',
+}
+
+Deno.test('systemd unit: required sections + ExecStart + restart policy', () => {
+  const unit = renderSystemdUnit(baseOpts)
+
+  // Required sections
+  assertStringIncludes(unit, '[Unit]')
+  assertStringIncludes(unit, '[Service]')
+  assertStringIncludes(unit, '[Install]')
+
+  // ExecStart correctly quotes and sequences argv
+  assertStringIncludes(unit, 'ExecStart=/usr/local/bin/slv gateway run')
+
+  // Restart policy: always, but NOT on config error (78)
+  assertStringIncludes(unit, 'Restart=always')
+  assertStringIncludes(unit, 'RestartPreventExitStatus=78')
+
+  // Log redirection uses the caller-supplied paths
+  assertStringIncludes(
+    unit,
+    'StandardOutput=append:/home/u/.slv/gateway/logs/gateway.log',
+  )
+  assertStringIncludes(
+    unit,
+    'StandardError=append:/home/u/.slv/gateway/logs/gateway.err.log',
+  )
+
+  // User-target install — no system-level install
+  assertStringIncludes(unit, 'WantedBy=default.target')
+
+  // Kill behavior reaches tool-call shell children
+  assertStringIncludes(unit, 'KillMode=control-group')
+})
+
+Deno.test('systemd unit: argv with spaces or shell chars is quoted', () => {
+  const unit = renderSystemdUnit({
+    ...baseOpts,
+    execPath: '/opt/my apps/slv',
+    execArgs: ['gateway', 'run'],
+  })
+  // The path-with-space must be wrapped so systemd's ExecStart
+  // tokenizer keeps it as a single argument.
+  assertStringIncludes(unit, 'ExecStart="/opt/my apps/slv" gateway run')
+})
+
+Deno.test('launchd plist: required keys + argv + log paths', () => {
+  const plist = renderLaunchdPlist(baseOpts)
+
+  // Plist envelope
+  assertStringIncludes(plist, '<?xml version="1.0"')
+  assertStringIncludes(plist, '<plist version="1.0">')
+
+  // Label matches our exported constant (clients and uninstall
+  // depend on the same value)
+  assertStringIncludes(plist, `<string>${LAUNCHD_LABEL}</string>`)
+
+  // ProgramArguments sequence
+  assertStringIncludes(plist, '<string>/usr/local/bin/slv</string>')
+  assertStringIncludes(plist, '<string>gateway</string>')
+  assertStringIncludes(plist, '<string>run</string>')
+
+  // RunAtLoad + KeepAlive — launchd boots + respawns us
+  assertStringIncludes(plist, '<key>RunAtLoad</key>\n  <true/>')
+  assertStringIncludes(plist, '<key>KeepAlive</key>\n  <true/>')
+
+  // Log paths set
+  assertStringIncludes(
+    plist,
+    '<string>/home/u/.slv/gateway/logs/gateway.log</string>',
+  )
+  assertStringIncludes(
+    plist,
+    '<string>/home/u/.slv/gateway/logs/gateway.err.log</string>',
+  )
+})
+
+Deno.test('launchd plist: XML-escapes problematic chars in paths', () => {
+  const plist = renderLaunchdPlist({
+    ...baseOpts,
+    stdoutLog: '/tmp/out & err <weird>.log',
+  })
+  // Ampersand must be &amp; to keep the plist parseable.
+  assertStringIncludes(plist, '&amp;')
+  assertStringIncludes(plist, '&lt;weird&gt;')
+  // Raw unescaped forms must NOT appear inside the <string>.
+  assert(!/\<string>[^<]*\&\ [^<]*\<\/string>/.test(plist))
+})
+
+Deno.test('launchd label is stable (clients + install/uninstall share)', () => {
+  // Hard-assert to lock against accidental rename. A rename would
+  // silently orphan existing installs.
+  assertEquals(LAUNCHD_LABEL, 'global.slv.gateway')
+})


### PR DESCRIPTION
## Context

Stacks on Phase 1A (#302, now merged into main). Adds the full daemon lifecycle surface — `slv gateway install / uninstall / start / stop / restart / status / logs` — via launchd (macOS) or systemd --user (Linux).

(Previously PR #303, auto-closed when its base branch was deleted on #302's merge. Content is identical — just rebased onto main.)

## Verified end-to-end on real Ubuntu VPS

All 11 lifecycle steps passed on `openclaw@84.32.103.177` (Ubuntu 24.04):

- install writes `~/.config/systemd/user/slv-gateway.service`
- start/restart/stop behave, `slv gateway status` reflects each transition
- `/healthz` + `/` respond correctly
- `slv gateway logs -n 10` interleaves stdout + stderr
- restart bumps PID cleanly
- uninstall removes the unit, keeps logs

One typo caught during smoke (`"stoping" → "stopping"`), fixed in a follow-up commit.

## What ships

Service abstraction in `cli/src/gateway/service/`:

| File | Role |
|---|---|
| `service.ts` | `GatewayService` interface — `install/uninstall/start/stop/restart/status` |
| `systemd.ts` | `systemctl --user` backend. `Restart=always`, `RestartPreventExitStatus=78` (respects EX_CONFIG from Phase 1A — no crash-loop on bad config), `KillMode=control-group`, `StandardOutput=append:~/.slv/gateway/logs/` |
| `launchd.ts` | macOS LaunchAgent. `RunAtLoad`, `KeepAlive`, `ThrottleInterval=5`, modern `launchctl bootstrap gui/<uid>` with `load -w` fallback |
| `pick.ts` | `Deno.build.os` dispatch; unsupported platforms get a clear error pointing at `gateway run` |

Action modules in `cli/src/gateway/`:

| File | Role |
|---|---|
| `install.ts` | Resolves ExecStart (`which slv` in dev, compiled binary otherwise), creates log dir + empty log files |
| `lifecycle.ts` | `runLifecycle('start'\|'stop'\|'restart')` with proper English (`starting/stopping/restarting`) |
| `status.ts` | Combined view: svc state + pidfile + config + log paths + raw backend tail |
| `logs.ts` | `tail -n N [-F]` over stdout + stderr interleaved; Ctrl+C forwards SIGINT |

## Tests

`test/unit/gateway_service_render.test.ts` (5 tests) — locks the generated unit/plist content against regressions: required sections, ExecStart quoting, restart policy, log-path redirection, XML escaping, stable LAUNCHD_LABEL.

Integration tests that actually talk to systemd/launchd are NOT in CI (they'd need a real user session per test). Phase 1A's subprocess integration suite + the render tests cover everything up to the service-manager boundary; the remote-VPS smoke covered everything past it.

## Relation to #298

Completes Phase 1 of Tier 3. Next: Phase 2A (WS upgrade + token auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)