### PR TITLE
feat(gateway): Phase 2B — session core + echo driver + slv gateway ping

### DIFF
--- a/cli/src/ai/core/events.ts
+++ b/cli/src/ai/core/events.ts
@@ -1,0 +1,23 @@
+/**
+ * Typed event stream emitted by a {@link Session}.
+ *
+ * Producers: the Session driver (echo for Phase 2B, real provider
+ * loop in a follow-up PR). Consumers: the TUI adapter (future) and
+ * the WS gateway's `session.send` handler which serializes each
+ * event into an `event` frame (see `cli/src/gateway/ws/frames.ts`).
+ *
+ * Keep this union ADDITIVE — clients match on `type` and ignore
+ * unknown events, so adding new variants is backward-compatible.
+ * Renaming or removing a type IS breaking and needs a protocol
+ * version bump.
+ */
+export type SessionEvent =
+  | { type: 'text_delta'; text: string }
+  | { type: 'tool_use_start'; id: string; name: string; args: unknown }
+  | { type: 'tool_result'; id: string; ok: boolean; content: string }
+  | { type: 'status'; state: 'running' | 'idle'; label?: string }
+  | { type: 'complete' }
+  | { type: 'aborted'; reason?: string }
+  | { type: 'error'; message: string }
+
+export type SessionEventListener = (event: SessionEvent) => void

--- a/cli/src/ai/core/session.ts
+++ b/cli/src/ai/core/session.ts
@@ -1,0 +1,175 @@
+import type {
+  SessionEvent,
+  SessionEventListener,
+} from '/src/ai/core/events.ts'
+
+/**
+ * Session drives a single chat run. It's driver-agnostic: pass any
+ * async function that produces `SessionEvent`s via the supplied
+ * `emit` callback, and the Session takes care of:
+ *
+ *   - listener management (subscribe/unsubscribe with cleanup)
+ *   - AbortController wiring (so Ctrl+C / WS `session.abort` can
+ *     cancel in-flight work)
+ *   - terminal-event guarantees (`complete` | `aborted` | `error`
+ *     always fires exactly once, even if the driver throws)
+ *
+ * Phase 2B ships the echo driver (below) for end-to-end wire tests.
+ * The real provider driver lands in the next PR — Session itself
+ * doesn't need to change.
+ */
+export type SessionDriver = (
+  text: string,
+  ctx: {
+    emit: (event: SessionEvent) => void
+    signal: AbortSignal
+  },
+) => Promise<void>
+
+export class Session {
+  private listeners = new Set<SessionEventListener>()
+  private abortController: AbortController | null = null
+  private sending = false
+
+  constructor(private driver: SessionDriver) {}
+
+  on(fn: SessionEventListener): () => void {
+    this.listeners.add(fn)
+    return () => {
+      this.listeners.delete(fn)
+    }
+  }
+
+  get isRunning(): boolean {
+    return this.sending
+  }
+
+  /**
+   * Kick off a turn. Returns when the driver settles. Every emitted
+   * event reaches every listener synchronously in `on`-registration
+   * order. Exactly one terminal event (`complete` | `aborted` |
+   * `error`) fires per call.
+   */
+  async send(text: string): Promise<void> {
+    if (this.sending) {
+      this.emit({
+        type: 'error',
+        message: 'session is already processing a turn',
+      })
+      return
+    }
+    this.sending = true
+    this.abortController = new AbortController()
+    this.emit({ type: 'status', state: 'running' })
+
+    let settled: 'complete' | 'aborted' | 'error' | null = null
+    const markTerminal = (kind: 'complete' | 'aborted' | 'error') => {
+      if (settled) return
+      settled = kind
+    }
+
+    try {
+      await this.driver(text, {
+        emit: (e) => {
+          if (e.type === 'complete') markTerminal('complete')
+          if (e.type === 'aborted') markTerminal('aborted')
+          if (e.type === 'error') markTerminal('error')
+          this.emit(e)
+        },
+        signal: this.abortController.signal,
+      })
+      // Driver returned without emitting a terminal event. If the
+      // abort signal was raised, that's an `aborted` terminal (the
+      // driver bailed out of its loop cleanly). Otherwise it's a
+      // `complete` — so downstream consumers always see exactly
+      // one terminal event per send().
+      if (!settled) {
+        if (this.abortController?.signal.aborted) {
+          this.emit({ type: 'aborted' })
+        } else {
+          this.emit({ type: 'complete' })
+        }
+      }
+    } catch (err) {
+      if (!settled) {
+        // If the driver threw because we aborted it, surface as
+        // aborted; otherwise as error. `signal.aborted` at this
+        // point means abort() was called before the driver settled.
+        if (this.abortController?.signal.aborted) {
+          this.emit({
+            type: 'aborted',
+            reason: err instanceof Error ? err.message : String(err),
+          })
+        } else {
+          this.emit({
+            type: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    } finally {
+      this.emit({ type: 'status', state: 'idle' })
+      this.sending = false
+      this.abortController = null
+    }
+  }
+
+  /**
+   * Cancel the in-flight send. The driver should check `signal.aborted`
+   * periodically — we don't force-kill from here. If nothing is in
+   * flight, abort() is a no-op.
+   */
+  abort(reason?: string): void {
+    if (!this.abortController) return
+    // AbortController only carries an optional reason on abort();
+    // our abort-observing drivers receive it via signal.reason.
+    this.abortController.abort(reason)
+  }
+
+  private emit(event: SessionEvent): void {
+    for (const fn of this.listeners) {
+      try {
+        fn(event)
+      } catch {
+        // Listener errors must not break the loop — other listeners
+        // still need the event, and the driver shouldn't care.
+      }
+    }
+  }
+}
+
+/**
+ * Echo driver: a dev/smoke-test driver that turns the input text into
+ * a small sequence of events so we can verify the Session → WS → client
+ * plumbing end-to-end without needing API keys or hitting a real
+ * provider. Splits on whitespace, emits one `text_delta` per token
+ * with a short delay, then `complete`. Respects `signal.aborted`.
+ */
+export const echoDriver: SessionDriver = async (text, { emit, signal }) => {
+  const tokens = text.split(/\s+/).filter((t) => t.length > 0)
+  if (tokens.length === 0) {
+    emit({ type: 'text_delta', text: '(empty message — echoing nothing)' })
+    emit({ type: 'complete' })
+    return
+  }
+  for (let i = 0; i < tokens.length; i++) {
+    if (signal.aborted) return // Session wraps this into an `aborted` event
+    emit({ type: 'text_delta', text: (i === 0 ? '' : ' ') + tokens[i] })
+    // Small delay so clients observing the stream see incremental
+    // arrival (not a batch).
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, 40)
+      const onAbort = () => {
+        clearTimeout(timer)
+        reject(new Error('aborted'))
+      }
+      if (signal.aborted) {
+        clearTimeout(timer)
+        reject(new Error('aborted'))
+        return
+      }
+      signal.addEventListener('abort', onAbort, { once: true })
+    }).catch(() => {/* aborted — fall through and let Session handle */})
+  }
+  emit({ type: 'complete' })
+}

--- a/cli/src/gateway/index.ts
+++ b/cli/src/gateway/index.ts
@@ -5,6 +5,7 @@ import { installAction, uninstallAction } from '/src/gateway/install.ts'
 import { runLifecycle } from '/src/gateway/lifecycle.ts'
 import { statusAction } from '/src/gateway/status.ts'
 import { logsAction } from '/src/gateway/logs.ts'
+import { pingAction } from '/src/gateway/ping.ts'
 
 export const gatewayCmd = new Command()
   .description(
@@ -81,5 +82,14 @@ gatewayCmd.command('logs')
   })
   .action(async (opts: { follow?: boolean; lines?: number }) => {
     const ok = await logsAction(opts)
+    if (!ok) Deno.exit(1)
+  })
+
+gatewayCmd.command('ping')
+  .description(
+    'Connect to the local gateway and run the hello → auth → ping handshake',
+  )
+  .action(async () => {
+    const ok = await pingAction()
     if (!ok) Deno.exit(1)
   })

--- a/cli/src/gateway/ping.ts
+++ b/cli/src/gateway/ping.ts
@@ -1,0 +1,116 @@
+import { colors } from '@cliffy/colors'
+import { loadGatewayConfig } from '/src/gateway/config.ts'
+import { errToString } from '/lib/errToString.ts'
+
+/**
+ * Minimal WebSocket smoke client for `slv gateway ping`. Connects to
+ * the local gateway, performs the hello → auth → ping handshake,
+ * prints the responses, and exits. Used for:
+ *
+ *   - post-install verification (is the daemon actually reachable?)
+ *   - external healthcheck (monitoring agents can shell out to this
+ *     and check the exit code)
+ *   - dogfooding on remote VPSes that don't have deno/python/websocat
+ *     installed (the slv binary is everything you need)
+ */
+export const pingAction = async (): Promise<boolean> => {
+  let config
+  try {
+    config = await loadGatewayConfig()
+  } catch (err) {
+    console.error(
+      colors.red(`❌ gateway config not found or invalid: ${errToString(err)}`),
+    )
+    console.error(
+      colors.white(`   Start the gateway first: slv gateway start`),
+    )
+    return false
+  }
+
+  const url = `ws://127.0.0.1:${config.port}/v1/session/ws`
+  console.log(colors.gray(`→ connecting ${url}`))
+
+  return new Promise((resolve) => {
+    const ws = new WebSocket(url)
+    const pending = new Map<
+      string,
+      (r: { ok: boolean; payload?: unknown; error?: string }) => void
+    >()
+    let counter = 0
+    const call = (method: string, params?: unknown) =>
+      new Promise<{ ok: boolean; payload?: unknown; error?: string }>((res) => {
+        const id = `p${++counter}`
+        pending.set(id, res)
+        ws.send(JSON.stringify({ kind: 'req', id, method, params }))
+      })
+    const timeout = setTimeout(() => {
+      console.error(colors.red('❌ ping timed out (5s)'))
+      try {
+        ws.close()
+      } catch { /* ignore */ }
+      resolve(false)
+    }, 5000)
+
+    ws.onopen = async () => {
+      try {
+        const hello = await call('gateway.hello')
+        if (!hello.ok) {
+          throw new Error(`hello: ${hello.error}`)
+        }
+        const info = hello.payload as { service: string; version: string }
+        console.log(
+          colors.green(
+            `✓ hello (service=${info.service} version=${info.version})`,
+          ),
+        )
+
+        const auth = await call('gateway.auth', { token: config.token })
+        if (!auth.ok) {
+          throw new Error(`auth: ${auth.error ?? 'rejected'}`)
+        }
+        console.log(colors.green(`✓ auth`))
+
+        const ping = await call('gateway.ping')
+        if (!ping.ok) {
+          throw new Error(`ping: ${ping.error ?? 'rejected'}`)
+        }
+        console.log(colors.green(`✓ ping`))
+        clearTimeout(timeout)
+        ws.close()
+        resolve(true)
+      } catch (err) {
+        clearTimeout(timeout)
+        console.error(colors.red(`❌ ${errToString(err)}`))
+        try {
+          ws.close()
+        } catch { /* ignore */ }
+        resolve(false)
+      }
+    }
+
+    ws.onmessage = (ev) => {
+      try {
+        const f = JSON.parse(String(ev.data)) as {
+          kind: string
+          id?: string
+          ok?: boolean
+          payload?: unknown
+          error?: string
+        }
+        if (f.kind === 'res' && typeof f.id === 'string') {
+          const r = pending.get(f.id)
+          if (r) {
+            pending.delete(f.id)
+            r({ ok: !!f.ok, payload: f.payload, error: f.error })
+          }
+        }
+      } catch { /* ignore malformed — request-response above times out */ }
+    }
+
+    ws.onerror = () => {
+      clearTimeout(timeout)
+      console.error(colors.red(`❌ WebSocket error — gateway not running?`))
+      resolve(false)
+    }
+  })
+}

--- a/cli/src/gateway/ws/router.ts
+++ b/cli/src/gateway/ws/router.ts
@@ -5,28 +5,42 @@ import {
   GATEWAY_SERVICE_ID,
 } from '/src/gateway/paths.ts'
 import { PROTOCOL_VERSION } from '/src/gateway/ws/frames.ts'
+import { echoDriver, Session } from '/src/ai/core/session.ts'
 
 /**
- * Per-connection state. Phase 2A tracks only auth; Phase 2B adds a
- * reference to the active session.
+ * Per-connection state. Phase 2A: just auth. Phase 2B adds the
+ * active session (created lazily on the first `session.send`-family
+ * call) and an event-seq counter that's bumped for every pushed
+ * event frame.
  */
 export type ConnState = {
   authenticated: boolean
-  // seq of the next server-pushed event. Bumped by the eventual
-  // session-core event emitter (Phase 2B); kept here so we don't
-  // need a separate store.
   nextEventSeq: number
+  // Lazily-created Session for this connection. Null until the
+  // first session.* method call.
+  session: Session | null
 }
 
 export const newConnState = (): ConnState => ({
   authenticated: false,
   nextEventSeq: 1,
+  session: null,
 })
+
+import type { SessionEvent } from '/src/ai/core/events.ts'
+
+export type DispatchCtx = {
+  token: string
+  // Push an event frame to this specific connection. The router
+  // framework packages each SessionEvent with the right seq number
+  // and encodes as an EventFrame — handlers don't see frames.
+  emitEvent: (event: SessionEvent) => void
+}
 
 type MethodHandler = (
   req: ReqFrame,
   state: ConnState,
-  ctx: { token: string },
+  ctx: DispatchCtx,
 ) => Promise<ResFrame> | ResFrame
 
 const methods: Record<string, MethodHandler> = {
@@ -68,6 +82,52 @@ const methods: Record<string, MethodHandler> = {
     if (!state.authenticated) return resErr(req, 'not authenticated')
     return resOk(req, { pong: true })
   },
+
+  /**
+   * Phase 2B loopback driver: echoes the input text back as a stream
+   * of `text_delta` events followed by `complete`. Purely a wire-
+   * validation tool — the real `session.send` arrives when the
+   * provider driver lands in the next PR. Using a separate method
+   * name now means the eventual `session.send` (backed by a real
+   * LLM) can be added without breaking callers that expect the
+   * deterministic echo behaviour.
+   */
+  'session.echo': (req, state, ctx) => {
+    if (!state.authenticated) return resErr(req, 'not authenticated')
+    const p = req.params as { text?: unknown } | undefined
+    const text = p && typeof p.text === 'string' ? p.text : null
+    if (text === null) return resErr(req, 'params.text must be a string')
+
+    // Lazily create the Session + wire our event-push callback the
+    // first time a session.* method is called on this connection.
+    if (!state.session) {
+      state.session = new Session(echoDriver)
+      state.session.on((event) => ctx.emitEvent(event))
+    }
+    if (state.session.isRunning) {
+      return resErr(req, 'session is already running; call session.abort first')
+    }
+
+    // Fire-and-forget — the driver emits events asynchronously.
+    // We return immediately so the client sees the req ack before
+    // the first event frame.
+    state.session.send(text).catch(() => {
+      // Session.send never throws (it wraps everything into error
+      // events), so this catch is defensive only.
+    })
+    return resOk(req, { accepted: true })
+  },
+
+  /**
+   * Cancel the in-flight session.send/echo. Idempotent: no-op if
+   * nothing is running.
+   */
+  'session.abort': (req, state) => {
+    if (!state.authenticated) return resErr(req, 'not authenticated')
+    const was = state.session?.isRunning ?? false
+    state.session?.abort('client requested abort')
+    return resOk(req, { wasRunning: was })
+  },
 }
 
 const constantTimeEquals = (a: string, b: string): boolean => {
@@ -87,7 +147,7 @@ const constantTimeEquals = (a: string, b: string): boolean => {
 export const dispatchRequest = async (
   req: ReqFrame,
   state: ConnState,
-  ctx: { token: string },
+  ctx: DispatchCtx,
 ): Promise<ResFrame> => {
   const handler = methods[req.method]
   if (!handler) return resErr(req, `method not found: ${req.method}`)

--- a/cli/src/gateway/ws/server.ts
+++ b/cli/src/gateway/ws/server.ts
@@ -4,10 +4,12 @@ import {
   parseFrame,
   resErr,
 } from '/src/gateway/ws/frames.ts'
+import type { EventFrame } from '/src/gateway/ws/frames.ts'
 import {
   dispatchRequest,
   newConnState,
 } from '/src/gateway/ws/router.ts'
+import type { SessionEvent } from '/src/ai/core/events.ts'
 
 /**
  * Register the `/v1/session/ws` WebSocket endpoint on the Hono app.
@@ -43,6 +45,21 @@ const upgradeWs = (
   const { socket, response } = Deno.upgradeWebSocket(c.req.raw)
   const state = newConnState()
   let preauthBad = 0
+
+  // Per-connection event pump: serializes each SessionEvent into an
+  // `event` frame with a monotonically-increasing `seq`. Clients
+  // that reconnect (Phase 3) will be able to resume from the last
+  // `seq` they saw; for now this at least gives them gap detection.
+  const emitEvent = (event: SessionEvent): void => {
+    if (socket.readyState !== WebSocket.OPEN) return
+    const frame: EventFrame = {
+      kind: 'event',
+      event: event.type,
+      payload: event,
+      seq: state.nextEventSeq++,
+    }
+    socket.send(encodeFrame(frame))
+  }
 
   socket.onopen = () => {
     // No server-initiated hello — spec says the client sends the
@@ -84,7 +101,10 @@ const upgradeWs = (
       return
     }
 
-    const res = await dispatchRequest(parsed, state, ctx)
+    const res = await dispatchRequest(parsed, state, {
+      token: ctx.token,
+      emitEvent,
+    })
     socket.send(encodeFrame(res))
     // Reset the bad-frame counter on any successful request (even
     // an unauthenticated hello) so a client that recovers after a
@@ -98,7 +118,10 @@ const upgradeWs = (
   }
 
   socket.onclose = () => {
-    // Future: clean up the session this conn was attached to.
+    // Abort any in-flight session so the echo driver (or future
+    // provider loop) stops burning cycles on events that can't be
+    // delivered. Idempotent: no-op if nothing is running.
+    state.session?.abort('client disconnected')
   }
 
   return response

--- a/cli/test/integration/gateway_ws_session.test.ts
+++ b/cli/test/integration/gateway_ws_session.test.ts
@@ -1,0 +1,261 @@
+import { assert, assertEquals } from '@std/assert'
+import { join } from '@std/path'
+
+// End-to-end WS tests for Phase 2B's `session.echo` + `session.abort`
+// methods. Boots a real gateway subprocess, authenticates, issues the
+// session methods, and collects streaming event frames.
+
+const CLI_ENTRY = new URL('../../src/index.ts', import.meta.url).pathname
+const pickPort = (): number => 30000 + Math.floor(Math.random() * 10000)
+
+type Gw = {
+  child: Deno.ChildProcess
+  home: string
+  port: number
+  token: string
+  stderr: Promise<string>
+}
+
+const startGateway = async (): Promise<Gw> => {
+  const home = await Deno.makeTempDir({ prefix: 'slv-gw-sess-' })
+  const port = pickPort()
+  const child = new Deno.Command(Deno.execPath(), {
+    args: ['run', '-A', '--no-check', CLI_ENTRY, 'gateway', 'run'],
+    env: {
+      HOME: home,
+      PATH: Deno.env.get('PATH') ?? '/usr/bin:/bin',
+      SLV_GATEWAY_PORT: String(port),
+    },
+    stdin: 'null',
+    stdout: 'piped',
+    stderr: 'piped',
+  }).spawn()
+  const drain = async (s: ReadableStream<Uint8Array>): Promise<string> => {
+    const r = s.getReader()
+    const chunks: Uint8Array[] = []
+    while (true) {
+      const { value, done } = await r.read()
+      if (done) break
+      if (value) chunks.push(value)
+    }
+    const total = chunks.reduce((n, c) => n + c.length, 0)
+    const buf = new Uint8Array(total)
+    let o = 0
+    for (const c of chunks) {
+      buf.set(c, o)
+      o += c.length
+    }
+    return new TextDecoder().decode(buf)
+  }
+  drain(child.stdout).catch(() => {})
+  const stderr = drain(child.stderr).catch(() => '')
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/healthz`)
+      if (res.ok) {
+        await res.body?.cancel()
+        break
+      }
+      await res.body?.cancel()
+    } catch { /* try again */ }
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  const cfg = JSON.parse(
+    await Deno.readTextFile(join(home, '.slv/gateway/gateway.json')),
+  ) as { token: string }
+  return { child, home, port, token: cfg.token, stderr }
+}
+
+const stopGateway = async (gw: Gw): Promise<void> => {
+  try {
+    gw.child.kill('SIGTERM')
+  } catch { /* already dead */ }
+  await gw.child.status.catch(() => {})
+  await gw.stderr
+  await Deno.remove(gw.home, { recursive: true }).catch(() => {})
+}
+
+type Frame =
+  | { kind: 'res'; id: string; ok: boolean; payload?: unknown; error?: string }
+  | { kind: 'event'; event: string; payload?: unknown; seq: number }
+
+type WsClient = {
+  socket: WebSocket
+  call: (
+    method: string,
+    params?: unknown,
+  ) => Promise<Extract<Frame, { kind: 'res' }>>
+  events: Frame[]
+  eventsOfType: (t: string) => unknown[]
+  waitForEvent: (
+    predicate: (f: Extract<Frame, { kind: 'event' }>) => boolean,
+    timeoutMs?: number,
+  ) => Promise<Extract<Frame, { kind: 'event' }>>
+  close: () => void
+}
+
+const openWs = (port: number): Promise<WsClient> =>
+  new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/session/ws`)
+    const pendingRes = new Map<
+      string,
+      (r: Extract<Frame, { kind: 'res' }>) => void
+    >()
+    const events: Frame[] = []
+    const eventWaiters: Array<{
+      check: (f: Extract<Frame, { kind: 'event' }>) => boolean
+      resolve: (f: Extract<Frame, { kind: 'event' }>) => void
+    }> = []
+    let counter = 0
+    ws.onopen = () => {
+      resolve({
+        socket: ws,
+        call: (method, params) =>
+          new Promise((res) => {
+            const id = `t${++counter}`
+            pendingRes.set(id, res)
+            ws.send(JSON.stringify({ kind: 'req', id, method, params }))
+          }),
+        events,
+        eventsOfType: (t) =>
+          events
+            .filter((e): e is Extract<Frame, { kind: 'event' }> =>
+              e.kind === 'event' && e.event === t
+            )
+            .map((e) => e.payload),
+        waitForEvent: (predicate, timeoutMs = 5000) =>
+          new Promise((resolve2, reject2) => {
+            const existing = events.find((e): e is Extract<Frame, { kind: 'event' }> =>
+              e.kind === 'event' && predicate(e)
+            )
+            if (existing) {
+              resolve2(existing)
+              return
+            }
+            const timer = setTimeout(() => reject2(new Error('event wait timeout')), timeoutMs)
+            eventWaiters.push({
+              check: predicate,
+              resolve: (f) => {
+                clearTimeout(timer)
+                resolve2(f)
+              },
+            })
+          }),
+        close: () => ws.close(),
+      })
+    }
+    ws.onmessage = (ev) => {
+      const f = JSON.parse(String(ev.data)) as Frame
+      if (f.kind === 'res') {
+        const r = pendingRes.get(f.id)
+        if (r) {
+          pendingRes.delete(f.id)
+          r(f)
+        }
+      } else if (f.kind === 'event') {
+        events.push(f)
+        for (let i = eventWaiters.length - 1; i >= 0; i--) {
+          if (eventWaiters[i].check(f)) {
+            eventWaiters[i].resolve(f)
+            eventWaiters.splice(i, 1)
+          }
+        }
+      }
+    }
+    ws.onerror = (e) => reject(e)
+  })
+
+const sub = { sanitizeResources: false, sanitizeOps: false } as const
+
+Deno.test(
+  'ws: session.echo streams text_delta events then complete',
+  sub,
+  async () => {
+    const gw = await startGateway()
+    try {
+      const c = await openWs(gw.port)
+      try {
+        const auth = await c.call('gateway.auth', { token: gw.token })
+        assertEquals(auth.ok, true)
+
+        const res = await c.call('session.echo', { text: 'hello world foo' })
+        assertEquals(res.ok, true)
+        assertEquals((res.payload as { accepted: boolean }).accepted, true)
+
+        // Wait for the complete event
+        await c.waitForEvent((f) => {
+          const p = f.payload as { type: string } | undefined
+          return p?.type === 'complete'
+        })
+
+        const deltas = c.eventsOfType('text_delta') as Array<{ text: string }>
+        assertEquals(deltas.length, 3)
+        const concat = deltas.map((d) => d.text).join('')
+        assertEquals(concat, 'hello world foo')
+
+        // Seq is monotonically increasing
+        const seqs = c.events
+          .filter((e): e is Extract<Frame, { kind: 'event' }> => e.kind === 'event')
+          .map((e) => e.seq)
+        for (let i = 1; i < seqs.length; i++) {
+          assert(seqs[i] > seqs[i - 1], `seq must increase: ${seqs[i - 1]} → ${seqs[i]}`)
+        }
+      } finally {
+        c.close()
+      }
+    } finally {
+      await stopGateway(gw)
+    }
+  },
+)
+
+Deno.test('ws: session.abort cancels in-flight echo', sub, async () => {
+  const gw = await startGateway()
+  try {
+    const c = await openWs(gw.port)
+    try {
+      await c.call('gateway.auth', { token: gw.token })
+
+      const sent = await c.call('session.echo', {
+        text: 'one two three four five six seven eight',
+      })
+      assertEquals(sent.ok, true)
+
+      // Let ~one token stream, then abort
+      await new Promise((r) => setTimeout(r, 60))
+      const abort = await c.call('session.abort')
+      assertEquals(abort.ok, true)
+      assertEquals((abort.payload as { wasRunning: boolean }).wasRunning, true)
+
+      await c.waitForEvent((f) => {
+        const p = f.payload as { type: string } | undefined
+        return p?.type === 'aborted'
+      })
+
+      // No `complete` should have fired
+      const complete = c.eventsOfType('complete')
+      assertEquals(complete.length, 0)
+    } finally {
+      c.close()
+    }
+  } finally {
+    await stopGateway(gw)
+  }
+})
+
+Deno.test('ws: session.echo requires auth', sub, async () => {
+  const gw = await startGateway()
+  try {
+    const c = await openWs(gw.port)
+    try {
+      const res = await c.call('session.echo', { text: 'hi' })
+      assertEquals(res.ok, false)
+      assert(res.error && /not authenticated/.test(res.error))
+    } finally {
+      c.close()
+    }
+  } finally {
+    await stopGateway(gw)
+  }
+})

--- a/cli/test/unit/session_core.test.ts
+++ b/cli/test/unit/session_core.test.ts
@@ -1,0 +1,85 @@
+import { assert, assertEquals } from '@std/assert'
+import { echoDriver, Session } from '/src/ai/core/session.ts'
+import type { SessionEvent } from '/src/ai/core/events.ts'
+
+const collect = (s: Session): SessionEvent[] => {
+  const events: SessionEvent[] = []
+  s.on((e) => events.push(e))
+  return events
+}
+
+Deno.test('echo driver produces one text_delta per token then complete', async () => {
+  const s = new Session(echoDriver)
+  const events = collect(s)
+  await s.send('hello world foo')
+  // Events: status(running) + 3 text_delta + complete + status(idle)
+  const deltas = events.filter((e) => e.type === 'text_delta')
+  assertEquals(deltas.length, 3)
+  assertEquals(events.find((e) => e.type === 'complete') !== undefined, true)
+  // Terminal + idle always fire
+  assertEquals(
+    events.filter((e) => e.type === 'status' && e.state === 'idle').length,
+    1,
+  )
+})
+
+Deno.test('Session emits complete even if driver forgets to', async () => {
+  const s = new Session(async (_text, _ctx) => {
+    // driver emits nothing
+  })
+  const events = collect(s)
+  await s.send('x')
+  assertEquals(events.find((e) => e.type === 'complete') !== undefined, true)
+})
+
+Deno.test('Session emits error when driver throws (non-abort)', async () => {
+  const s = new Session(async () => {
+    throw new Error('boom')
+  })
+  const events = collect(s)
+  await s.send('x')
+  const err = events.find((e) => e.type === 'error')
+  assert(err && err.type === 'error')
+  assertEquals(err.message, 'boom')
+})
+
+Deno.test('Session.abort during echo fires aborted, not complete', async () => {
+  const s = new Session(echoDriver)
+  const events = collect(s)
+  // Start a multi-token echo but abort before it finishes
+  const p = s.send('one two three four five six')
+  setTimeout(() => s.abort('test reason'), 60)
+  await p
+  assert(events.some((e) => e.type === 'aborted'))
+  assert(!events.some((e) => e.type === 'complete'))
+})
+
+Deno.test('Session refuses overlapping sends', async () => {
+  const s = new Session(echoDriver)
+  const events = collect(s)
+  const first = s.send('one two three')
+  await s.send('overlap')
+  const errs = events.filter((e) => e.type === 'error')
+  assert(errs.some((e) => e.type === 'error' && /already processing/.test(e.message)))
+  await first
+})
+
+Deno.test('listeners can unsubscribe and stop seeing events', async () => {
+  const s = new Session(echoDriver)
+  const seen: SessionEvent[] = []
+  const unsub = s.on((e) => seen.push(e))
+  unsub()
+  await s.send('hi')
+  assertEquals(seen.length, 0)
+})
+
+Deno.test('listener errors do not break other listeners', async () => {
+  const s = new Session(echoDriver)
+  const good: SessionEvent[] = []
+  s.on(() => {
+    throw new Error('listener-bug')
+  })
+  s.on((e) => good.push(e))
+  await s.send('hi')
+  assert(good.length > 0, 'good listener should still have received events')
+})


### PR DESCRIPTION
## Context

Stacks on Phase 2A (#305, merged). Adds the Session abstraction that will drive the real LLM/tool loop in a follow-up PR, plus an echo driver so the full WS → router → Session → events pipeline can be exercised end-to-end TODAY — including on remote VPSes that have no LLM API key configured.

Plus a new `slv gateway ping` CLI command that's perfect for post-install verification, monitoring healthchecks, and dogfooding on machines that don't have deno/python/websocat installed.

## Verified end-to-end on real Ubuntu 24.04 VPS

\`openclaw@84.32.103.177\`:

\`\`\`
$ slv gateway install && slv gateway start
⚙️  starting gateway via systemd --user...
✅ gateway started

$ slv gateway ping
→ connecting ws://127.0.0.1:20026/v1/session/ws
✓ hello (service=slv-gateway version=1)
✓ auth
✓ ping

$ slv gateway logs -n 5
…

$ slv gateway stop && slv gateway uninstall
\`\`\`

## Session core (new, driver-agnostic)

| File | Role |
|---|---|
| \`cli/src/ai/core/events.ts\` | \`SessionEvent\` discriminated union (\`text_delta\`, \`tool_use_start\`, \`tool_result\`, \`status\`, \`complete\`, \`aborted\`, \`error\`). Additive-only to preserve client compatibility. |
| \`cli/src/ai/core/session.ts\` | \`Session\` class + \`echoDriver\`. Guarantees exactly ONE terminal event per \`send()\`, even if driver forgets or throws. Listener errors don't break other listeners. AbortController threaded through so `signal.aborted` in drivers yields the right \`aborted\` event. |

The echo driver tokenizes the input and emits one \`text_delta\` per token with a short delay — deterministic, no external deps, perfect wire-validation tool.

## New WS methods (extend Phase 2A router)

- **\`session.echo\`** — lazily creates a per-connection \`Session\` with the echo driver, subscribes an emit callback that packages each \`SessionEvent\` into a monotonically-seq'd \`event\` frame, kicks off the send, returns \`{accepted: true}\` immediately.
- **\`session.abort\`** — calls \`Session.abort()\`; returns \`{wasRunning}\`.

Router's \`MethodHandler\` signature extended with a new \`DispatchCtx\` carrying \`emitEvent\`. Server.ts event pump handles seq-number allocation centrally so handlers never see frame-level details. Connection close aborts any in-flight session.

## New CLI: \`slv gateway ping\`

Minimal WebSocket smoke client baked into the slv binary itself. Reads the local token, connects to \`ws://127.0.0.1:<port>/v1/session/ws\`, walks the hello → auth → ping handshake, prints ✓ per step. Solves three practical problems:

- Post-install verification on fresh machines
- External healthchecks (exit-code for monitoring agents)
- Dogfooding on VPSes without deno/python/websocat

## Tests (10 new, 98 total pass)

- \`test/unit/session_core.test.ts\` (7) — terminal-event guarantees, abort-during-echo behaviour, listener errors don't break peers, overlapping-send rejection.
- \`test/integration/gateway_ws_session.test.ts\` (3) — end-to-end against a real gateway subprocess:
  - \`session.echo\` streams text_delta events in order, seq monotonically increases, \`complete\` fires.
  - \`session.abort\` fires \`aborted\` terminal, NO \`complete\`.
  - \`session.echo\` requires auth.

Full CI: **88 → 98 passing tests**.

## What is NOT in this PR

- Real provider driver (Anthropic/OpenAI/SLV) behind \`session.send\` — will be swappable with \`echoDriver\` in the next PR.
- \`consoleAction.ts\` switched to consume \`Session\` events instead of the current per-provider callbacks.
- Gap-recovery on WS reconnect (client sends last-seen seq → server replays from buffer).

## Relation to #298

Phase 2B of Tier 3. Next: real provider driver + TUI migration to Session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)