### PR TITLE
feat(gateway): Phase 2C — real provider driver + session.send WS method

### DIFF
--- a/cli/src/ai/core/drivers/provider.ts
+++ b/cli/src/ai/core/drivers/provider.ts
@@ -1,0 +1,142 @@
+import type { SessionDriver } from '/src/ai/core/session.ts'
+import type { ChatCallbacks } from '/src/ai/console/consoleAction.ts'
+import { AnthropicProvider } from '/src/ai/console/providers/anthropic.ts'
+import { OpenAIProvider } from '/src/ai/console/providers/openai.ts'
+import { SLVProvider } from '/src/ai/console/providers/slv.ts'
+import {
+  clearAbort,
+  killActiveProcess,
+} from '/src/ai/console/tools.ts'
+import type { AiProvider } from '/src/ai/config.ts'
+import { errToString } from '/lib/errToString.ts'
+
+/**
+ * Minimum provider-chat shape the driver needs — any object with a
+ * `.chat(text)` method that emits via callbacks supplied at
+ * construction time. All three existing providers fit.
+ */
+export type ProviderLike = { chat: (userMessage: string) => Promise<void> }
+
+export type ProviderBuilder = (callbacks: ChatCallbacks) => ProviderLike
+
+export type ProviderConfig = {
+  kind: AiProvider
+  apiKey: string
+  model: string
+  systemPrompt: string
+}
+
+/**
+ * Default builder that instantiates the real SDK-backed provider
+ * matching `cfg.kind`. Exposed as a separate function so tests can
+ * inject a stub via `providerDriver({build: ...})` — and so the
+ * Session doesn't need to import the SDKs directly when mocked.
+ */
+export const defaultProviderBuilder = (cfg: ProviderConfig): ProviderBuilder =>
+(callbacks) => {
+  switch (cfg.kind) {
+    case 'anthropic':
+      return new AnthropicProvider(cfg.apiKey, cfg.model, cfg.systemPrompt, callbacks)
+    case 'openai':
+      return new OpenAIProvider(cfg.apiKey, cfg.model, cfg.systemPrompt, callbacks)
+    case 'slv':
+      return new SLVProvider(cfg.apiKey, cfg.model, cfg.systemPrompt, callbacks)
+  }
+}
+
+/**
+ * Translate a provider's callback-based streaming into `SessionEvent`s.
+ *
+ * Key translations:
+ *   - `onStream(fullText)` is CUMULATIVE — we diff against the last
+ *     observed length to emit incremental `text_delta`s. This matches
+ *     what clients expect (and keeps the WS frame size bounded).
+ *   - `onToolCall(name, detail)` becomes `tool_use_start` with a
+ *     synthetic id (providers don't expose their internal id) and
+ *     `args` parsed from JSON best-effort — fall back to raw string.
+ *   - `onComplete` becomes `complete`.
+ *
+ * Abort handling: when the Session's signal fires we call
+ * `killActiveProcess()` which flips the global abort flag read by the
+ * provider loops (see #299). This is a single-session-at-a-time
+ * constraint — documented in the PR. Multi-session abort isolation
+ * needs a deeper provider refactor and is out of scope here.
+ */
+export const providerDriver = (
+  cfgOrBuilder: ProviderConfig | { build: ProviderBuilder },
+): SessionDriver => {
+  const buildProvider: ProviderBuilder = 'build' in cfgOrBuilder
+    ? cfgOrBuilder.build
+    : defaultProviderBuilder(cfgOrBuilder)
+
+  return async (text, { emit, signal }) => {
+    let emittedChars = 0
+    let toolSeq = 0
+    let aborted = false
+
+    const callbacks: ChatCallbacks = {
+      onStream: (full: string) => {
+        if (typeof full !== 'string') return
+        const delta = full.slice(emittedChars)
+        emittedChars = full.length
+        if (delta.length > 0) emit({ type: 'text_delta', text: delta })
+      },
+      onToolCall: (name: string, detail: string) => {
+        let args: unknown = detail
+        try {
+          args = JSON.parse(detail)
+        } catch { /* leave as raw string */ }
+        emit({
+          type: 'tool_use_start',
+          id: `${name}-${++toolSeq}`,
+          name,
+          args,
+        })
+      },
+      // Providers call onComplete even on the abort path — their
+      // `shouldAbortAfterTools` helper fires onComplete before
+      // returning. So we re-check the abort state here; if we
+      // aborted, emit `aborted` so Session's terminal logic doesn't
+      // settle as `complete` when the user explicitly cancelled.
+      onComplete: () => {
+        if (aborted || signal.aborted) {
+          emit({ type: 'aborted' })
+        } else {
+          emit({ type: 'complete' })
+        }
+      },
+    }
+
+    const provider = buildProvider(callbacks)
+
+    // Forward Session.abort → global provider abort flag. Providers
+    // check this flag between LLM turns and break out of their loop
+    // cleanly. See cli/src/ai/console/tools.ts:killActiveProcess.
+    const onAbort = () => {
+      aborted = true
+      try {
+        killActiveProcess()
+      } catch { /* already dead */ }
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    // Reset the global abort flag before starting so a previous
+    // abort doesn't instantly short-circuit us.
+    clearAbort()
+
+    try {
+      await provider.chat(text)
+      // Provider.chat already fires onComplete → Session turns it
+      // into `complete`. If it returned without either, Session
+      // synthesizes one in its wrapper.
+    } catch (err) {
+      if (aborted || signal.aborted) {
+        emit({ type: 'aborted', reason: errToString(err) })
+      } else {
+        emit({ type: 'error', message: errToString(err) })
+      }
+    } finally {
+      signal.removeEventListener('abort', onAbort)
+    }
+  }
+}

--- a/cli/src/gateway/ws/router.ts
+++ b/cli/src/gateway/ws/router.ts
@@ -6,6 +6,9 @@ import {
 } from '/src/gateway/paths.ts'
 import { PROTOCOL_VERSION } from '/src/gateway/ws/frames.ts'
 import { echoDriver, Session } from '/src/ai/core/session.ts'
+import { providerDriver } from '/src/ai/core/drivers/provider.ts'
+import { readAiConfig } from '/src/ai/config.ts'
+import { getApiKeyFromYml } from '/lib/getApiKeyFromYml.ts'
 
 /**
  * Per-connection state. Phase 2A: just auth. Phase 2B adds the
@@ -84,13 +87,10 @@ const methods: Record<string, MethodHandler> = {
   },
 
   /**
-   * Phase 2B loopback driver: echoes the input text back as a stream
-   * of `text_delta` events followed by `complete`. Purely a wire-
-   * validation tool — the real `session.send` arrives when the
-   * provider driver lands in the next PR. Using a separate method
-   * name now means the eventual `session.send` (backed by a real
-   * LLM) can be added without breaking callers that expect the
-   * deterministic echo behaviour.
+   * Deterministic loopback driver that echoes the input text back as
+   * a stream of `text_delta` events followed by `complete`. Kept
+   * alongside `session.send` (real LLM) because it's invaluable for
+   * wire-protocol tests + fresh-VPS smoke-testing without API keys.
    */
   'session.echo': (req, state, ctx) => {
     if (!state.authenticated) return resErr(req, 'not authenticated')
@@ -98,29 +98,95 @@ const methods: Record<string, MethodHandler> = {
     const text = p && typeof p.text === 'string' ? p.text : null
     if (text === null) return resErr(req, 'params.text must be a string')
 
-    // Lazily create the Session + wire our event-push callback the
-    // first time a session.* method is called on this connection.
-    if (!state.session) {
-      state.session = new Session(echoDriver)
-      state.session.on((event) => ctx.emitEvent(event))
-    }
-    if (state.session.isRunning) {
+    if (state.session?.isRunning) {
       return resErr(req, 'session is already running; call session.abort first')
     }
+    // Fresh session per turn so switching drivers between echo and
+    // send works cleanly. Previous-turn history is not preserved in
+    // Phase 2C; session persistence lands in a later PR.
+    state.session = new Session(echoDriver)
+    state.session.on((event) => ctx.emitEvent(event))
 
-    // Fire-and-forget — the driver emits events asynchronously.
-    // We return immediately so the client sees the req ack before
-    // the first event frame.
     state.session.send(text).catch(() => {
-      // Session.send never throws (it wraps everything into error
-      // events), so this catch is defensive only.
+      // Session.send swallows errors into `error` events; this
+      // catch is defensive only.
     })
     return resOk(req, { accepted: true })
   },
 
   /**
-   * Cancel the in-flight session.send/echo. Idempotent: no-op if
-   * nothing is running.
+   * Real LLM turn. Loads the configured provider from ~/.slv/api.yml
+   * (respecting the `ai.provider` + `ai.model` the user set via
+   * `slv onboard`) and runs one chat turn, streaming `text_delta`,
+   * `tool_use_start`, `complete` / `aborted` / `error` events.
+   *
+   * Single-session-per-gateway limitation: provider abort goes
+   * through the global abort flag in tools.ts, so starting a
+   * session.send while a TUI chat is running in the same process
+   * will share abort state. Acceptable for Phase 2C (one client at
+   * a time); full isolation needs a provider refactor.
+   */
+  'session.send': async (req, state, ctx) => {
+    if (!state.authenticated) return resErr(req, 'not authenticated')
+    const p = req.params as { text?: unknown } | undefined
+    const text = p && typeof p.text === 'string' ? p.text : null
+    if (text === null) return resErr(req, 'params.text must be a string')
+
+    if (state.session?.isRunning) {
+      return resErr(req, 'session is already running; call session.abort first')
+    }
+
+    let aiCfg
+    try {
+      aiCfg = await readAiConfig()
+    } catch (err) {
+      return resErr(req, `failed to read AI config: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    if (!aiCfg) {
+      return resErr(
+        req,
+        'no AI provider configured — run `slv onboard` first',
+      )
+    }
+    // SLV provider reads its bearer from ~/.slv/api.yml's slv.api_key
+    // (not the ai.api_key field, which is used by anthropic/openai
+    // for their own API keys).
+    let apiKey = aiCfg.api_key
+    if (aiCfg.provider === 'slv') {
+      try {
+        apiKey = await getApiKeyFromYml(true)
+      } catch (err) {
+        return resErr(
+          req,
+          `failed to read SLV API key: ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+      if (!apiKey) {
+        return resErr(
+          req,
+          'no SLV API key — run `slv signup` / `slv login` first',
+        )
+      }
+    }
+
+    const driver = providerDriver({
+      kind: aiCfg.provider,
+      apiKey,
+      model: aiCfg.model,
+      systemPrompt: '', // Phase 2C: empty system prompt; agent config integration later
+    })
+    state.session = new Session(driver)
+    state.session.on((event) => ctx.emitEvent(event))
+
+    state.session.send(text).catch(() => {
+      // Session.send swallows errors into `error` events.
+    })
+    return resOk(req, { accepted: true, provider: aiCfg.provider })
+  },
+
+  /**
+   * Cancel the in-flight session. Idempotent: no-op if nothing is
+   * running.
    */
   'session.abort': (req, state) => {
     if (!state.authenticated) return resErr(req, 'not authenticated')

--- a/cli/test/unit/provider_driver.test.ts
+++ b/cli/test/unit/provider_driver.test.ts
@@ -1,0 +1,163 @@
+import { assert, assertEquals } from '@std/assert'
+import { providerDriver } from '/src/ai/core/drivers/provider.ts'
+import { Session } from '/src/ai/core/session.ts'
+import type { SessionEvent } from '/src/ai/core/events.ts'
+import type { ChatCallbacks } from '/src/ai/console/consoleAction.ts'
+import type { ProviderLike } from '/src/ai/core/drivers/provider.ts'
+
+// Tests use a mock provider to keep the cookbook-translation logic
+// (cumulative-text → delta, onToolCall → tool_use_start, etc.)
+// exercised without network. Real-provider wire-level behavior is
+// verified by the existing remote VPS smoke.
+
+type MockScript = ({
+  stream?: string
+  toolCall?: { name: string; detail: string }
+  throw?: Error
+  delayMs?: number
+})[]
+
+const buildMock = (script: MockScript) => (callbacks: ChatCallbacks): ProviderLike => ({
+  chat: async (_text: string) => {
+    for (const step of script) {
+      if (step.delayMs) {
+        await new Promise((r) => setTimeout(r, step.delayMs))
+      }
+      if (step.throw) throw step.throw
+      if (step.stream !== undefined) callbacks.onStream(step.stream)
+      if (step.toolCall) {
+        callbacks.onToolCall(step.toolCall.name, step.toolCall.detail)
+      }
+    }
+    callbacks.onComplete()
+  },
+})
+
+const collect = (session: Session): SessionEvent[] => {
+  const events: SessionEvent[] = []
+  session.on((e) => events.push(e))
+  return events
+}
+
+Deno.test('providerDriver computes text_delta from cumulative stream', async () => {
+  const build = buildMock([
+    { stream: 'Hel' },
+    { stream: 'Hello' },
+    { stream: 'Hello, wo' },
+    { stream: 'Hello, world' },
+  ])
+  const session = new Session(providerDriver({ build }))
+  const events = collect(session)
+  await session.send('hi')
+
+  const deltas = events
+    .filter((e): e is Extract<SessionEvent, { type: 'text_delta' }> =>
+      e.type === 'text_delta'
+    )
+    .map((e) => e.text)
+  // Cumulative: Hel → Hello → Hello, wo → Hello, world
+  // Deltas:      Hel  +   lo  +   , wo  +   rld
+  assertEquals(deltas, ['Hel', 'lo', ', wo', 'rld'])
+  assertEquals(
+    events.find((e) => e.type === 'complete') !== undefined,
+    true,
+  )
+})
+
+Deno.test('providerDriver emits tool_use_start with parsed args', async () => {
+  const build = buildMock([
+    {
+      toolCall: {
+        name: 'run_command',
+        detail: '{"command":"echo hi"}',
+      },
+    },
+  ])
+  const session = new Session(providerDriver({ build }))
+  const events = collect(session)
+  await session.send('run it')
+
+  const tool = events.find((e): e is Extract<SessionEvent, { type: 'tool_use_start' }> =>
+    e.type === 'tool_use_start'
+  )
+  assert(tool)
+  assertEquals(tool.name, 'run_command')
+  assertEquals((tool.args as { command: string }).command, 'echo hi')
+  // Tool ID includes the tool name
+  assert(tool.id.startsWith('run_command-'))
+})
+
+Deno.test('providerDriver falls back to raw string args if JSON invalid', async () => {
+  const build = buildMock([
+    {
+      toolCall: {
+        name: 'mystery',
+        detail: 'not json',
+      },
+    },
+  ])
+  const session = new Session(providerDriver({ build }))
+  const events = collect(session)
+  await session.send('x')
+
+  const tool = events.find((e): e is Extract<SessionEvent, { type: 'tool_use_start' }> =>
+    e.type === 'tool_use_start'
+  )
+  assert(tool)
+  assertEquals(tool.args, 'not json')
+})
+
+Deno.test('providerDriver emits error when provider throws (not aborted)', async () => {
+  const build = buildMock([{ throw: new Error('API limit exceeded') }])
+  const session = new Session(providerDriver({ build }))
+  const events = collect(session)
+  await session.send('x')
+
+  const err = events.find((e): e is Extract<SessionEvent, { type: 'error' }> =>
+    e.type === 'error'
+  )
+  assert(err)
+  assertEquals(err.message, 'API limit exceeded')
+  // NOT `aborted` — the provider threw independently
+  assertEquals(events.find((e) => e.type === 'aborted'), undefined)
+})
+
+Deno.test('providerDriver emits aborted when Session.abort fires mid-chat', async () => {
+  const build = buildMock([
+    { stream: 'start', delayMs: 50 },
+    { stream: 'start middle', delayMs: 50 },
+    { stream: 'start middle end', delayMs: 50 },
+  ])
+  const session = new Session(providerDriver({ build }))
+  const events = collect(session)
+  const promise = session.send('x')
+  // Abort after the first chunk but before the last
+  setTimeout(() => session.abort('test'), 75)
+  await promise
+
+  // We should see an aborted terminal, not complete
+  const aborted = events.find((e) => e.type === 'aborted')
+  const complete = events.find((e) => e.type === 'complete')
+  assert(aborted, 'expected aborted event')
+  assertEquals(complete, undefined, 'complete should not fire when aborted')
+})
+
+Deno.test('providerDriver ignores zero-length text_delta', async () => {
+  // If the provider fires onStream with identical cumulative text
+  // twice (no new chars), we should NOT emit an empty text_delta.
+  const build = buildMock([
+    { stream: 'hi' },
+    { stream: 'hi' }, // same — delta is empty
+    { stream: 'hi!' }, // adds '!'
+  ])
+  const session = new Session(providerDriver({ build }))
+  const events = collect(session)
+  await session.send('x')
+
+  const deltas = events
+    .filter((e): e is Extract<SessionEvent, { type: 'text_delta' }> =>
+      e.type === 'text_delta'
+    )
+    .map((e) => e.text)
+  assertEquals(deltas, ['hi', '!'])
+})


### PR DESCRIPTION
## Context

Stacks on Phase 2B (#306, merged). Replaces the echo placeholder with **actual LLM work**: \`session.send\` now runs the configured provider from \`~/.slv/api.yml\` (SLV / Anthropic / OpenAI) and streams real responses as \`text_delta\` / \`tool_use_start\` / \`complete\` events over the WebSocket.

## Verified end-to-end on Ubuntu 24.04 VPS

\`openclaw@84.32.103.177\` — real SLV LLM call through WebSocket:

\`\`\`
$ slv gateway install && slv gateway start
✅ gateway started

$ slv gateway ping
✓ hello (service=slv-gateway version=1)
✓ auth
✓ ping

(via WS client)
session.send { text: "Say hi in one short sentence." }
  → res: { ok: true, payload: { accepted: true, provider: 'slv' } }
  → event: text_delta { text: "Hi there! 👋" }
  → event: complete
\`\`\`

## providerDriver (new)

\`cli/src/ai/core/drivers/provider.ts\` — factory that turns any existing provider (Anthropic / OpenAI / SLV) into a \`SessionDriver\`:

| Translation | Detail |
|---|---|
| \`onStream(cumulativeText)\` → \`text_delta(delta)\` | Diffs against last emitted length; skips empty deltas (provider may fire with identical text twice on edge cases) |
| \`onToolCall(name, detail)\` → \`tool_use_start\` | Synthetic \`id\` (providers don't expose internal ids), best-effort \`JSON.parse\` of detail with raw-string fallback |
| \`onComplete\` → \`complete\` OR \`aborted\` | Re-checks abort state: providers' \`shouldAbortAfterTools\` fires onComplete before returning true, so an aborted turn needs this check or it would incorrectly settle as \`complete\` |

**Abort threading**: \`Session.abort\` → driver's onAbort → \`killActiveProcess()\` from tools.ts (flips the global abort flag providers honor since #299). Reuses existing abort infra; full per-session isolation needs a provider refactor, out of scope.

**Dependency injection**: \`providerDriver({build: ...})\` for tests — no network needed for unit coverage.

## New WS method: session.send

Reads AI config from \`~/.slv/api.yml\` (\`ai.provider\`, \`ai.model\`, plus \`slv.api_key\` for the SLV provider). Creates a fresh Session per turn bound to the real driver. Returns \`{accepted, provider}\` on the req ack, then streams events.

\`session.echo\` refactored to also create a fresh session per turn so switching between drivers works cleanly.

## Tests (6 new, all pass)

\`test/unit/provider_driver.test.ts\` with an injected mock provider (no network):

- cumulative text → incremental deltas (4-step check)
- \`onToolCall\` with valid JSON → parsed args + synthetic id
- \`onToolCall\` with non-JSON → raw string args
- provider throw → \`error\` event (NOT \`aborted\`)
- \`Session.abort\` mid-turn → \`aborted\` terminal, no \`complete\`
- identical cumulative stream → no empty delta emitted

Full suite: **88 → 94 passing tests**.

## What is NOT in this PR

- TUI migration to consume Session events instead of provider callbacks (big refactor in consoleAction.ts)
- Session persistence across WS reconnect (Phase 3 territory)
- Per-session abort isolation (needs provider API change)
- Agent-config-driven system prompts in session.send (currently empty; matches echo-driver parity)

## Relation to #298

Phase 2C of Tier 3. Next: TUI adapter switches from direct provider calls to WS session subscription (closes Phase 2 of #298), or daemon-mode packaging (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)