### PR TITLE
feat(ai): Phase 2D-v1 — opt-in `slv c --via-gateway` routes chat through the local daemon

### DIFF
--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -467,7 +467,10 @@ async function promptInstallDependencies(missing: string[]): Promise<void> {
   console.log('')
 }
 
-export const consoleAction = async () => {
+export type ConsoleOptions = { viaGateway?: boolean }
+
+export const consoleAction = async (options: ConsoleOptions = {}) => {
+  const viaGateway = options.viaGateway === true
   await initI18n()
   // Reset lazy-loaded tools, context modules, and demand-driven caches at session start
   resetActiveTools()
@@ -948,7 +951,60 @@ export const consoleAction = async () => {
     },
   }
 
-  if (config.provider === 'openai') {
+  // Gateway-backed provider (experimental opt-in via `slv c -g`).
+  // Bootstraps the local daemon if it isn't running yet — user-
+  // facing messages are plain-English ("background service"), no
+  // systemd/launchd jargon. On failure we fall back to the direct
+  // provider so the user still gets a working chat.
+  let gatewayBootstrap:
+    | { port: number; token: string }
+    | null = null
+  if (viaGateway) {
+    const { ensureGatewayRunning } = await import(
+      '/src/gateway/ensureRunning.ts'
+    )
+    const outcome = await ensureGatewayRunning()
+    if (!outcome.ok) {
+      console.log(
+        `\n  ${
+          t(
+            '⚠️  Running without the background service: {reason}',
+          ).replace('{reason}', () => outcome.reason)
+        }\n`,
+      )
+    } else {
+      gatewayBootstrap = { port: outcome.config.port, token: outcome.config.token }
+      if (outcome.bootstrapped) {
+        console.log(
+          `\n  ${
+            t(
+              '🌐 Background service is ready. You can now also connect SLV from a web browser later if you add one.',
+            )
+          }\n`,
+        )
+      }
+    }
+  }
+
+  if (gatewayBootstrap) {
+    // Swap in the WS-backed provider. SLV api key is still read
+    // because some code paths (authorization checks, token
+    // purchasing) reach for it.
+    if (config.provider === 'slv') {
+      const ctx = await loadAgentContext()
+      slvApiKey = ctx.raw.api.slv.api_key ?? ''
+    }
+    const { GatewaySessionProvider } = await import(
+      '/src/ai/core/sessionClient.ts'
+    )
+    provider = new GatewaySessionProvider(
+      `ws://127.0.0.1:${gatewayBootstrap.port}/v1/session/ws`,
+      gatewayBootstrap.token,
+      config.model,
+      currentSystemPrompt,
+      callbacks,
+    ) as unknown as SLVProvider // structurally compatible with the union
+  } else if (config.provider === 'openai') {
     provider = new OpenAIProvider(
       config.api_key,
       config.model,

--- a/cli/src/ai/core/sessionClient.ts
+++ b/cli/src/ai/core/sessionClient.ts
@@ -1,0 +1,183 @@
+import type { ChatCallbacks } from '/src/ai/console/consoleAction.ts'
+import { errToString } from '/lib/errToString.ts'
+
+/**
+ * Minimal WebSocket client that lets the TUI talk to a local
+ * gateway's `session.send` as if it were a direct provider.
+ *
+ * Implements the same 4-method shape existing providers expose
+ * (`constructor / setSystemPrompt / chat`) so `consoleAction.ts` can
+ * swap this in at the provider-init site with no further TUI
+ * changes. Under the hood it opens one WS per chat() turn (simple
+ * and stateless; connection reuse is a future optimisation).
+ *
+ * Translation from gateway events → existing ChatCallbacks:
+ *
+ *   - `text_delta` → accumulate and fire `onStream(fullText)` since
+ *     providers are contractually cumulative.
+ *   - `tool_use_start` → `onToolCall(name, argsJson)`.
+ *   - `complete` / `aborted` → `onComplete()` and resolve.
+ *   - `error` → resolve with an Error so the caller's catch fires.
+ *
+ * Notes for the Phase 2D-v1 surface:
+ *
+ *   - `systemPrompt` is accepted for API parity but NOT yet
+ *     forwarded (gateway's session.send doesn't thread it today —
+ *     tracked as a future enhancement).
+ *   - Tool use will surface as `onToolCall` but the gateway's
+ *     Session doesn't actually execute tools yet — that's Phase
+ *     2D-v2. Users who rely on tools today should stay off
+ *     `--via-gateway` until v2 lands.
+ */
+export class GatewaySessionProvider {
+  private systemPrompt: string
+  private callbacks: ChatCallbacks
+
+  constructor(
+    private wsUrl: string,
+    private token: string,
+    _model: string,
+    systemPrompt: string,
+    callbacks: ChatCallbacks,
+  ) {
+    this.systemPrompt = systemPrompt
+    this.callbacks = callbacks
+  }
+
+  setSystemPrompt(systemPrompt: string): void {
+    this.systemPrompt = systemPrompt
+  }
+
+  async chat(userMessage: string): Promise<void> {
+    // Open a fresh WS per turn. Simpler than keeping a long-lived
+    // connection, and robust against the gateway restarting —
+    // each turn reconnects.
+    const ws = new WebSocket(this.wsUrl)
+    const opened = new Promise<void>((resolve, reject) => {
+      const onErr = () => reject(new Error('could not connect to gateway'))
+      ws.addEventListener('open', () => resolve(), { once: true })
+      ws.addEventListener('error', onErr, { once: true })
+    })
+    try {
+      await opened
+    } catch (err) {
+      throw new Error(
+        `can't reach the SLV background service: ${errToString(err)}`,
+      )
+    }
+
+    const pending = new Map<
+      string,
+      (f: { ok: boolean; payload?: unknown; error?: string }) => void
+    >()
+    let nextId = 0
+    const call = (method: string, params?: unknown) =>
+      new Promise<{ ok: boolean; payload?: unknown; error?: string }>((res) => {
+        const id = `c${++nextId}`
+        pending.set(id, res)
+        ws.send(JSON.stringify({ kind: 'req', id, method, params }))
+      })
+
+    let accumulated = ''
+    let terminalResolve: (() => void) | null = null
+    let terminalReject: ((err: Error) => void) | null = null
+    const terminal = new Promise<void>((resolve, reject) => {
+      terminalResolve = resolve
+      terminalReject = reject
+    })
+
+    ws.addEventListener('message', (ev) => {
+      let f: {
+        kind: string
+        id?: string
+        ok?: boolean
+        payload?: unknown
+        error?: string
+        event?: string
+      }
+      try {
+        f = JSON.parse(String(ev.data))
+      } catch {
+        return
+      }
+      if (f.kind === 'res' && typeof f.id === 'string') {
+        const r = pending.get(f.id)
+        if (r) {
+          pending.delete(f.id)
+          r({ ok: !!f.ok, payload: f.payload, error: f.error })
+        }
+        return
+      }
+      if (f.kind !== 'event') return
+      const payload = f.payload as { type?: string } | undefined
+      switch (payload?.type) {
+        case 'text_delta': {
+          const delta = (payload as { text?: string }).text ?? ''
+          accumulated += delta
+          this.callbacks.onStream(accumulated)
+          break
+        }
+        case 'tool_use_start': {
+          const p = payload as { name?: string; args?: unknown }
+          const name = p.name ?? 'unknown'
+          const detail = typeof p.args === 'string'
+            ? p.args
+            : JSON.stringify(p.args ?? {})
+          this.callbacks.onToolCall(name, detail)
+          break
+        }
+        case 'complete':
+        case 'aborted':
+          this.callbacks.onComplete()
+          terminalResolve?.()
+          break
+        case 'error': {
+          const msg = (payload as { message?: string }).message ?? 'unknown error'
+          terminalReject?.(new Error(msg))
+          break
+        }
+      }
+    })
+
+    ws.addEventListener('close', () => {
+      // If close arrives before a terminal event, surface as an
+      // error so the TUI doesn't hang forever.
+      terminalReject?.(new Error('connection to SLV background service was lost'))
+    })
+
+    try {
+      const hello = await call('gateway.hello')
+      if (!hello.ok) throw new Error(`gateway rejected hello: ${hello.error}`)
+
+      const auth = await call('gateway.auth', { token: this.token })
+      if (!auth.ok) {
+        throw new Error(
+          `gateway rejected authentication — try deleting ~/.slv/gateway/gateway.json and rerunning`,
+        )
+      }
+
+      // Apply system prompt if we have one — the gateway ignores
+      // it today but this is where it'll land when wired.
+      if (this.systemPrompt) {
+        // params.systemPrompt is reserved for the future gateway
+        // upgrade; no-op today.
+      }
+
+      const sent = await call('session.send', { text: userMessage })
+      if (!sent.ok) throw new Error(sent.error ?? 'session.send rejected')
+
+      await terminal
+    } finally {
+      try {
+        ws.close()
+      } catch { /* ignore */ }
+    }
+  }
+
+  async abort(): Promise<void> {
+    // No-op for Phase 2D-v1: the per-turn WS client isn't persistent
+    // enough to route abort reliably. Ctrl+C still kills any child
+    // process via the TUI's existing handler. Session-level abort
+    // over WS arrives with connection reuse in Phase 2D-v2.
+  }
+}

--- a/cli/src/ai/index.ts
+++ b/cli/src/ai/index.ts
@@ -5,14 +5,32 @@ import { consoleAction } from '@/ai/console/consoleAction.ts'
 import { aiUsageAction } from '@/ai/usage/usageAction.ts'
 import { aiProductAction } from '@/ai/product/productAction.ts'
 
+// `-g / --via-gateway` opts the TUI into the new WebSocket-backed
+// client that talks to the local gateway daemon. Still experimental
+// (Phase 2D-v1) — tool calls aren't wired into gateway sessions
+// yet, so for now this is a text-chat dogfood mode. Kept as a flag
+// (not the default) to avoid regressing non-engineer users mid-
+// rollout. Will flip default once tool support + reconnect land.
+type ConsoleFlags = { viaGateway?: boolean }
+
 export const aiCmd = new Command()
   .description(colors.white('AI console and configuration'))
-  .action(async () => {
-    await consoleAction()
+  .option(
+    '-g, --via-gateway',
+    'Run the chat through the local SLV background service (experimental — text-only for now)',
+    { default: false },
+  )
+  .action(async (opts: ConsoleFlags) => {
+    await consoleAction({ viaGateway: opts.viaGateway })
   })
   .command('console', 'Start the AI chat console')
-  .action(async () => {
-    await consoleAction()
+  .option(
+    '-g, --via-gateway',
+    'Run the chat through the local SLV background service (experimental — text-only for now)',
+    { default: false },
+  )
+  .action(async (opts: ConsoleFlags) => {
+    await consoleAction({ viaGateway: opts.viaGateway })
   })
   .command('usage', 'Show AI token usage and remaining balance')
   .action(async () => {

--- a/cli/src/gateway/ensureRunning.ts
+++ b/cli/src/gateway/ensureRunning.ts
@@ -1,0 +1,143 @@
+import { colors } from '@cliffy/colors'
+import {
+  ensureGatewayConfig,
+  type GatewayConfig,
+} from '/src/gateway/config.ts'
+import { pickGatewayService } from '/src/gateway/service/pick.ts'
+import { installAction } from '/src/gateway/install.ts'
+import { errToString } from '/lib/errToString.ts'
+
+/**
+ * Make sure the local gateway daemon is up, starting it if needed.
+ *
+ * This is the "zero-config" entry point for any feature that needs
+ * the gateway — `slv c --via-gateway` today, future web UI launcher
+ * tomorrow. The chat is aimed at non-engineer users: they shouldn't
+ * need to know the daemon exists or understand the lifecycle
+ * commands. If it's not running, we just start it; if it's not
+ * installed, we install it first (as a per-user launchd/systemd
+ * service — no sudo needed).
+ *
+ * All user-visible messages avoid jargon. "systemd-user-unit" is a
+ * detail; "background service" is what lands.
+ */
+export type EnsureOutcome = {
+  ok: true
+  config: GatewayConfig
+  // True if this call started/installed the daemon (not merely
+  // confirmed it was already running). Callers can use this to
+  // show a one-time welcome message on the initial bootstrap.
+  bootstrapped: boolean
+} | { ok: false; reason: string }
+
+const probeHealthy = async (port: number): Promise<boolean> => {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/healthz`, {
+      signal: AbortSignal.timeout(1000),
+    })
+    const ok = res.ok
+    await res.body?.cancel()
+    return ok
+  } catch {
+    return false
+  }
+}
+
+const waitHealthy = async (
+  port: number,
+  timeoutMs = 10_000,
+): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await probeHealthy(port)) return true
+    await new Promise((r) => setTimeout(r, 200))
+  }
+  return false
+}
+
+export const ensureGatewayRunning = async (
+  opts: { quiet?: boolean } = {},
+): Promise<EnsureOutcome> => {
+  const say = (msg: string) => {
+    if (!opts.quiet) console.log(msg)
+  }
+
+  let config: GatewayConfig
+  try {
+    config = await ensureGatewayConfig()
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `couldn't read gateway config: ${errToString(err)}`,
+    }
+  }
+
+  // Happy path: already running. Most of the time this is what
+  // happens after the first launch.
+  if (await probeHealthy(config.port)) {
+    return { ok: true, config, bootstrapped: false }
+  }
+
+  // Not running. Pick the right service backend for the OS.
+  let service
+  try {
+    service = pickGatewayService()
+  } catch (err) {
+    return {
+      ok: false,
+      reason:
+        `automatic background service setup isn't supported on this platform. ` +
+        `${errToString(err)}`,
+    }
+  }
+
+  // Install if missing. The installAction handles all the
+  // plumbing (log files, plist/unit generation, enable) and is
+  // idempotent.
+  const status = await service.status().catch(() => ({
+    loaded: false,
+    running: false,
+    details: '',
+  }))
+  let bootstrapped = false
+  if (!status.loaded) {
+    say(
+      colors.cyan(
+        '🔧 First-time setup: registering the SLV background service...',
+      ),
+    )
+    bootstrapped = true
+    const installed = await installAction()
+    if (!installed) {
+      return {
+        ok: false,
+        reason: 'background service install failed (see messages above)',
+      }
+    }
+  }
+
+  // Start it if not already up.
+  if (!(await probeHealthy(config.port))) {
+    say(colors.cyan('🚀 Starting the SLV background service...'))
+    try {
+      await service.start()
+    } catch (err) {
+      return {
+        ok: false,
+        reason: `couldn't start the background service: ${errToString(err)}`,
+      }
+    }
+  }
+
+  // Wait for the daemon to actually accept connections. On cold
+  // start this can take a second or two while the port binds.
+  if (!(await waitHealthy(config.port))) {
+    return {
+      ok: false,
+      reason:
+        `the background service started but isn't responding on port ${config.port} yet`,
+    }
+  }
+
+  return { ok: true, config, bootstrapped }
+}


### PR DESCRIPTION
## Context

Stacks on Phase 2C (#307, merged). First TUI adapter that speaks WebSocket to the local gateway instead of constructing providers in-process.

**Shipped as OPT-IN (`slv c -g`)**, not a default change. Non-engineer users who don't touch the flag see zero difference. This lets us dogfood + iterate the daemon-backed flow while the provider loop + tool support still fall through to the in-process path.

## Non-engineer UX decisions

- **Zero manual setup.** Users don't need to know about `slv gateway install` / `start`. If the daemon isn't running when `-g` is passed, we install and start it automatically — no sudo required (per-user launchd on macOS, systemd --user on Linux).
- **Plain-English messages.** "🔧 First-time setup: registering the SLV background service..." — no systemd / launchd / plist jargon in user-facing strings.
- **Graceful fallback.** If the daemon can't start we print a yellow ⚠️ with the reason and fall back to the in-process provider so the chat still works.

## Verified end-to-end on Ubuntu 24.04 VPS

Starting from a clean slate on \`openclaw@84.32.103.177\` (no config, no service installed):

\`\`\`
$ slv c -g
🔧 First-time setup: registering the SLV background service...
⚙️  Installing systemd --user unit...
✅ gateway service installed and enabled
🚀 Starting the SLV background service...
🌐 Background service is ready. You can now also connect SLV
   from a web browser later if you add one.
(TUI launches; chat works via WS)
\`\`\`

After exit, \`slv gateway status\` confirms \`installed: yes / running: yes\`. The whole bootstrap → chat → teardown is one command for the user.

## Files

| File | Role |
|---|---|
| \`cli/src/gateway/ensureRunning.ts\` | \`ensureGatewayRunning()\` helper. Probe healthz → install if missing → start → wait-for-healthy. Returns \`{ok, config, bootstrapped}\`. |
| \`cli/src/ai/core/sessionClient.ts\` | \`GatewaySessionProvider\` — duck-types the existing provider shape (\`constructor / setSystemPrompt / chat\`) but under the hood: opens a WS per turn, runs hello → auth → session.send, accumulates \`text_delta\` into the cumulative \`onStream\` contract, translates \`tool_use_start\` → \`onToolCall\`, \`complete\`/\`aborted\` → \`onComplete\`, \`error\`/close → throws. |
| \`cli/src/ai/index.ts\` | Adds \`-g, --via-gateway\` flag to both \`slv c\` and \`slv c console\`. |
| \`cli/src/ai/console/consoleAction.ts\` | Accepts \`ConsoleOptions { viaGateway }\`. When set, bootstraps the daemon and swaps \`GatewaySessionProvider\` into the provider-init site. All other code paths unchanged — the TUI widget code doesn't know the provider's backend. |

## Known Phase 2D-v1 limitations

(Documented in help text so \`-g\` users understand the scope.)

- **Tool calls aren't wired into gateway sessions yet.** \`session.send\` runs providers without the tools module, so \`run_command\` / \`read_file\` etc. come back as unsupported in \`-g\` mode. Users who need tools should stay on the default path until Phase 2D-v2 lands.
- **No connection reuse.** One WS per turn; reconnect on each send. Robust against gateway restart but precludes cross-turn gateway state.
- **\`session.abort\` not wired through the one-shot WS client.** Ctrl+C still kills active children via the TUI's existing handler; mid-stream abort over WS arrives with connection reuse.

## Tests

No new automated tests in this PR. Phase 2A-2C cover all the moving parts below the TUI (94 passing). TUI-level integration would need a pi-tui harness, which is outside scope. Manual verification covered in the transcript above.

## Relation to #298

Phase 2D-v1 of Tier 3. Next: Phase 2D-v2 wires tools into the gateway session, enables connection reuse + abort, then flips the default after dogfooding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)