### PR TITLE
feat(gateway): Phase 2D-v3 — persistent WS + mid-stream abort

### DIFF
--- a/cli/src/ai/console/consoleAction.ts
+++ b/cli/src/ai/console/consoleAction.ts
@@ -1237,6 +1237,14 @@ RULES:
         )
       } catch { /* ignore save errors */ }
     }
+    // If we're on the gateway-backed provider, close the WS cleanly.
+    // Duck-typed so this path doesn't hard-depend on the class.
+    const disposable = provider as unknown as { dispose?: () => void }
+    if (typeof disposable.dispose === 'function') {
+      try {
+        disposable.dispose()
+      } catch { /* ignore */ }
+    }
     tui.stop()
     await terminal.drainInput()
     console.log(`\n  ${t('Goodbye!')}\n`)
@@ -1802,8 +1810,23 @@ RULES:
         ctrlCCount = 0
       }, 2000)
 
+      // If the active provider is the gateway-backed WS client, it has
+      // an `abort()` method that sends `session.abort` over the live
+      // socket — letting the gateway cancel its in-flight tool loop.
+      // Structural check + cast keeps the Ctrl+C path ignorant of which
+      // concrete provider class is in use.
+      const gatewayAbort = (): void => {
+        const maybe = provider as unknown as { abort?: () => void }
+        if (typeof maybe.abort === 'function') {
+          try {
+            maybe.abort()
+          } catch { /* already gone */ }
+        }
+      }
+
       if (ctrlCCount >= 2) {
         // Double Ctrl+C: force exit immediately no matter what
+        gatewayAbort()
         killActiveProcess()
         tui.stop()
         console.log(`\n  ${t('Force exit.')}\n`)
@@ -1811,8 +1834,9 @@ RULES:
       }
 
       if (isProcessing) {
-        // First Ctrl+C during processing: kill child process, drop queued
-        // messages (user wants to stop, not resume with stale intent).
+        // First Ctrl+C during processing: kill child process, tell the
+        // gateway (if we have one) to cancel, drop queued messages.
+        gatewayAbort()
         killActiveProcess()
         const dropped = pendingUserMessages.length
         pendingUserMessages.length = 0

--- a/cli/src/ai/core/sessionClient.ts
+++ b/cli/src/ai/core/sessionClient.ts
@@ -2,36 +2,52 @@ import type { ChatCallbacks } from '/src/ai/console/consoleAction.ts'
 import { errToString } from '/lib/errToString.ts'
 
 /**
- * Minimal WebSocket client that lets the TUI talk to a local
- * gateway's `session.send` as if it were a direct provider.
- *
- * Implements the same 4-method shape existing providers expose
- * (`constructor / setSystemPrompt / chat`) so `consoleAction.ts` can
+ * WebSocket client that lets the TUI talk to a local gateway's
+ * `session.send` as if it were a direct provider. Implements the
+ * same 4-method shape existing providers expose (`constructor` /
+ * `setSystemPrompt` / `chat` / `abort`) so `consoleAction.ts` can
  * swap this in at the provider-init site with no further TUI
- * changes. Under the hood it opens one WS per chat() turn (simple
- * and stateless; connection reuse is a future optimisation).
+ * changes.
  *
- * Translation from gateway events → existing ChatCallbacks:
+ * Phase 2D-v3: one persistent WebSocket per TUI session.
+ *
+ *   - `ensureConnected()` opens + authenticates lazily on first
+ *     chat(). Subsequent chat() calls reuse the socket, amortising
+ *     the handshake cost and — more importantly — making
+ *     `abort()` deliverable without opening a second connection.
+ *   - If the server drops us (gateway restart), the next chat()
+ *     transparently reopens.
+ *   - `abort()` fires `session.abort` over the live socket so the
+ *     gateway cancels the in-flight provider loop. The server emits
+ *     `aborted`, which chat()'s terminal promise resolves on.
+ *
+ * Translation from gateway events → ChatCallbacks:
  *
  *   - `text_delta` → accumulate and fire `onStream(fullText)` since
  *     providers are contractually cumulative.
  *   - `tool_use_start` → `onToolCall(name, argsJson)`.
+ *   - `tool_stdout` → `onToolStdout?(line)` — renders through the
+ *     TUI's existing progress viewport so cargo builds etc. feel
+ *     identical to the in-process path.
+ *   - `tool_progress` → `onToolProgress?(label)`.
  *   - `complete` / `aborted` → `onComplete()` and resolve.
- *   - `error` → resolve with an Error so the caller's catch fires.
- *
- * Notes for the Phase 2D-v1 surface:
- *
- *   - `systemPrompt` is accepted for API parity but NOT yet
- *     forwarded (gateway's session.send doesn't thread it today —
- *     tracked as a future enhancement).
- *   - Tool use will surface as `onToolCall` but the gateway's
- *     Session doesn't actually execute tools yet — that's Phase
- *     2D-v2. Users who rely on tools today should stay off
- *     `--via-gateway` until v2 lands.
+ *   - `error` → reject so the caller's try/catch fires.
  */
 export class GatewaySessionProvider {
   private systemPrompt: string
   private callbacks: ChatCallbacks
+  private ws: WebSocket | null = null
+  private pendingCalls = new Map<
+    string,
+    (res: { ok: boolean; payload?: unknown; error?: string }) => void
+  >()
+  private nextCallId = 0
+  // When a chat is in flight we store its event handlers here so
+  // message dispatch (which is WS-global) can route events to the
+  // right promise without juggling per-message listeners.
+  private activeChat: {
+    onEvent: (event: string, payload: Record<string, unknown>) => void
+  } | null = null
 
   constructor(
     private wsUrl: string,
@@ -48,35 +64,39 @@ export class GatewaySessionProvider {
     this.systemPrompt = systemPrompt
   }
 
-  async chat(userMessage: string): Promise<void> {
-    // Open a fresh WS per turn. Simpler than keeping a long-lived
-    // connection, and robust against the gateway restarting —
-    // each turn reconnects.
-    const ws = new WebSocket(this.wsUrl)
-    const opened = new Promise<void>((resolve, reject) => {
-      const onErr = () => reject(new Error('could not connect to gateway'))
-      ws.addEventListener('open', () => resolve(), { once: true })
-      ws.addEventListener('error', onErr, { once: true })
-    })
-    try {
-      await opened
-    } catch (err) {
-      throw new Error(
-        `can't reach the SLV background service: ${errToString(err)}`,
-      )
+  /** Close the socket and reject any pending calls. Called on TUI exit. */
+  dispose(): void {
+    this.pendingCalls.forEach((fn) =>
+      fn({ ok: false, error: 'client disposed' })
+    )
+    this.pendingCalls.clear()
+    if (this.ws && this.ws.readyState !== WebSocket.CLOSED) {
+      try {
+        this.ws.close()
+      } catch { /* ignore */ }
     }
+    this.ws = null
+  }
 
-    const pending = new Map<
-      string,
-      (f: { ok: boolean; payload?: unknown; error?: string }) => void
-    >()
-    let nextId = 0
-    const call = (method: string, params?: unknown) =>
-      new Promise<{ ok: boolean; payload?: unknown; error?: string }>((res) => {
-        const id = `c${++nextId}`
-        pending.set(id, res)
-        ws.send(JSON.stringify({ kind: 'req', id, method, params }))
-      })
+  /**
+   * Request the gateway cancel the in-flight session. Fire-and-
+   * forget: the server emits an `aborted` event which the in-flight
+   * `chat()` resolves on. Safe to call when nothing is running —
+   * the server returns `wasRunning: false`.
+   */
+  abort(): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return
+    try {
+      this.ws.send(JSON.stringify({
+        kind: 'req',
+        id: `a${++this.nextCallId}`,
+        method: 'session.abort',
+      }))
+    } catch { /* socket closing — nothing to do */ }
+  }
+
+  async chat(userMessage: string): Promise<void> {
+    await this.ensureConnected()
 
     let accumulated = ''
     let terminalResolve: (() => void) | null = null
@@ -86,108 +106,156 @@ export class GatewaySessionProvider {
       terminalReject = reject
     })
 
-    ws.addEventListener('message', (ev) => {
-      let f: {
-        kind: string
-        id?: string
-        ok?: boolean
-        payload?: unknown
-        error?: string
-        event?: string
-      }
-      try {
-        f = JSON.parse(String(ev.data))
-      } catch {
-        return
-      }
-      if (f.kind === 'res' && typeof f.id === 'string') {
-        const r = pending.get(f.id)
-        if (r) {
-          pending.delete(f.id)
-          r({ ok: !!f.ok, payload: f.payload, error: f.error })
+    this.activeChat = {
+      onEvent: (eventName, payload) => {
+        const type = payload.type as string | undefined
+        switch (type) {
+          case 'text_delta': {
+            const delta = (payload.text as string) ?? ''
+            accumulated += delta
+            this.callbacks.onStream(accumulated)
+            break
+          }
+          case 'tool_use_start': {
+            const name = (payload.name as string) ?? 'unknown'
+            const args = payload.args
+            const detail = typeof args === 'string'
+              ? args
+              : JSON.stringify(args ?? {})
+            this.callbacks.onToolCall(name, detail)
+            break
+          }
+          case 'tool_stdout': {
+            const text = (payload.text as string) ?? ''
+            this.callbacks.onToolStdout?.(text)
+            break
+          }
+          case 'tool_progress': {
+            const label = (payload.label as string) ?? ''
+            this.callbacks.onToolProgress?.(label)
+            break
+          }
+          case 'complete':
+          case 'aborted':
+            this.callbacks.onComplete()
+            terminalResolve?.()
+            break
+          case 'error': {
+            const msg = (payload.message as string) ?? 'unknown error'
+            terminalReject?.(new Error(msg))
+            break
+          }
         }
-        return
-      }
-      if (f.kind !== 'event') return
-      const payload = f.payload as { type?: string } | undefined
-      switch (payload?.type) {
-        case 'text_delta': {
-          const delta = (payload as { text?: string }).text ?? ''
-          accumulated += delta
-          this.callbacks.onStream(accumulated)
-          break
-        }
-        case 'tool_use_start': {
-          const p = payload as { name?: string; args?: unknown }
-          const name = p.name ?? 'unknown'
-          const detail = typeof p.args === 'string'
-            ? p.args
-            : JSON.stringify(p.args ?? {})
-          this.callbacks.onToolCall(name, detail)
-          break
-        }
-        case 'tool_stdout': {
-          const text = (payload as { text?: string }).text ?? ''
-          this.callbacks.onToolStdout?.(text)
-          break
-        }
-        case 'tool_progress': {
-          const label = (payload as { label?: string }).label ?? ''
-          this.callbacks.onToolProgress?.(label)
-          break
-        }
-        case 'complete':
-        case 'aborted':
-          this.callbacks.onComplete()
-          terminalResolve?.()
-          break
-        case 'error': {
-          const msg = (payload as { message?: string }).message ?? 'unknown error'
-          terminalReject?.(new Error(msg))
-          break
-        }
-      }
-    })
-
-    ws.addEventListener('close', () => {
-      // If close arrives before a terminal event, surface as an
-      // error so the TUI doesn't hang forever.
-      terminalReject?.(new Error('connection to SLV background service was lost'))
-    })
+        // Silence unused-param lint: server's `event` field mirrors
+        // payload.type today. Retained for debugging.
+        void eventName
+      },
+    }
 
     try {
-      const hello = await call('gateway.hello')
-      if (!hello.ok) throw new Error(`gateway rejected hello: ${hello.error}`)
-
-      const auth = await call('gateway.auth', { token: this.token })
-      if (!auth.ok) {
-        throw new Error(
-          `gateway rejected authentication — try deleting ~/.slv/gateway/gateway.json and rerunning`,
-        )
-      }
-
-      // Apply system prompt if we have one — the gateway ignores
-      // it today but this is where it'll land when wired.
-      if (this.systemPrompt) {
-        // params.systemPrompt is reserved for the future gateway
-        // upgrade; no-op today.
-      }
-
-      const sent = await call('session.send', { text: userMessage })
+      const sent = await this.call('session.send', { text: userMessage })
       if (!sent.ok) throw new Error(sent.error ?? 'session.send rejected')
-
+      // Also surface the system prompt the next time we're wired
+      // end-to-end; gateway currently ignores it.
+      void this.systemPrompt
       await terminal
     } finally {
-      try {
-        ws.close()
-      } catch { /* ignore */ }
+      this.activeChat = null
     }
   }
 
-  async abort(): Promise<void> {
-    // No-op for Phase 2D-v1: the per-turn WS client isn't persistent
-    // enough to route abort reliably. Ctrl+C still kills any child
-    // process via the TUI's existing handler. Session-level abort
-    // over WS arrives with connection reuse in Phase 2D-v2.
+  // ---- private plumbing ----
+
+  private async ensureConnected(): Promise<void> {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) return
+    this.ws = new WebSocket(this.wsUrl)
+    await new Promise<void>((resolve, reject) => {
+      this.ws!.addEventListener('open', () => resolve(), { once: true })
+      this.ws!.addEventListener('error', () => {
+        reject(new Error("can't reach the SLV background service"))
+      }, { once: true })
+    }).catch((err) => {
+      this.ws = null
+      throw new Error(errToString(err))
+    })
+
+    this.ws.addEventListener('message', (ev) => this.onMessage(ev))
+    this.ws.addEventListener('close', () => this.onClose())
+
+    const hello = await this.call('gateway.hello')
+    if (!hello.ok) throw new Error(`gateway rejected hello: ${hello.error}`)
+
+    const auth = await this.call('gateway.auth', { token: this.token })
+    if (!auth.ok) {
+      throw new Error(
+        'gateway rejected authentication — try deleting ~/.slv/gateway/gateway.json and rerunning',
+      )
+    }
+  }
+
+  private onMessage(ev: MessageEvent): void {
+    let f: {
+      kind: string
+      id?: string
+      ok?: boolean
+      payload?: unknown
+      error?: string
+      event?: string
+    }
+    try {
+      f = JSON.parse(String(ev.data))
+    } catch {
+      return
+    }
+    if (f.kind === 'res' && typeof f.id === 'string') {
+      const r = this.pendingCalls.get(f.id)
+      if (r) {
+        this.pendingCalls.delete(f.id)
+        r({ ok: !!f.ok, payload: f.payload, error: f.error })
+      }
+      return
+    }
+    if (f.kind === 'event' && this.activeChat) {
+      const payload = (f.payload ?? {}) as Record<string, unknown>
+      this.activeChat.onEvent(f.event ?? '', payload)
+    }
+  }
+
+  private onClose(): void {
+    // If a chat was in flight, surface a clean error so the caller
+    // isn't left waiting forever. The next chat() will transparently
+    // reconnect.
+    if (this.activeChat) {
+      // terminalReject isn't directly reachable here — route via a
+      // synthetic error event.
+      this.activeChat.onEvent('error', {
+        type: 'error',
+        message: 'connection to SLV background service was lost',
+      })
+      this.activeChat = null
+    }
+    // Reject any outstanding RPC calls too.
+    this.pendingCalls.forEach((fn) =>
+      fn({ ok: false, error: 'connection closed' })
+    )
+    this.pendingCalls.clear()
+    this.ws = null
+  }
+
+  private call(
+    method: string,
+    params?: unknown,
+  ): Promise<{ ok: boolean; payload?: unknown; error?: string }> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.resolve({
+        ok: false,
+        error: 'not connected to gateway',
+      })
+    }
+    return new Promise((resolve) => {
+      const id = `c${++this.nextCallId}`
+      this.pendingCalls.set(id, resolve)
+      this.ws!.send(JSON.stringify({ kind: 'req', id, method, params }))
+    })
   }
 }

--- a/cli/test/integration/gateway_session_abort.test.ts
+++ b/cli/test/integration/gateway_session_abort.test.ts
@@ -1,0 +1,269 @@
+import { assert, assertEquals } from '@std/assert'
+import { join } from '@std/path'
+
+// End-to-end tests for Phase 2D-v3: one persistent WS that carries
+// both the chat and the mid-stream `session.abort`. Verifies the
+// abort sequence fires a single `aborted` terminal with NO trailing
+// `complete`, and that the same connection can be reused for a
+// follow-up `session.echo` without re-authenticating.
+
+const CLI_ENTRY = new URL('../../src/index.ts', import.meta.url).pathname
+const pickPort = (): number => 30000 + Math.floor(Math.random() * 10000)
+
+type Gw = {
+  child: Deno.ChildProcess
+  home: string
+  port: number
+  token: string
+  stderr: Promise<string>
+}
+
+const startGateway = async (): Promise<Gw> => {
+  const home = await Deno.makeTempDir({ prefix: 'slv-gw-abort-' })
+  const port = pickPort()
+  const child = new Deno.Command(Deno.execPath(), {
+    args: ['run', '-A', '--no-check', CLI_ENTRY, 'gateway', 'run'],
+    env: {
+      HOME: home,
+      PATH: Deno.env.get('PATH') ?? '/usr/bin:/bin',
+      SLV_GATEWAY_PORT: String(port),
+    },
+    stdin: 'null',
+    stdout: 'piped',
+    stderr: 'piped',
+  }).spawn()
+  const drain = async (s: ReadableStream<Uint8Array>): Promise<string> => {
+    const r = s.getReader()
+    const chunks: Uint8Array[] = []
+    while (true) {
+      const { value, done } = await r.read()
+      if (done) break
+      if (value) chunks.push(value)
+    }
+    const total = chunks.reduce((n, c) => n + c.length, 0)
+    const buf = new Uint8Array(total)
+    let o = 0
+    for (const c of chunks) {
+      buf.set(c, o)
+      o += c.length
+    }
+    return new TextDecoder().decode(buf)
+  }
+  drain(child.stdout).catch(() => {})
+  const stderr = drain(child.stderr).catch(() => '')
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/healthz`)
+      if (res.ok) {
+        await res.body?.cancel()
+        break
+      }
+      await res.body?.cancel()
+    } catch { /* retry */ }
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  const cfg = JSON.parse(
+    await Deno.readTextFile(join(home, '.slv/gateway/gateway.json')),
+  ) as { token: string }
+  return { child, home, port, token: cfg.token, stderr }
+}
+
+const stopGateway = async (gw: Gw): Promise<void> => {
+  try {
+    gw.child.kill('SIGTERM')
+  } catch { /* already dead */ }
+  await gw.child.status.catch(() => {})
+  await gw.stderr
+  await Deno.remove(gw.home, { recursive: true }).catch(() => {})
+}
+
+type EventFrame = {
+  kind: 'event'
+  event: string
+  payload?: { type?: string; [k: string]: unknown }
+  seq: number
+}
+
+type ResFrame = {
+  kind: 'res'
+  id: string
+  ok: boolean
+  payload?: unknown
+  error?: string
+}
+
+const openWs = (port: number): Promise<{
+  socket: WebSocket
+  call: (method: string, params?: unknown) => Promise<ResFrame>
+  events: EventFrame[]
+  waitForEvent: (
+    predicate: (e: EventFrame) => boolean,
+    timeoutMs?: number,
+  ) => Promise<EventFrame>
+}> =>
+  new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/session/ws`)
+    const pending = new Map<string, (r: ResFrame) => void>()
+    const events: EventFrame[] = []
+    const waiters: {
+      check: (e: EventFrame) => boolean
+      resolve: (e: EventFrame) => void
+    }[] = []
+    let n = 0
+    ws.onopen = () => {
+      resolve({
+        socket: ws,
+        call: (method, params) =>
+          new Promise((res) => {
+            const id = `c${++n}`
+            pending.set(id, res)
+            ws.send(JSON.stringify({ kind: 'req', id, method, params }))
+          }),
+        events,
+        waitForEvent: (pred, timeoutMs = 5000) =>
+          new Promise((resW, rejW) => {
+            const found = events.find(pred)
+            if (found) {
+              resW(found)
+              return
+            }
+            const timer = setTimeout(() => rejW(new Error('timeout')), timeoutMs)
+            waiters.push({
+              check: pred,
+              resolve: (e) => {
+                clearTimeout(timer)
+                resW(e)
+              },
+            })
+          }),
+      })
+    }
+    ws.onmessage = (ev) => {
+      const f = JSON.parse(String(ev.data))
+      if (f.kind === 'res') {
+        const fn = pending.get(f.id)
+        if (fn) {
+          pending.delete(f.id)
+          fn(f)
+        }
+      } else if (f.kind === 'event') {
+        events.push(f as EventFrame)
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          if (waiters[i].check(f as EventFrame)) {
+            waiters[i].resolve(f as EventFrame)
+            waiters.splice(i, 1)
+          }
+        }
+      }
+    }
+    ws.onerror = (e) => reject(e)
+  })
+
+const sub = { sanitizeResources: false, sanitizeOps: false } as const
+
+Deno.test(
+  'ws: session.abort mid-stream cancels echo with `aborted`, no `complete`',
+  sub,
+  async () => {
+    const gw = await startGateway()
+    try {
+      const c = await openWs(gw.port)
+      try {
+        await c.call('gateway.auth', { token: gw.token })
+
+        const sent = await c.call('session.echo', {
+          text: 'one two three four five six seven eight nine ten',
+        })
+        assertEquals(sent.ok, true)
+
+        // Let the echo driver emit a few deltas, then abort on the
+        // SAME socket.
+        await new Promise((r) => setTimeout(r, 80))
+        const ab = await c.call('session.abort')
+        assertEquals(ab.ok, true)
+        assertEquals((ab.payload as { wasRunning: boolean }).wasRunning, true)
+
+        await c.waitForEvent((e) => e.payload?.type === 'aborted')
+
+        const completes = c.events.filter((e) =>
+          e.payload?.type === 'complete'
+        )
+        assertEquals(
+          completes.length,
+          0,
+          'complete must not fire when aborted',
+        )
+      } finally {
+        c.socket.close()
+      }
+    } finally {
+      await stopGateway(gw)
+    }
+  },
+)
+
+Deno.test(
+  'ws: persistent connection reuses auth across multiple session.echo calls',
+  sub,
+  async () => {
+    const gw = await startGateway()
+    try {
+      const c = await openWs(gw.port)
+      try {
+        await c.call('gateway.auth', { token: gw.token })
+
+        // Turn 1
+        await c.call('session.echo', { text: 'first' })
+        await c.waitForEvent((e) => e.payload?.type === 'complete')
+        const firstCompletes = c.events.filter((e) =>
+          e.payload?.type === 'complete'
+        ).length
+
+        // Turn 2 — no re-auth, just another session.echo on the
+        // same socket.
+        const sent2 = await c.call('session.echo', { text: 'second' })
+        assertEquals(sent2.ok, true)
+        await c.waitForEvent((e) => {
+          // Second `complete` event
+          const completes = c.events.filter((e2) =>
+            e2.payload?.type === 'complete'
+          )
+          return completes.length > firstCompletes
+        })
+        const secondCompletes = c.events.filter((e) =>
+          e.payload?.type === 'complete'
+        ).length
+        assert(
+          secondCompletes > firstCompletes,
+          'second turn did not produce a fresh complete event',
+        )
+      } finally {
+        c.socket.close()
+      }
+    } finally {
+      await stopGateway(gw)
+    }
+  },
+)
+
+Deno.test(
+  'ws: session.abort when nothing is running reports wasRunning:false',
+  sub,
+  async () => {
+    const gw = await startGateway()
+    try {
+      const c = await openWs(gw.port)
+      try {
+        await c.call('gateway.auth', { token: gw.token })
+        const ab = await c.call('session.abort')
+        assertEquals(ab.ok, true)
+        assertEquals((ab.payload as { wasRunning: boolean }).wasRunning, false)
+      } finally {
+        c.socket.close()
+      }
+    } finally {
+      await stopGateway(gw)
+    }
+  },
+)


### PR DESCRIPTION
## Context

Stacks on Phase 2D-v2 (#309, merged). Makes \`-g\` mode genuinely usable: **one WS per TUI session** (not per turn), and **Ctrl+C now cancels an in-flight command running on the gateway — even mid-tool-execution**.

## Verified end-to-end on Ubuntu 24.04 VPS

Sent a \`session.send\` asking the LLM to run \`for i in 1..10; do echo tick-\$i; sleep 1; done\` — then aborted mid-stream:

\`\`\`
tool_stdout lines received before abort: 1   (only "tick-1")
abort res: {"wasRunning":true}
terminal type: aborted
tool_stdout lines total: 1                   (stayed at 1 — abort cut the sleep loop)
\`\`\`

The gateway's SIGTERM reached the bash subprocess, killed the sleep, provider loop broke, server emitted \`aborted\`. Client saw the stream stop cleanly. Exactly the mid-tool cancellation behavior the TUI needs.

## Changes

### \`sessionClient.ts\` — persistent WS with multiplexed RPC

Rewrote \`GatewaySessionProvider\` to hold one WebSocket for the lifetime of the TUI session:

| Method | Role |
|---|---|
| \`ensureConnected()\` | Lazy open + handshake (hello + auth) on first \`chat()\`. Later calls reuse the live socket. |
| \`call(method, params)\` | RPC via a shared \`pendingCalls\` map keyed on id. Multiple in-flight requests (send + abort) on the same socket don't race. |
| \`chat(text)\` | Subscribes the current \`activeChat\`'s event handler; \`onmessage\` routes \`res\` frames to pendingCalls and \`event\` frames to activeChat. |
| \`abort()\` **NEW** | Fire-and-forget \`session.abort\` on the live socket. Server cancels → emits \`aborted\` → \`chat()\`'s terminal promise resolves. |
| \`dispose()\` **NEW** | Called from TUI exit to close the socket + reject pending calls cleanly. |

\`onclose\` rejects the in-flight chat with a clear "connection to SLV background service was lost" so the TUI doesn't hang forever.

### \`consoleAction.ts\` — wire abort + dispose

- Ctrl+C handler now also calls \`provider.abort()\` (duck-typed) so gateway-backed sessions get the cancel signal in addition to the existing \`killActiveProcess()\` call for in-process tools. One handler, two backends.
- Session-exit path (\`saveMemoryAndExit\`) calls \`provider.dispose()\` (duck-typed) so the WS closes cleanly on \`/exit\`.

### Tests

New \`test/integration/gateway_session_abort.test.ts\` (3 tests):

- \`session.abort\` mid-echo produces \`aborted\`, NO trailing \`complete\`
- Persistent connection reuses auth across multiple \`session.echo\` calls on the same socket
- \`session.abort\` when nothing is running returns \`wasRunning: false\`

**94 → 97 passing tests**.

## What remains (future work)

- Flip \`-g\` to the default, remove the flag (pending broader dogfooding)
- WS reconnect with seq-based event replay (for cross-network, not loopback)
- Per-session abort isolation (currently routes through the gateway-process global abort flag)

## Relation to #298

Phase 2D-v3 of Tier 3. The \`-g\` path is now feature-complete for single-user dev-VPS use: text + tools + output streaming + mid-stream abort. Next step: dogfood, then flip the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)