### PR TITLE
feat(gateway): UI polish — i18n, history, reconnect, thinking, agent context (was #313)

### DIFF
--- a/cli/src/ai/i18n/index.ts
+++ b/cli/src/ai/i18n/index.ts
@@ -18,6 +18,12 @@ export const BUILTIN_LANGS: Record<string, Record<string, string>> = {
 let loaded: Record<string, string> = en
 let currentLang = 'en'
 let initialized = false
+// Cache the in-flight init promise, not just the post-init bool.
+// Without this, concurrent callers during first startup (e.g. the
+// gateway's /ui/ handler serving several requests while
+// `translateViaSlvAi` is still running for a custom language) would
+// each fall through to the init path and race on global state.
+let initPromise: Promise<void> | null = null
 
 const cachePath = (lang: string): string => {
   const home = Deno.env.get('HOME') || ''
@@ -115,30 +121,34 @@ const translateViaSlvAi = async (
   }
 }
 
-export const initI18n = async (): Promise<void> => {
-  currentLang = await readLang()
-  if (BUILTIN_LANGS[currentLang]) {
-    loaded = BUILTIN_LANGS[currentLang]
+export const initI18n = (): Promise<void> => {
+  if (initPromise) return initPromise
+  initPromise = (async () => {
+    currentLang = await readLang()
+    if (BUILTIN_LANGS[currentLang]) {
+      loaded = BUILTIN_LANGS[currentLang]
+      initialized = true
+      return
+    }
+    // Non-builtin: try cache, then AI translation, else fall back to English.
+    const cached = await loadCache(currentLang)
+    if (cached) {
+      loaded = { ...en, ...cached }
+      initialized = true
+      return
+    }
+    const translated = await translateViaSlvAi(currentLang, en)
+    if (translated) {
+      await saveCache(currentLang, translated).catch(() => {})
+      loaded = translated
+      initialized = true
+      return
+    }
+    // Fallback: English.
+    loaded = en
     initialized = true
-    return
-  }
-  // Non-builtin: try cache, then AI translation, else fall back to English.
-  const cached = await loadCache(currentLang)
-  if (cached) {
-    loaded = { ...en, ...cached }
-    initialized = true
-    return
-  }
-  const translated = await translateViaSlvAi(currentLang, en)
-  if (translated) {
-    await saveCache(currentLang, translated).catch(() => {})
-    loaded = translated
-    initialized = true
-    return
-  }
-  // Fallback: English.
-  loaded = en
-  initialized = true
+  })()
+  return initPromise
 }
 
 export const t = (key: string): string => {

--- a/cli/src/ai/i18n/messages/en.ts
+++ b/cli/src/ai/i18n/messages/en.ts
@@ -255,4 +255,31 @@ export const messages: Record<string, string> = {
   'Force exit.': 'Force exit.',
   '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
     '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.',
+
+  // --- Gateway browser chat UI ---
+  'Send': 'Send',
+  'Stop': 'Stop',
+  'clear': 'clear',
+  'Connect': 'Connect',
+  'Clear chat history': 'Clear chat history',
+  'Paste your gateway token': 'Paste your gateway token',
+  "This browser is reaching the SLV gateway from a different host. Paste the gateway token value (found in ~/.slv/gateway/gateway.json on the gateway host) to continue. It's saved in your browser's localStorage.":
+    "This browser is reaching the SLV gateway from a different host. Paste the gateway token value (found in ~/.slv/gateway/gateway.json on the gateway host) to continue. It's saved in your browser's localStorage.",
+  'Type a message and press Enter': 'Type a message and press Enter',
+  '64 hex characters': '64 hex characters',
+  'You': 'You',
+  'Assistant': 'Assistant',
+  'Thinking…': 'Thinking…',
+  'connecting…': 'connecting…',
+  'reconnecting…': 'reconnecting…',
+  'reconnecting in {secs}s…': 'reconnecting in {secs}s…',
+  'connected': 'connected',
+  'disconnected': 'disconnected',
+  'connection error': 'connection error',
+  'token required': 'token required',
+  'handshake failed': 'handshake failed',
+  'auth failed — check token': 'auth failed — check token',
+  '⏸ aborted': '⏸ aborted',
+  '❌ error': '❌ error',
+  '[disconnected — reply interrupted]': '[disconnected — reply interrupted]',
 }

--- a/cli/src/ai/i18n/messages/ja.ts
+++ b/cli/src/ai/i18n/messages/ja.ts
@@ -232,4 +232,31 @@ export const messages: Record<string, string> = {
   'Force exit.': '強制終了します。',
   '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
     '⚠️ 中断しました。もう一度 Ctrl+C で終了、またはメッセージを入力してください。',
+
+  // --- ゲートウェイのブラウザチャット UI ---
+  'Send': '送信',
+  'Stop': '停止',
+  'clear': 'クリア',
+  'Connect': '接続',
+  'Clear chat history': 'チャット履歴を消去',
+  'Paste your gateway token': 'ゲートウェイトークンを貼り付けてください',
+  "This browser is reaching the SLV gateway from a different host. Paste the gateway token value (found in ~/.slv/gateway/gateway.json on the gateway host) to continue. It's saved in your browser's localStorage.":
+    'このブラウザは別ホストから SLV ゲートウェイへアクセスしています。ゲートウェイホストの ~/.slv/gateway/gateway.json にある token の値を貼り付けて続行してください。ブラウザの localStorage に保存されます。',
+  'Type a message and press Enter': 'メッセージを入力して Enter で送信',
+  '64 hex characters': '64 文字の 16 進数',
+  'You': 'あなた',
+  'Assistant': 'アシスタント',
+  'Thinking…': '考えています…',
+  'connecting…': '接続中…',
+  'reconnecting…': '再接続中…',
+  'reconnecting in {secs}s…': '{secs} 秒後に再接続…',
+  'connected': '接続済み',
+  'disconnected': '切断されました',
+  'connection error': '接続エラー',
+  'token required': 'トークンが必要です',
+  'handshake failed': 'ハンドシェイクに失敗しました',
+  'auth failed — check token': '認証失敗 — トークンを確認してください',
+  '⏸ aborted': '⏸ 中断',
+  '❌ error': '❌ エラー',
+  '[disconnected — reply interrupted]': '[切断されました — 応答が中断されました]',
 }

--- a/cli/src/ai/i18n/messages/ru.ts
+++ b/cli/src/ai/i18n/messages/ru.ts
@@ -242,4 +242,31 @@ export const messages: Record<string, string> = {
   'Force exit.': 'Принудительный выход.',
   '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
     '⚠️ Прервано. Нажмите Ctrl+C ещё раз для выхода или введите сообщение.',
+
+  // --- Браузерный чат шлюза ---
+  'Send': 'Отправить',
+  'Stop': 'Стоп',
+  'clear': 'очистить',
+  'Connect': 'Подключиться',
+  'Clear chat history': 'Очистить историю чата',
+  'Paste your gateway token': 'Вставьте токен шлюза',
+  "This browser is reaching the SLV gateway from a different host. Paste the gateway token value (found in ~/.slv/gateway/gateway.json on the gateway host) to continue. It's saved in your browser's localStorage.":
+    'Этот браузер подключается к шлюзу SLV с другого хоста. Вставьте значение token из ~/.slv/gateway/gateway.json на хосте шлюза, чтобы продолжить. Сохраняется в localStorage браузера.',
+  'Type a message and press Enter': 'Введите сообщение и нажмите Enter',
+  '64 hex characters': '64 шестнадцатеричных символа',
+  'You': 'Вы',
+  'Assistant': 'Ассистент',
+  'Thinking…': 'Думаю…',
+  'connecting…': 'подключение…',
+  'reconnecting…': 'переподключение…',
+  'reconnecting in {secs}s…': 'переподключение через {secs} с…',
+  'connected': 'подключено',
+  'disconnected': 'отключено',
+  'connection error': 'ошибка соединения',
+  'token required': 'требуется токен',
+  'handshake failed': 'сбой рукопожатия',
+  'auth failed — check token': 'ошибка авторизации — проверьте токен',
+  '⏸ aborted': '⏸ прервано',
+  '❌ error': '❌ ошибка',
+  '[disconnected — reply interrupted]': '[отключено — ответ прерван]',
 }

--- a/cli/src/ai/i18n/messages/vi.ts
+++ b/cli/src/ai/i18n/messages/vi.ts
@@ -239,4 +239,31 @@ export const messages: Record<string, string> = {
   'Force exit.': 'Thoát bắt buộc.',
   '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
     '⚠️ Đã ngắt. Nhấn Ctrl+C lần nữa để thoát, hoặc nhập tin nhắn.',
+
+  // --- Giao diện chat trình duyệt của cổng ---
+  'Send': 'Gửi',
+  'Stop': 'Dừng',
+  'clear': 'xóa',
+  'Connect': 'Kết nối',
+  'Clear chat history': 'Xóa lịch sử trò chuyện',
+  'Paste your gateway token': 'Dán token cổng',
+  "This browser is reaching the SLV gateway from a different host. Paste the gateway token value (found in ~/.slv/gateway/gateway.json on the gateway host) to continue. It's saved in your browser's localStorage.":
+    'Trình duyệt này đang truy cập cổng SLV từ host khác. Dán giá trị token trong ~/.slv/gateway/gateway.json trên host cổng để tiếp tục. Sẽ được lưu trong localStorage của trình duyệt.',
+  'Type a message and press Enter': 'Nhập tin nhắn và nhấn Enter',
+  '64 hex characters': '64 ký tự hex',
+  'You': 'Bạn',
+  'Assistant': 'Trợ lý',
+  'Thinking…': 'Đang suy nghĩ…',
+  'connecting…': 'đang kết nối…',
+  'reconnecting…': 'đang kết nối lại…',
+  'reconnecting in {secs}s…': 'kết nối lại sau {secs} giây…',
+  'connected': 'đã kết nối',
+  'disconnected': 'đã ngắt kết nối',
+  'connection error': 'lỗi kết nối',
+  'token required': 'cần token',
+  'handshake failed': 'bắt tay thất bại',
+  'auth failed — check token': 'xác thực thất bại — kiểm tra token',
+  '⏸ aborted': '⏸ đã hủy',
+  '❌ error': '❌ lỗi',
+  '[disconnected — reply interrupted]': '[đã ngắt kết nối — phản hồi bị gián đoạn]',
 }

--- a/cli/src/ai/i18n/messages/zh.ts
+++ b/cli/src/ai/i18n/messages/zh.ts
@@ -224,4 +224,31 @@ export const messages: Record<string, string> = {
   'Force exit.': '强制退出。',
   '⚠️ Interrupted. Press Ctrl+C again to exit, or type a message.':
     '⚠️ 已中断。再次按 Ctrl+C 退出，或输入消息。',
+
+  // --- 网关浏览器聊天界面 ---
+  'Send': '发送',
+  'Stop': '停止',
+  'clear': '清除',
+  'Connect': '连接',
+  'Clear chat history': '清除聊天记录',
+  'Paste your gateway token': '粘贴网关令牌',
+  "This browser is reaching the SLV gateway from a different host. Paste the gateway token value (found in ~/.slv/gateway/gateway.json on the gateway host) to continue. It's saved in your browser's localStorage.":
+    '此浏览器正从其他主机访问 SLV 网关。请粘贴网关主机上 ~/.slv/gateway/gateway.json 中的 token 值以继续。将保存在浏览器的 localStorage 中。',
+  'Type a message and press Enter': '输入消息并按 Enter 发送',
+  '64 hex characters': '64 个十六进制字符',
+  'You': '你',
+  'Assistant': '助手',
+  'Thinking…': '思考中…',
+  'connecting…': '连接中…',
+  'reconnecting…': '重连中…',
+  'reconnecting in {secs}s…': '{secs} 秒后重连…',
+  'connected': '已连接',
+  'disconnected': '已断开',
+  'connection error': '连接错误',
+  'token required': '需要令牌',
+  'handshake failed': '握手失败',
+  'auth failed — check token': '认证失败 — 请检查令牌',
+  '⏸ aborted': '⏸ 已中止',
+  '❌ error': '❌ 错误',
+  '[disconnected — reply interrupted]': '[已断开 — 回复被中断]',
 }

--- a/cli/src/gateway/runForeground.ts
+++ b/cli/src/gateway/runForeground.ts
@@ -160,12 +160,20 @@ export const runGatewayForeground = async (): Promise<number> => {
   // but an attacker with network access to the bound port can
   // already try every other endpoint anyway.
   const uiHandler = async (c: Context) => {
-    return c.html(
-      await renderChatHtml({
-        token: isLoopbackHost(c.req.header('host')) ? config.token : null,
-        mode: config.mode,
-      }),
-    )
+    try {
+      return c.html(
+        await renderChatHtml({
+          token: isLoopbackHost(c.req.header('host')) ? config.token : null,
+          mode: config.mode,
+        }),
+      )
+    } catch (err) {
+      console.error(colors.red(`/ui/ render failed: ${errToString(err)}`))
+      return c.text(
+        'SLV gateway: /ui/ is temporarily unavailable. Check the gateway logs.',
+        500,
+      )
+    }
   }
   app.get('/ui', uiHandler)
   app.get('/ui/', uiHandler)

--- a/cli/src/gateway/runForeground.ts
+++ b/cli/src/gateway/runForeground.ts
@@ -159,9 +159,9 @@ export const runGatewayForeground = async (): Promise<number> => {
   // `localhost`. Not bulletproof against a forged Host header,
   // but an attacker with network access to the bound port can
   // already try every other endpoint anyway.
-  const uiHandler = (c: Context) => {
+  const uiHandler = async (c: Context) => {
     return c.html(
-      renderChatHtml({
+      await renderChatHtml({
         token: isLoopbackHost(c.req.header('host')) ? config.token : null,
         mode: config.mode,
       }),

--- a/cli/src/gateway/ui/static.ts
+++ b/cli/src/gateway/ui/static.ts
@@ -31,7 +31,8 @@ export const renderChatHtml = (opts: RenderOptions): string => {
 <html lang="en">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+<meta name="theme-color" content="#0b0f14" />
 <title>SLV Chat</title>
 <style>
   :root {
@@ -45,6 +46,7 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     --tool: #d29922;
     --error: #f85149;
     --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
   }
   * { box-sizing: border-box; }
   html, body {
@@ -53,11 +55,13 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     background: var(--bg);
     color: var(--text);
     font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, sans-serif;
+    -webkit-text-size-adjust: 100%;
   }
   body { display: flex; flex-direction: column; }
   header {
     flex: 0 0 auto;
     padding: 10px 14px;
+    padding-top: calc(10px + env(safe-area-inset-top, 0px));
     border-bottom: 1px solid var(--border);
     background: var(--panel);
     display: flex;
@@ -73,6 +77,16 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     border-radius: 4px;
   }
   header .badge.lan { background: #3d3218; color: #ffdf7a; }
+  header #clear {
+    background: transparent;
+    color: var(--muted);
+    border: 1px solid var(--border);
+    padding: 4px 10px;
+    font-weight: 400;
+    font-size: 12px;
+    min-height: 0;
+  }
+  header #clear:hover { color: var(--text); border-color: var(--muted); }
   header .status {
     margin-left: auto;
     font: 12px var(--mono);
@@ -84,12 +98,14 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     flex: 1 1 auto;
     overflow-y: auto;
     padding: 12px 14px;
+    -webkit-overflow-scrolling: touch;
   }
   footer {
     flex: 0 0 auto;
     border-top: 1px solid var(--border);
     background: var(--panel);
     padding: 10px 14px;
+    padding-bottom: calc(10px + var(--safe-bottom));
     display: flex;
     gap: 8px;
   }
@@ -100,9 +116,9 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     border: 1px solid var(--border);
     border-radius: 6px;
     padding: 8px 10px;
-    font: 14px var(--mono);
+    font: 16px var(--mono);
     resize: none;
-    min-height: 36px;
+    min-height: 40px;
     max-height: 180px;
   }
   #input:focus { outline: 2px solid var(--accent); }
@@ -112,8 +128,11 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     border: 0;
     border-radius: 6px;
     padding: 0 14px;
+    min-height: 40px;
     font-weight: 600;
+    font-size: 14px;
     cursor: pointer;
+    touch-action: manipulation;
   }
   button:disabled { opacity: 0.5; cursor: default; }
   button.abort { background: var(--error); color: white; }
@@ -155,11 +174,11 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     color: var(--text);
     border: 1px solid var(--border);
     border-radius: 6px;
-    padding: 8px 10px;
-    font: 13px var(--mono);
+    padding: 10px;
+    font: 16px var(--mono);
   }
   .token-gate input:focus { outline: 2px solid var(--accent); }
-  .token-gate button { padding: 8px 14px; margin-top: 10px; }
+  .token-gate button { padding: 10px 14px; margin-top: 10px; min-height: 44px; }
   .token-gate code {
     font: 12px var(--mono);
     background: var(--bg);
@@ -167,12 +186,25 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     border-radius: 4px;
     color: var(--text);
   }
+  @media (max-width: 640px) {
+    header { padding: 8px 10px; padding-top: calc(8px + env(safe-area-inset-top, 0px)); gap: 6px; }
+    header .title { font-size: 13px; }
+    header .badge { font-size: 10px; }
+    header #clear { padding: 4px 8px; font-size: 11px; }
+    header .status { font-size: 11px; }
+    main { padding: 10px; }
+    footer { padding: 8px 10px; padding-bottom: calc(8px + var(--safe-bottom)); }
+    .token-gate { margin: 16px 10px; padding: 16px; }
+    button { padding: 0 12px; min-height: 44px; }
+    #input { min-height: 44px; }
+  }
 </style>
 </head>
 <body data-slv-token="${inlineToken}" data-slv-protocol="${GATEWAY_PROTOCOL_VERSION}">
 <header>
   <span class="title">🌐 SLV Chat</span>
   <span class="badge ${opts.mode}">${opts.mode}</span>
+  <button id="clear" type="button" title="Clear chat history">clear</button>
   <span id="status" class="status">connecting…</span>
 </header>
 <main id="log"></main>
@@ -193,6 +225,7 @@ export const renderChatHtml = (opts: RenderOptions): string => {
   const input = document.getElementById('input')
   const sendBtn = document.getElementById('send')
   const abortBtn = document.getElementById('abort')
+  const clearBtn = document.getElementById('clear')
   const statusEl = document.getElementById('status')
   const footerEl = document.getElementById('footer')
   const gateEl = document.getElementById('gate')
@@ -201,11 +234,20 @@ export const renderChatHtml = (opts: RenderOptions): string => {
 
   const inlineToken = document.body.dataset.slvToken || ''
   const storageKey = 'slv.gateway.token.' + location.host
+  const logKey     = 'slv.gateway.log.'   + location.host
 
+  // Client-side message history. Kept in memory and mirrored to
+  // localStorage so a reload rehydrates the visible transcript.
+  // Cap entries to keep localStorage under the ~5MB per-origin
+  // quota — a noisy session can otherwise run away.
+  const HISTORY_MAX = 500
+  let history = []
   let ws = null
   let nextId = 0
   const pending = new Map()
   let currentAssistantEl = null
+  let currentAssistantEntry = null
+  let assistantLabel = 'Assistant'
 
   const getToken = () => {
     if (inlineToken) return inlineToken
@@ -248,20 +290,71 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     if (e.key === 'Enter') tokenSubmit.click()
   })
 
-  const addMsg = (who, whoLabel, text) => {
+  const saveHistory = () => {
+    try {
+      localStorage.setItem(logKey, JSON.stringify(history))
+    } catch {
+      // Over quota or disabled — history still lives in memory.
+    }
+  }
+
+  const renderMsg = (entry) => {
     const div = document.createElement('div')
-    div.className = 'msg ' + who
+    div.className = 'msg ' + entry.who
     const label = document.createElement('div')
     label.className = 'who'
-    label.textContent = whoLabel
+    label.textContent = entry.label
     const pre = document.createElement('pre')
-    pre.textContent = text
+    pre.textContent = entry.text
     div.appendChild(label)
     div.appendChild(pre)
     log.appendChild(div)
-    log.scrollTop = log.scrollHeight
     return pre
   }
+
+  const addMsg = (who, whoLabel, text) => {
+    const entry = { who, label: whoLabel, text: text || '' }
+    history.push(entry)
+    if (history.length > HISTORY_MAX) {
+      const excess = history.length - HISTORY_MAX
+      history.splice(0, excess)
+      // Drop the corresponding leading DOM nodes. Only trims if we
+      // actually exceeded the cap, so the normal path is O(1).
+      for (let i = 0; i < excess && log.firstChild; i++) {
+        log.removeChild(log.firstChild)
+      }
+    }
+    const pre = renderMsg(entry)
+    log.scrollTop = log.scrollHeight
+    saveHistory()
+    return { pre, entry }
+  }
+
+  const restoreHistory = () => {
+    let raw
+    try {
+      raw = localStorage.getItem(logKey)
+    } catch {
+      return
+    }
+    if (!raw) return
+    try {
+      const parsed = JSON.parse(raw)
+      if (!Array.isArray(parsed)) return
+      history = parsed.slice(-HISTORY_MAX)
+      for (const entry of history) renderMsg(entry)
+      log.scrollTop = log.scrollHeight
+    } catch {
+      // Corrupt JSON — drop it rather than wedge on every reload.
+      try { localStorage.removeItem(logKey) } catch { /* ignore */ }
+    }
+  }
+
+  clearBtn.addEventListener('click', () => {
+    history = []
+    log.innerHTML = ''
+    try { localStorage.removeItem(logKey) } catch { /* ignore */ }
+  })
 
   const call = (method, params) => new Promise((resolve) => {
     const id = 'w' + (++nextId)
@@ -292,6 +385,14 @@ export const renderChatHtml = (opts: RenderOptions): string => {
         return
       }
       setStatus('connected', 'connected')
+      // Surface the configured agent's display name. session.info is
+      // cheap (cached AgentContext) so the round-trip is noise-free.
+      try {
+        const info = await call('session.info')
+        if (info.ok && info.payload && typeof info.payload.agentName === 'string') {
+          assistantLabel = info.payload.agentName
+        }
+      } catch { /* fall back to default label */ }
       input.focus()
     }
     ws.onmessage = (ev) => {
@@ -306,9 +407,14 @@ export const renderChatHtml = (opts: RenderOptions): string => {
       switch (p.type) {
         case 'text_delta':
           if (!currentAssistantEl) {
-            currentAssistantEl = addMsg('assistant', 'Assistant', '')
+            const added = addMsg('assistant', assistantLabel, '')
+            currentAssistantEl = added.pre
+            currentAssistantEntry = added.entry
           }
           currentAssistantEl.textContent += p.text
+          if (currentAssistantEntry) {
+            currentAssistantEntry.text = currentAssistantEl.textContent
+          }
           log.scrollTop = log.scrollHeight
           break
         case 'tool_use_start':
@@ -322,7 +428,9 @@ export const renderChatHtml = (opts: RenderOptions): string => {
           break
         case 'complete':
         case 'aborted':
+          saveHistory()
           currentAssistantEl = null
+          currentAssistantEntry = null
           sendBtn.disabled = false
           abortBtn.style.display = 'none'
           if (p.type === 'aborted') {
@@ -332,6 +440,7 @@ export const renderChatHtml = (opts: RenderOptions): string => {
         case 'error':
           addMsg('error', '❌ error', p.message || '')
           currentAssistantEl = null
+          currentAssistantEntry = null
           sendBtn.disabled = false
           abortBtn.style.display = 'none'
           break
@@ -350,6 +459,7 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     sendBtn.disabled = true
     abortBtn.style.display = 'inline-block'
     currentAssistantEl = null
+    currentAssistantEntry = null
     const res = await call('session.send', { text })
     if (!res.ok) {
       addMsg('error', '❌ error', res.error || 'session.send rejected')
@@ -363,8 +473,14 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     if (!ws || ws.readyState !== WebSocket.OPEN) return
     ws.send(JSON.stringify({ kind: 'req', id: 'a' + (++nextId), method: 'session.abort' }))
   })
+  // Guard against IME composition: Japanese / Chinese / Korean input
+  // methods use Enter to commit the composition, which would
+  // otherwise send a half-typed message and leave the composition
+  // buffer stuck in the textarea. keyCode 229 is the legacy signal
+  // some mobile browsers still rely on; isComposing is the modern
+  // one. Check both.
   input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
       e.preventDefault()
       sendMessage()
     }
@@ -373,6 +489,8 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     input.style.height = 'auto'
     input.style.height = Math.min(input.scrollHeight, 180) + 'px'
   })
+
+  restoreHistory()
 
   const initial = getToken()
   if (initial) {

--- a/cli/src/gateway/ui/static.ts
+++ b/cli/src/gateway/ui/static.ts
@@ -415,9 +415,13 @@ export const renderChatHtml = (opts: RenderOptions): string => {
       }
       const auth = await call('gateway.auth', { token })
       if (!auth.ok) {
-        // Wrong token is terminal — don't loop. Clear both the
-        // saved token and any reconnect schedule so the gate is
-        // the clean entry point again.
+        // Distinguish a real server rejection ("invalid token")
+        // from a mid-auth disconnect: onclose nulls ws and
+        // resolves the pending promise with a local sentinel, so
+        // a null ws here means the socket died during auth. In
+        // that case the token is still probably valid — let the
+        // reconnect loop retry instead of wiping localStorage.
+        if (ws === null) return
         currentToken = ''
         if (reconnectTimer !== null) {
           clearTimeout(reconnectTimer)

--- a/cli/src/gateway/ui/static.ts
+++ b/cli/src/gateway/ui/static.ts
@@ -29,10 +29,9 @@ export type RenderOptions = {
 export const renderChatHtml = async (opts: RenderOptions): Promise<string> => {
   await initI18n()
   const inlineToken = opts.token ?? ''
-  // The client JS needs localized status/label strings too; bake
-  // them into a JSON object rather than round-tripping through t()
-  // on the browser (the browser has no access to the i18n dict).
-  const i18n = {
+  // Strings used only in the server-rendered HTML; they never leave
+  // this function so keep them out of the browser-visible JSON.
+  const html = {
     send: t('Send'),
     stop: t('Stop'),
     clear: t('clear'),
@@ -44,6 +43,11 @@ export const renderChatHtml = async (opts: RenderOptions): Promise<string> => {
     gateBody: t(
       "This browser is reaching the SLV gateway from a different host. Paste the gateway token value (found in ~/.slv/gateway/gateway.json on the gateway host) to continue. It's saved in your browser's localStorage.",
     ),
+  }
+  // Strings the client JS needs at runtime (status labels, chat
+  // message prefixes, the reconnect countdown template). Baked in
+  // as JSON so the browser has no need for a t() round-trip.
+  const clientI18n = {
     you: t('You'),
     assistant: t('Assistant'),
     thinking: t('Thinking…'),
@@ -51,7 +55,6 @@ export const renderChatHtml = async (opts: RenderOptions): Promise<string> => {
     reconnecting: t('reconnecting…'),
     reconnectingIn: t('reconnecting in {secs}s…'),
     connected: t('connected'),
-    disconnected: t('disconnected'),
     connectionError: t('connection error'),
     tokenRequired: t('token required'),
     handshakeFailed: t('handshake failed'),
@@ -60,7 +63,7 @@ export const renderChatHtml = async (opts: RenderOptions): Promise<string> => {
     errorLabel: t('❌ error'),
     interrupted: t('[disconnected — reply interrupted]'),
   }
-  const i18nJson = JSON.stringify(i18n)
+  const i18nJson = JSON.stringify(clientI18n)
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -261,20 +264,20 @@ export const renderChatHtml = async (opts: RenderOptions): Promise<string> => {
 <header>
   <span class="title">🌐 SLV Chat</span>
   <span class="badge ${opts.mode}">${opts.mode}</span>
-  <button id="clear" type="button" title="${i18n.clearTitle}">${i18n.clear}</button>
-  <span id="status" class="status">${i18n.connecting}</span>
+  <button id="clear" type="button" title="${html.clearTitle}">${html.clear}</button>
+  <span id="status" class="status">${clientI18n.connecting}</span>
 </header>
 <main id="log"></main>
 <div id="gate" class="token-gate" style="display:none">
-  <h2>${i18n.gateHeading}</h2>
-  <p>${i18n.gateBody}</p>
-  <input id="token-input" type="password" autocomplete="off" placeholder="${i18n.placeholderToken}" />
-  <div><button id="token-submit">${i18n.connect}</button></div>
+  <h2>${html.gateHeading}</h2>
+  <p>${html.gateBody}</p>
+  <input id="token-input" type="password" autocomplete="off" placeholder="${html.placeholderToken}" />
+  <button id="token-submit">${html.connect}</button>
 </div>
 <footer id="footer" style="display:none">
-  <textarea id="input" rows="1" placeholder="${i18n.placeholderMessage}"></textarea>
-  <button id="send">${i18n.send}</button>
-  <button id="abort" class="abort" style="display:none">${i18n.stop}</button>
+  <textarea id="input" rows="1" placeholder="${html.placeholderMessage}"></textarea>
+  <button id="send">${html.send}</button>
+  <button id="abort" class="abort" style="display:none">${html.stop}</button>
 </footer>
 <script>
 (function () {

--- a/cli/src/gateway/ui/static.ts
+++ b/cli/src/gateway/ui/static.ts
@@ -504,7 +504,7 @@ export const renderChatHtml = (opts: RenderOptions): string => {
       // in both the visible DOM and the persisted history so the
       // user knows to retry.
       if (currentAssistantEntry) {
-        const note = '\n\n[disconnected — reply interrupted]'
+        const note = '\\n\\n[disconnected — reply interrupted]'
         currentAssistantEntry.text += note
         if (currentAssistantEl) currentAssistantEl.textContent += note
       }

--- a/cli/src/gateway/ui/static.ts
+++ b/cli/src/gateway/ui/static.ts
@@ -1,5 +1,6 @@
 import { GATEWAY_PROTOCOL_VERSION } from '/src/gateway/paths.ts'
 import type { GatewayMode } from '/src/gateway/config.ts'
+import { initI18n, t } from '/src/ai/i18n/index.ts'
 
 export type RenderOptions = {
   /**
@@ -25,8 +26,41 @@ export type RenderOptions = {
  *     /ui/; token NOT inlined — user pastes it once and we persist
  *     in localStorage keyed on origin.
  */
-export const renderChatHtml = (opts: RenderOptions): string => {
+export const renderChatHtml = async (opts: RenderOptions): Promise<string> => {
+  await initI18n()
   const inlineToken = opts.token ?? ''
+  // The client JS needs localized status/label strings too; bake
+  // them into a JSON object rather than round-tripping through t()
+  // on the browser (the browser has no access to the i18n dict).
+  const i18n = {
+    send: t('Send'),
+    stop: t('Stop'),
+    clear: t('clear'),
+    clearTitle: t('Clear chat history'),
+    connect: t('Connect'),
+    placeholderMessage: t('Type a message and press Enter'),
+    placeholderToken: t('64 hex characters'),
+    gateHeading: t('Paste your gateway token'),
+    gateBody: t(
+      "This browser is reaching the SLV gateway from a different host. Paste the gateway token value (found in ~/.slv/gateway/gateway.json on the gateway host) to continue. It's saved in your browser's localStorage.",
+    ),
+    you: t('You'),
+    assistant: t('Assistant'),
+    thinking: t('Thinking…'),
+    connecting: t('connecting…'),
+    reconnecting: t('reconnecting…'),
+    reconnectingIn: t('reconnecting in {secs}s…'),
+    connected: t('connected'),
+    disconnected: t('disconnected'),
+    connectionError: t('connection error'),
+    tokenRequired: t('token required'),
+    handshakeFailed: t('handshake failed'),
+    authFailed: t('auth failed — check token'),
+    aborted: t('⏸ aborted'),
+    errorLabel: t('❌ error'),
+    interrupted: t('[disconnected — reply interrupted]'),
+  }
+  const i18nJson = JSON.stringify(i18n)
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -158,6 +192,29 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     word-break: break-word;
   }
   .msg.assistant pre { background: transparent; border: 0; padding: 4px 0; }
+  .thinking {
+    margin: 0 0 12px 0;
+    padding: 6px 0;
+    color: var(--muted);
+    font-style: italic;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .thinking .dot {
+    width: 6px;
+    height: 6px;
+    background: var(--accent);
+    border-radius: 50%;
+    animation: pulse 1.2s infinite;
+  }
+  .thinking .dot:nth-child(2) { animation-delay: 0.2s; }
+  .thinking .dot:nth-child(3) { animation-delay: 0.4s; }
+  @keyframes pulse {
+    0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1); }
+  }
   .token-gate {
     max-width: 520px;
     margin: 60px auto;
@@ -204,23 +261,25 @@ export const renderChatHtml = (opts: RenderOptions): string => {
 <header>
   <span class="title">🌐 SLV Chat</span>
   <span class="badge ${opts.mode}">${opts.mode}</span>
-  <button id="clear" type="button" title="Clear chat history">clear</button>
-  <span id="status" class="status">connecting…</span>
+  <button id="clear" type="button" title="${i18n.clearTitle}">${i18n.clear}</button>
+  <span id="status" class="status">${i18n.connecting}</span>
 </header>
 <main id="log"></main>
 <div id="gate" class="token-gate" style="display:none">
-  <h2>Paste your gateway token</h2>
-  <p>This browser is reaching the SLV gateway from a different host. Paste the <code>token</code> value from <code>~/.slv/gateway/gateway.json</code> on the gateway host to continue. It's saved in your browser's localStorage.</p>
-  <input id="token-input" type="password" autocomplete="off" placeholder="64 hex characters" />
-  <div><button id="token-submit">Connect</button></div>
+  <h2>${i18n.gateHeading}</h2>
+  <p>${i18n.gateBody}</p>
+  <input id="token-input" type="password" autocomplete="off" placeholder="${i18n.placeholderToken}" />
+  <div><button id="token-submit">${i18n.connect}</button></div>
 </div>
 <footer id="footer" style="display:none">
-  <textarea id="input" rows="1" placeholder="Type a message and press Enter"></textarea>
-  <button id="send">Send</button>
-  <button id="abort" class="abort" style="display:none">Stop</button>
+  <textarea id="input" rows="1" placeholder="${i18n.placeholderMessage}"></textarea>
+  <button id="send">${i18n.send}</button>
+  <button id="abort" class="abort" style="display:none">${i18n.stop}</button>
 </footer>
 <script>
 (function () {
+  const I18N = ${i18nJson}
+
   const log = document.getElementById('log')
   const input = document.getElementById('input')
   const sendBtn = document.getElementById('send')
@@ -247,7 +306,8 @@ export const renderChatHtml = (opts: RenderOptions): string => {
   const pending = new Map()
   let currentAssistantEl = null
   let currentAssistantEntry = null
-  let assistantLabel = 'Assistant'
+  let thinkingEl = null
+  let assistantLabel = I18N.assistant
 
   // Reconnect state: survives across connection lifetimes.
   // reconnectAttempt resets on a successful auth; backoff is
@@ -371,13 +431,35 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     pending.clear()
   }
 
+  const showThinking = () => {
+    if (thinkingEl) return
+    thinkingEl = document.createElement('div')
+    thinkingEl.className = 'thinking'
+    const label = document.createElement('span')
+    label.textContent = I18N.thinking
+    thinkingEl.appendChild(label)
+    for (let i = 0; i < 3; i++) {
+      const d = document.createElement('span')
+      d.className = 'dot'
+      thinkingEl.appendChild(d)
+    }
+    log.appendChild(thinkingEl)
+    log.scrollTop = log.scrollHeight
+  }
+
+  const hideThinking = () => {
+    if (!thinkingEl) return
+    thinkingEl.remove()
+    thinkingEl = null
+  }
+
   const scheduleReconnect = () => {
     if (!currentToken) return
     if (reconnectTimer !== null) return
     const base = Math.min(30000, 1000 * Math.pow(2, reconnectAttempt))
     const delay = base + Math.random() * 250
     const secs = Math.max(1, Math.round(delay / 1000))
-    setStatus('reconnecting in ' + secs + 's…', 'error')
+    setStatus(I18N.reconnectingIn.replace('{secs}', String(secs)), 'error')
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null
       reconnectAttempt++
@@ -394,7 +476,7 @@ export const renderChatHtml = (opts: RenderOptions): string => {
   const connect = (token) => {
     if (!token) {
       showGate()
-      setStatus('token required', 'error')
+      setStatus(I18N.tokenRequired, 'error')
       return
     }
     if (ws && (ws.readyState === 0 || ws.readyState === 1)) return
@@ -404,13 +486,13 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     }
     currentToken = token
     showChat()
-    setStatus(reconnectAttempt > 0 ? 'reconnecting…' : 'connecting…', '')
+    setStatus(reconnectAttempt > 0 ? I18N.reconnecting : I18N.connecting, '')
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
     ws = new WebSocket(proto + '//' + location.host + '/v1/session/ws')
     ws.onopen = async () => {
       const hello = await call('gateway.hello')
       if (!hello.ok) {
-        setStatus('handshake failed', 'error')
+        setStatus(I18N.handshakeFailed, 'error')
         return
       }
       const auth = await call('gateway.auth', { token })
@@ -427,13 +509,13 @@ export const renderChatHtml = (opts: RenderOptions): string => {
           clearTimeout(reconnectTimer)
           reconnectTimer = null
         }
-        setStatus('auth failed — check token', 'error')
+        setStatus(I18N.authFailed, 'error')
         try { localStorage.removeItem(storageKey) } catch { /* ignore */ }
         showGate()
         return
       }
       reconnectAttempt = 0
-      setStatus('connected', 'connected')
+      setStatus(I18N.connected, 'connected')
       // Surface the configured agent's display name. session.info is
       // cheap (cached AgentContext) so the round-trip is noise-free.
       try {
@@ -453,6 +535,10 @@ export const renderChatHtml = (opts: RenderOptions): string => {
       }
       if (f.kind !== 'event') return
       const p = f.payload || {}
+      // Any incoming event means the model is responding — drop the
+      // thinking indicator. Keeping it through text_delta would show
+      // dots next to the actual reply, which is noisy.
+      hideThinking()
       switch (p.type) {
         case 'text_delta':
           if (!currentAssistantEl) {
@@ -483,11 +569,11 @@ export const renderChatHtml = (opts: RenderOptions): string => {
           sendBtn.disabled = false
           abortBtn.style.display = 'none'
           if (p.type === 'aborted') {
-            addMsg('system', '⏸ aborted', p.reason || '')
+            addMsg('system', I18N.aborted, p.reason || '')
           }
           break
         case 'error':
-          addMsg('error', '❌ error', p.message || '')
+          addMsg('error', I18N.errorLabel, p.message || '')
           currentAssistantEl = null
           currentAssistantEntry = null
           sendBtn.disabled = false
@@ -497,6 +583,7 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     }
     ws.onclose = () => {
       ws = null
+      hideThinking()
       // Any outstanding req/res awaits would otherwise hang forever;
       // resolve them with a sentinel so callers return cleanly.
       rejectPending('disconnected')
@@ -504,7 +591,7 @@ export const renderChatHtml = (opts: RenderOptions): string => {
       // in both the visible DOM and the persisted history so the
       // user knows to retry.
       if (currentAssistantEntry) {
-        const note = '\\n\\n[disconnected — reply interrupted]'
+        const note = '\\n\\n' + I18N.interrupted
         currentAssistantEntry.text += note
         if (currentAssistantEl) currentAssistantEl.textContent += note
       }
@@ -519,23 +606,25 @@ export const renderChatHtml = (opts: RenderOptions): string => {
       // onerror always runs right before onclose, so leave the
       // real recovery logic (pending rejection, reconnect schedule)
       // in onclose to avoid double-trigger.
-      setStatus('connection error', 'error')
+      setStatus(I18N.connectionError, 'error')
     }
   }
 
   const sendMessage = async () => {
     const text = input.value.trim()
     if (!text || !ws || ws.readyState !== WebSocket.OPEN) return
-    addMsg('user', 'You', text)
+    addMsg('user', I18N.you, text)
     input.value = ''
     input.style.height = 'auto'
     sendBtn.disabled = true
     abortBtn.style.display = 'inline-block'
     currentAssistantEl = null
     currentAssistantEntry = null
+    showThinking()
     const res = await call('session.send', { text })
     if (!res.ok) {
-      addMsg('error', '❌ error', res.error || 'session.send rejected')
+      hideThinking()
+      addMsg('error', I18N.errorLabel, res.error || 'session.send rejected')
       sendBtn.disabled = false
       abortBtn.style.display = 'none'
     }

--- a/cli/src/gateway/ui/static.ts
+++ b/cli/src/gateway/ui/static.ts
@@ -249,6 +249,14 @@ export const renderChatHtml = (opts: RenderOptions): string => {
   let currentAssistantEntry = null
   let assistantLabel = 'Assistant'
 
+  // Reconnect state: survives across connection lifetimes.
+  // reconnectAttempt resets on a successful auth; backoff is
+  // 1s → 2s → 4s → 8s → 16s → 30s (capped) with ±250ms jitter so
+  // a flaky network doesn't produce synchronized reconnect storms.
+  let currentToken = ''
+  let reconnectAttempt = 0
+  let reconnectTimer = null
+
   const getToken = () => {
     if (inlineToken) return inlineToken
     try {
@@ -356,6 +364,27 @@ export const renderChatHtml = (opts: RenderOptions): string => {
     try { localStorage.removeItem(logKey) } catch { /* ignore */ }
   })
 
+  const rejectPending = (reason) => {
+    for (const resolve of pending.values()) {
+      resolve({ ok: false, error: reason })
+    }
+    pending.clear()
+  }
+
+  const scheduleReconnect = () => {
+    if (!currentToken) return
+    if (reconnectTimer !== null) return
+    const base = Math.min(30000, 1000 * Math.pow(2, reconnectAttempt))
+    const delay = base + Math.random() * 250
+    const secs = Math.max(1, Math.round(delay / 1000))
+    setStatus('reconnecting in ' + secs + 's…', 'error')
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      reconnectAttempt++
+      connect(currentToken)
+    }, delay)
+  }
+
   const call = (method, params) => new Promise((resolve) => {
     const id = 'w' + (++nextId)
     pending.set(id, resolve)
@@ -368,7 +397,14 @@ export const renderChatHtml = (opts: RenderOptions): string => {
       setStatus('token required', 'error')
       return
     }
+    if (ws && (ws.readyState === 0 || ws.readyState === 1)) return
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    currentToken = token
     showChat()
+    setStatus(reconnectAttempt > 0 ? 'reconnecting…' : 'connecting…', '')
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
     ws = new WebSocket(proto + '//' + location.host + '/v1/session/ws')
     ws.onopen = async () => {
@@ -379,11 +415,20 @@ export const renderChatHtml = (opts: RenderOptions): string => {
       }
       const auth = await call('gateway.auth', { token })
       if (!auth.ok) {
+        // Wrong token is terminal — don't loop. Clear both the
+        // saved token and any reconnect schedule so the gate is
+        // the clean entry point again.
+        currentToken = ''
+        if (reconnectTimer !== null) {
+          clearTimeout(reconnectTimer)
+          reconnectTimer = null
+        }
         setStatus('auth failed — check token', 'error')
         try { localStorage.removeItem(storageKey) } catch { /* ignore */ }
         showGate()
         return
       }
+      reconnectAttempt = 0
       setStatus('connected', 'connected')
       // Surface the configured agent's display name. session.info is
       // cheap (cached AgentContext) so the round-trip is noise-free.
@@ -446,8 +491,32 @@ export const renderChatHtml = (opts: RenderOptions): string => {
           break
       }
     }
-    ws.onclose = () => setStatus('disconnected', 'error')
-    ws.onerror = () => setStatus('connection error', 'error')
+    ws.onclose = () => {
+      ws = null
+      // Any outstanding req/res awaits would otherwise hang forever;
+      // resolve them with a sentinel so callers return cleanly.
+      rejectPending('disconnected')
+      // An in-flight assistant reply is lost on disconnect — mark it
+      // in both the visible DOM and the persisted history so the
+      // user knows to retry.
+      if (currentAssistantEntry) {
+        const note = '\n\n[disconnected — reply interrupted]'
+        currentAssistantEntry.text += note
+        if (currentAssistantEl) currentAssistantEl.textContent += note
+      }
+      currentAssistantEl = null
+      currentAssistantEntry = null
+      sendBtn.disabled = false
+      abortBtn.style.display = 'none'
+      saveHistory()
+      scheduleReconnect()
+    }
+    ws.onerror = () => {
+      // onerror always runs right before onclose, so leave the
+      // real recovery logic (pending rejection, reconnect schedule)
+      // in onclose to avoid double-trigger.
+      setStatus('connection error', 'error')
+    }
   }
 
   const sendMessage = async () => {

--- a/cli/src/gateway/ws/router.ts
+++ b/cli/src/gateway/ws/router.ts
@@ -10,6 +10,7 @@ import { providerDriver } from '/src/ai/core/drivers/provider.ts'
 import { readAiConfig } from '/src/ai/config.ts'
 import { getApiKeyFromYml } from '/lib/getApiKeyFromYml.ts'
 import { loadAgentContext } from '/src/ai/agentConfig/loader.ts'
+import { buildSystemPrompt } from '/src/ai/console/systemPrompt.ts'
 
 /**
  * Per-connection state. Phase 2A: just auth. Phase 2B adds the
@@ -188,11 +189,28 @@ const methods: Record<string, MethodHandler> = {
       }
     }
 
+    // Hydrate the same system prompt the TUI uses so browser chat has
+    // access to SOUL.md (agent identity), USER.md (user profile + name),
+    // MEMORY.md (persisted session notes), enabled skills, and the
+    // sub-agent team. Without this, `/ui/` just talks to a raw LLM with
+    // no context and the conversation feels disconnected from `slv c`.
+    // buildSystemPrompt memoizes via loadAgentContext, so the cost is a
+    // one-time FS read per process.
+    let systemPrompt = ''
+    try {
+      systemPrompt = await buildSystemPrompt()
+    } catch (err) {
+      return resErr(
+        req,
+        `failed to build system prompt: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+
     const driver = providerDriver({
       kind: aiCfg.provider,
       apiKey,
       model: aiCfg.model,
-      systemPrompt: '', // Phase 2C: empty system prompt; agent config integration later
+      systemPrompt,
     })
     state.session = new Session(driver)
     state.session.on((event) => ctx.emitEvent(event))

--- a/cli/src/gateway/ws/router.ts
+++ b/cli/src/gateway/ws/router.ts
@@ -9,6 +9,7 @@ import { echoDriver, Session } from '/src/ai/core/session.ts'
 import { providerDriver } from '/src/ai/core/drivers/provider.ts'
 import { readAiConfig } from '/src/ai/config.ts'
 import { getApiKeyFromYml } from '/lib/getApiKeyFromYml.ts'
+import { loadAgentContext } from '/src/ai/agentConfig/loader.ts'
 
 /**
  * Per-connection state. Phase 2A: just auth. Phase 2B adds the
@@ -75,6 +76,24 @@ const methods: Record<string, MethodHandler> = {
     }
     state.authenticated = true
     return resOk(req, { authenticated: true })
+  },
+
+  /**
+   * Metadata the browser UI needs once per connection: the configured
+   * agent's display name + the AI provider/model in use. Kept out of
+   * gateway.hello so unauthenticated callers can't fingerprint the
+   * agent config; kept out of every event frame because it's a
+   * session constant, not per-message.
+   */
+  'session.info': async (req, state) => {
+    if (!state.authenticated) return resErr(req, 'not authenticated')
+    const ctx = await loadAgentContext()
+    const aiCfg = await readAiConfig().catch(() => null)
+    return resOk(req, {
+      agentName: ctx.soul?.name ?? 'Assistant',
+      provider: aiCfg?.provider ?? null,
+      model: aiCfg?.model ?? null,
+    })
   },
 
   /**


### PR DESCRIPTION
Replaces #313 (auto-closed when its stacked base `feat/gateway-lan-mode` was deleted on #312 merge). Same commits, rebased onto main.

## Summary

Browser chat at `/ui/` previously felt disconnected from `slv c` and had several rough edges. This PR brings it to parity:

### 1. Real agent name instead of `"Assistant"`
New WS method `session.info` (authenticated) returns `{ agentName, provider, model }` reading `AgentContext.soul.name` (e.g. `"EL"`). Browser calls it right after auth.

### 2. IME (CJK) input bug
Typing `テスト` + Enter no longer sends a half-composed message. Guard now checks `!e.isComposing && e.keyCode !== 229`.

### 3. Mobile optimization
`viewport-fit=cover`, safe-area padding, 16px input font (no iOS auto-zoom), 44px touch targets, narrow-screen media query, header `clear` button.

### 4. Client-side history persistence
Chat log mirrored to `localStorage['slv.gateway.log.' + origin]`, rehydrated on reload, capped at 500 entries. Streaming reply tracked via entry *reference* so cap-trim can't corrupt in-flight messages.

### 5. Auto-reconnect with exponential backoff
On ws.onclose: outstanding req promises rejected, in-flight reply flagged as interrupted in DOM + history, reconnect scheduled with 1s → 2s → 4s → 8s → 16s → 30s backoff + jitter. Successful auth resets the counter. Invalid token is terminal (no loop). **Critical bug fix:** mid-auth disconnect no longer wipes the stored token.

### 6. Full agent context in browser chat
`session.send` now calls `buildSystemPrompt()` — the same builder the TUI uses — so browser chat gets SOUL.md persona, USER.md profile, MEMORY.md memory, enabled skills, and the sub-agent team. Previously it was an empty system prompt (Phase 2C TODO).

### 7. i18n via ~/.slv/api.yml `lang`
`renderChatHtml` is now async and calls `initI18n()` before producing HTML. Every UI label + client-side status string routes through `t()`. Translations added to all 5 built-in locales (en/ja/zh/ru/vi). Server-only strings stay out of the client-shipped JSON.

### 8. Instant `Thinking…` indicator
Pulsing dots + label appear the moment the user sends; hides as soon as ANY event arrives (text_delta, tool_use_start, etc.) or the socket drops. Not persisted to history — transient affordance.

## Pre-merge review fixes included

- Split server-rendered vs client-shipped i18n dicts (9 fewer keys on the wire)
- Removed empty `<div>` wrapper around the token-submit button
- `try/catch` in the `/ui/` handler so a future render error returns 500, not a process-level crash
- `initI18n` caches the in-flight Promise (not just a bool) for startup-race safety

## Test plan

- [x] Type-check passes for all touched files
- [x] Gateway test suite green (web_ui + foreground + router = 9 integration + many unit)
- [x] Binary cross-compiled + deployed to test VPS; `/healthz` + `/ui/` serving
- [x] Japanese UI verified live on VPS (`lang: ja` → 「送信」「メッセージを入力して Enter で送信」など)
- [x] `session.info` returns `agentName: "EL"` on the VPS
- [x] "テスト" via browser now gets context-aware EL response (knows "Kawasaki-san", references past MEMORY.md items)

## Deferred (tracked separately)

- Server-side event replay on reconnect — needs SessionId + per-session ring buffer + `session.resume`. Client-side reconnect handles the common case (sleep/wake, blips) without it.
- Multi-user auth — user confirmed out of scope for now.
- Image attachments — tracked in #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)