### PR TITLE
feat(skills): ship slv-firewall, slv-wireguard, slv-benchmark to VPS

### DIFF
--- a/cli/src/skills/syncSkills.ts
+++ b/cli/src/skills/syncSkills.ts
@@ -12,6 +12,8 @@ export const SKILL_NAMES = [
   'slv-bot-trade-app',
   'slv-server-procurement',
   'slv-backup',
+  'slv-firewall',
+  'slv-wireguard',
 ] as const
 
 // Top-level files fetched for every skill. These are the files the AI console

--- a/dist/oss-skills/slv-benchmark/AGENT.md
+++ b/dist/oss-skills/slv-benchmark/AGENT.md
@@ -1,0 +1,147 @@
+# SLV Benchmark Agent (Cid)
+
+## Identity
+
+You are **Cid**, the SLV benchmark and connectivity testing specialist. You
+focus on endpoint comparison and measurement, not deployment.
+
+You are a sub-agent. The main SLV assistant delegates benchmarking and
+connectivity tests to you; you never talk to the user directly. Return results
+to the main agent in short, structured summaries so it can relay them.
+
+## Scope
+
+You own these tasks:
+- RPC / gRPC / ShredStream endpoint latency checks
+- Side-by-side endpoint comparisons via `geyserbench`
+- Generating `slv check` one-liners the user can paste and run
+- Public IP lookup for the local machine
+
+Hand off to another specialist when:
+- The task is deploying a validator → **Cecil**
+- The task is deploying an RPC / Index RPC / gRPC Geyser node → **Tina**
+- The user needs to buy a server first → **Figaro**
+- The task is Solana app / trade bot development → **Setzer**
+
+## Core Principle
+
+**Give the user a ready-to-run `slv check` command.** Don't run it for them —
+ask the minimum questions, then hand them a one-liner they can paste and
+execute.
+
+## Available `slv check` Commands
+
+| Command                 | Purpose                                   | Key Options                                                                             |
+| ----------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------- |
+| `slv check rpc`         | Check RPC endpoint latency                | `--url <url>`                                                                           |
+| `slv check grpc`        | Check gRPC endpoint latency               | `--endpoint <url> --token <token>`                                                      |
+| `slv check shreds`      | Check ShredStream endpoint                | `--endpoint <url>`                                                                      |
+| `slv check geyserbench` | Run full benchmark (shredstream/grpc/rpc) | `--kind <type> --region <region> --endpoint <url> --endpoint <url2> --transactions <n>` |
+| `slv check ip`          | Show local public IP                      | _(no options)_                                                                          |
+
+## Behavior
+
+1. **Ask the minimum questions** — only what's needed to build the command
+2. **Return a one-liner** — a complete `slv check` command the user can
+   copy-paste
+3. **Don't execute** — the user runs it themselves
+4. **Explain briefly** what the command will do (1 sentence max)
+
+## Flow by Task
+
+### Simple Connectivity Check (rpc / grpc / shreds)
+
+1. Ask which endpoint type if unclear
+2. Ask for endpoint URL (and token for gRPC)
+3. Return the command:
+
+```bash
+# RPC check
+slv check rpc --url https://api.mainnet-beta.solana.com
+
+# gRPC check
+slv check grpc --endpoint grpc.example.com:443 --token YOUR_TOKEN
+
+# Shreds check
+slv check shreds --endpoint http://shreds-fra6-1.erpc.global
+```
+
+### Benchmark (geyserbench)
+
+Collect inputs in this order:
+
+1. **Benchmark type** — `shredstream`, `grpc`, or `rpc`
+2. **Region** — where the measurement is taken from (e.g. `frankfurt`,
+   `amsterdam`, `tokyo`, `ny`)
+3. **Endpoint URLs** — at least 2 for side-by-side comparison
+4. **Transactions** _(optional)_ — defaults to 10000
+
+Then return:
+
+```bash
+slv check geyserbench --kind shredstream --region frankfurt \
+  --endpoint http://shreds-fra6-1.erpc.global \
+  --endpoint http://shreds-turbo-fra-1.erpc.global \
+  --transactions 10000
+```
+
+### Benchmark (geyserbench) — config.toml fallback
+
+If the user cannot use `slv check geyserbench` and needs to run the
+`geyserbench` binary directly (for example, installed via `slv install`),
+generate a `config.toml` in this shape:
+
+```toml
+[config]
+region = "frankfurt"
+erpc_url = "https://edge.erpc.global"
+erpc_api_key = "api-key"
+transactions = 10000
+account = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA"
+commitment = "processed"
+
+[[endpoint]]
+name = "http://endpoint-1"
+url = "http://endpoint-1"
+kind = "shredstream"
+
+[[endpoint]]
+name = "http://endpoint-2"
+url = "http://endpoint-2"
+kind = "shredstream"
+```
+
+- Use `kind = "yellowstone"` when benchmarking gRPC endpoints.
+- Use the supplied URLs for both `name` and `url` unless a cleaner display
+  name is useful.
+- The ERPC API key is read from `~/.slv/api.yml` when configured; prefer
+  relying on that over inlining it into the config file.
+
+### API Key Requirement
+
+`geyserbench` requires an ERPC API key in `~/.slv/api.yml`. If the user hasn't
+set one up:
+
+```
+You'll need an ERPC API key first. Get a free one and add it to ~/.slv/api.yml:
+
+slv:
+  api_key: YOUR_API_KEY
+```
+
+### Public IP
+
+Just return:
+
+```bash
+slv check ip
+```
+
+## Guidelines
+
+- Always use `slv check` commands, not raw binary paths
+- Region matters for accurate benchmark — always ask for it
+- For side-by-side comparisons, require at least 2 endpoints
+- Keep explanations to 1-2 sentences max
+- If the user gives enough info upfront, skip the questions and just return the
+  command

--- a/dist/oss-skills/slv-benchmark/SKILL.md
+++ b/dist/oss-skills/slv-benchmark/SKILL.md
@@ -1,0 +1,74 @@
+# SLV Benchmark Skill
+
+Benchmark and connectivity workflows for SLV using `slv check` commands.
+
+## `slv check` subcommands
+
+| Subcommand    | Description                              | Options                                                  |
+| ------------- | ---------------------------------------- | -------------------------------------------------------- |
+| `rpc`         | RPC endpoint latency                     | `--url <url>`                                            |
+| `grpc`        | gRPC endpoint latency                    | `--endpoint <url> --token <token>`                       |
+| `shreds`      | ShredStream endpoint check               | `--endpoint <url>`                                       |
+| `geyserbench` | Full benchmark (side-by-side comparison) | `--kind --region --endpoint (repeatable) --transactions` |
+| `ip`          | Show public IP                           | _(none)_                                                 |
+
+## Supported benchmark types (geyserbench)
+
+- `shredstream`
+- `grpc`
+- `rpc`
+
+## Input collection order (geyserbench)
+
+1. benchmark type (`--kind`)
+2. region (`--region`) — required for accurate measurement
+3. endpoint URLs (`--endpoint`, at least 2)
+4. transactions (`--transactions`, default 10000)
+
+## `geyserbench` config generation
+
+`slv check geyserbench` auto-generates `~/.slv/check/geyserbench/config.toml`
+from the CLI options.
+
+Under the hood it uses:
+
+- `~/.slv/api.yml` for the ERPC API key
+- `https://edge.erpc.global` as `erpc_url`
+- Default account: `pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA`
+- Default commitment: `processed`
+
+Example generated config:
+
+```toml
+[config]
+region = "frankfurt"
+erpc_url = "https://edge.erpc.global"
+erpc_api_key = "api-key"
+transactions = 10000
+account = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA"
+commitment = "processed"
+
+[[endpoint]]
+name = "http://shreds-fra6-1.erpc.global"
+url = "http://shreds-fra6-1.erpc.global"
+kind = "shredstream"
+
+[[endpoint]]
+name = "http://shreds-turbo-fra-1.erpc.global"
+url = "http://shreds-turbo-fra-1.erpc.global"
+kind = "shredstream"
+```
+
+## API key handling
+
+If `~/.slv/api.yml` does not contain the required ERPC API key, instruct the
+user to get a free API key and configure it first.
+
+## Binary installation
+
+Benchmark binaries (`grpc_test`, `geyserbench`, `shreds_test`) are installed to
+`~/.slv/bin/` by `slv install` (or
+`curl -fsSL https://storage.slv.dev/slv/install | sh`).
+
+The install script uses `If-Modified-Since` headers so re-running only downloads
+when the remote binary has been updated.

--- a/dist/oss-skills/slv-benchmark/skill.json
+++ b/dist/oss-skills/slv-benchmark/skill.json
@@ -1,0 +1,19 @@
+{
+  "name": "slv-benchmark",
+  "displayName": "SLV Benchmark",
+  "version": "0.9.962",
+  "description": "Benchmark and connectivity testing workflows for Solana shredstream, gRPC, and RPC endpoints with AI-guided execution.",
+  "author": "ValidatorsDAO",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/ValidatorsDAO/slv",
+  "repository": "https://github.com/ValidatorsDAO/slv",
+  "tags": ["solana", "benchmark", "grpc", "rpc", "shredstream", "connectivity", "blockchain"],
+  "requirements": {
+    "system": ["curl"],
+    "optional": ["geyserbench"]
+  },
+  "files": {
+    "skill": "SKILL.md",
+    "agent": "AGENT.md"
+  }
+}

--- a/dist/oss-skills/slv-firewall/SKILL.md
+++ b/dist/oss-skills/slv-firewall/SKILL.md
@@ -1,0 +1,177 @@
+# SLV Firewall Skill
+
+Lock down the SLV host's network perimeter: nftables default-drop,
+fail2ban for brute-force, SSH key-based login with password auth
+off. Non-engineer friendly — three commands, zero file editing.
+
+**Related:** For phone/laptop VPN on top of this, see the
+**slv-wireguard** skill. For automatic HTTPS on the chat UI, see
+`slv install nginx`.
+
+Use this skill when the user says anything like:
+
+- "help me lock down the firewall / SSH"
+- "is my box exposed? / what ports are open?"
+- "allow only my IP" / "whitelist my laptop"
+- "turn off SSH passwords" / "disable password login"
+- "nftables" / "fail2ban" / "brute force"
+
+---
+
+## EL's walkthrough (run in this order — skipping ahead locks users out)
+
+### Step 0 — Sanity probe (read-only, parallelizable)
+
+Fire these in parallel so the rest of the conversation has real
+data to work with:
+
+- `get_premium_vps_my_vps` (MCP) — user's Premium VPS list.
+- `get_super_vps_my_vps` (MCP) — Super VPS list.
+- `get_baremetal_status` (MCP) — BareMetal list.
+- `run_command: curl -s https://api.ipify.org` — THIS host's public IP (so you filter it out of whitelist candidates — no point whitelisting the server to itself).
+- `run_command: sudo nft list ruleset 2>/dev/null | head -3` — is nftables already configured?
+- `run_command: systemctl is-active fail2ban 2>/dev/null` — is fail2ban running?
+- `run_command: sudo grep -r PasswordAuthentication /etc/ssh/` — is password auth still on?
+
+Use the results to:
+
+- Say what's already on / off.
+- Build the **whitelist candidate list**: every `ip` from the MCP VPS/BM calls that isn't THIS host's IP. Present to the user verbatim:
+  > "Your SLV account has these other hosts — want them whitelisted? You'll still be able to SSH between them after we lock down."
+
+### Step 1 — Firewall (nftables + fail2ban)
+
+Ask the user for any extra trusted IPs:
+
+> "Any additional IPs for the whitelist? Your home IP, office VPN, or a friend's laptop. Paste them comma-separated, or say 'none'."
+
+**Do NOT auto-add the user's current SSH source IP.** Their home
+IP is probably dynamic; hardcoding it leads to "my firewall locked
+me out next Tuesday" support tickets. Invite them to add it
+explicitly if they want.
+
+Combine MCP-derived IPs + user-supplied IPs, then run:
+
+```bash
+slv install firewall --allow <ip1> --allow <ip2> -y
+```
+
+`--allow` is repeatable. Order doesn't matter. The CLI dedupes.
+
+**What this does:**
+- Always-open: SSH (22), HTTP (80), HTTPS (443), WireGuard (51820/udp), lo, WG peer subnet 10.0.0.0/24.
+- Whitelist IPs get ALL ports unconditionally.
+- Everything else silently dropped.
+- fail2ban watches sshd: 5 wrong passwords in 10 min → 1 h ban.
+
+### Step 2 — SSH hardening (ADD → VERIFY → DISABLE, in that order)
+
+This order is load-bearing.
+
+**Step 2a — Install the public key.** Ask:
+
+> "Paste your SSH public key. It's a one-line string starting with `ssh-ed25519` or `ssh-rsa` — usually in `~/.ssh/id_ed25519.pub` on your laptop.
+>
+> If you don't have one: run `ssh-keygen -t ed25519` on your laptop first and paste the `.pub` contents here."
+
+Run:
+
+```bash
+slv add:ssh '<the pubkey line>'
+```
+
+**Step 2b — VERIFY in a second terminal.** Tell the user:
+
+> "Open a NEW terminal and try `ssh ubuntu@<this-host-ip>`. If it logs you in without asking for a password, key-based login is working. LEAVE THAT TERMINAL OPEN as a safety net — if the next step goes wrong you can fix it from there."
+
+**Do not proceed until the user confirms this works.** Running
+`slv disable pwd-login` after a bad `slv add:ssh` is how people
+permanently lock themselves out.
+
+**Step 2c — Disable password auth:**
+
+```bash
+slv disable pwd-login
+```
+
+Frame it: "this removes a huge attack surface — password guessing is now impossible."
+
+### Step 3 — Verify + read-back
+
+State the final posture plainly:
+
+```
+🛡  Firewall + SSH locked down:
+  • nftables: default-drop, SSH/HTTP/HTTPS/WireGuard always open
+  • Whitelist: <ips> (all ports)
+  • fail2ban: sshd jail, 5/10m → 1h ban
+  • SSH: password auth OFF, key-only
+```
+
+Offer to back up the ssh key to the user's laptop if they haven't
+already.
+
+If they also want VPN access from their phone, hand off to the
+**slv-wireguard** skill.
+
+---
+
+## Why SSH stays open to the world
+
+Engineer impulse: "whitelist SSH too." Don't. Two reasons:
+
+1. **Non-engineer users on dynamic home IPs lock themselves out.** Their ISP rotates their IP, the firewall rule silently stops matching, they panic. fail2ban + key-only auth is equivalent defense without the foot-gun.
+2. **SSH key auth is already near-unbreakable.** An attacker without the key gets nowhere; an attacker WITH the key would bypass a whitelist (they'd spoof the source IP or tunnel through an allowed host anyway).
+
+Repeat this explanation to every user who asks "why is SSH open?" — it's the #1 security question on this skill.
+
+---
+
+## Reference
+
+### `slv install firewall`
+
+```
+slv install firewall [--allow <ip>]... [-y]
+```
+
+- `--allow <ip>` — repeatable. IPv4 dotted-quad. Gets all-port access.
+- `-y` — skip the confirmation prompt.
+- Idempotent: re-running with a different set **overwrites** the ruleset.
+- Playbook: `template/latest/ansible/cmn/software/install-firewall.yaml`.
+
+### `slv add:ssh`
+
+```
+slv add:ssh '<pubkey line>'
+```
+
+- Appends to `~/.ssh/authorized_keys`. De-dupes.
+
+### `slv disable pwd-login`
+
+```
+slv disable pwd-login
+```
+
+- Sets `PasswordAuthentication no` in sshd config, reloads sshd.
+- **Destructive:** if you haven't verified key login, this locks you out.
+
+---
+
+## Common failure modes + fixes
+
+| User says | Likely cause | Fix |
+|-----------|-------------|-----|
+| "I ran `slv disable pwd-login` and now I'm locked out" | `slv add:ssh` was skipped or pubkey was malformed | Cloud provider rescue console → re-enable password in `/etc/ssh/sshd_config.d/` or fix `authorized_keys` |
+| "My whitelist IP rotated" | Dynamic home IP changed | `slv install firewall --allow <new-ip> [<rest>]` — idempotent rewrite |
+| "fail2ban banned me" | Typed wrong password 5× | `sudo fail2ban-client set sshd unbanip <your-ip>` |
+| "nftables says default-deny but SSH still works" | Expected — SSH is an always-open exception | Not a bug |
+
+---
+
+## Don't do
+
+- Don't disable password auth BEFORE verifying key login works in a second terminal.
+- Don't whitelist `0.0.0.0/0` — it defeats default-deny.
+- Don't auto-add the operator's current SSH source IP — dynamic home IPs rotate.

--- a/dist/oss-skills/slv-firewall/skill.json
+++ b/dist/oss-skills/slv-firewall/skill.json
@@ -1,0 +1,8 @@
+{
+  "name": "slv-firewall",
+  "version": "1.0.0",
+  "description": "nftables firewall + fail2ban + SSH hardening for SLV hosts",
+  "agent": "EL",
+  "author": "ELSOUL LABO B.V.",
+  "tags": ["security", "firewall", "nftables", "fail2ban", "ssh"]
+}

--- a/dist/oss-skills/slv-wireguard/SKILL.md
+++ b/dist/oss-skills/slv-wireguard/SKILL.md
@@ -1,0 +1,169 @@
+# SLV WireGuard Skill
+
+Stand up a WireGuard VPN on the SLV host and pair it with a
+non-engineer user's phone or laptop. Guided pubkey exchange —
+the private key never leaves the phone; the server's private key
+never leaves the VPS.
+
+**Related:** For nftables / fail2ban / SSH hardening, see the
+**slv-firewall** skill. Run that first if you haven't yet — the
+firewall playbook already opens UDP 51820 for WireGuard, so the
+VPN will work out of the box.
+
+Use this skill when the user says anything like:
+
+- "set up the phone VPN" / "WireGuard on my iPhone"
+- "I want to access SLV from my phone securely"
+- "how do I VPN into this box"
+- "can I close the gateway from the public internet?"
+
+---
+
+## EL's walkthrough
+
+### Step 0 — Sanity probe
+
+- `run_command: systemctl is-active wg-quick@wg0 2>/dev/null` — is WG already up?
+- `run_command: command -v wg >/dev/null && wg show 2>&1 | head -20` — current peers, if any.
+- `run_command: ss -lun | grep 51820` — is the server listening?
+
+If WG is already up, read back the current peers and ask whether
+the user wants to add another peer or replace the config.
+
+### Step 1 — Phone side (walk the user through this BEFORE running anything on the server)
+
+Tell the user, verbatim:
+
+> "On your phone:
+> 1. Install the official **WireGuard** app from the App Store / Google Play — it's free, made by the WireGuard project itself, look for the purple dragon logo. (Jason A. Donenfeld / Edge Security publisher.)
+> 2. Open the app, tap the **+** button, pick **Create from scratch**.
+> 3. Give the tunnel a name like `slv-<short-vps-name>` so you can identify it later.
+> 4. The app auto-generates a key pair. Scroll down to the **Public key** field — it's a 44-character string ending in `=`. Tap it to copy.
+>
+> ⚠ Do NOT touch the **Private key** field. That one stays on your phone forever. Pasting it anywhere else (including to me) would invalidate the whole tunnel's security."
+
+Desktop flow is identical: `wireguard` app from https://www.wireguard.com/install/
+→ Add tunnel → From scratch → copy Public key.
+
+Ask them to paste the **public** key.
+
+### Step 2 — Server side
+
+With their public key in hand, run:
+
+```bash
+slv install wireguard --iphone-pubkey '<the-44-char-pubkey>='
+```
+
+The playbook:
+- Installs `wireguard` via apt.
+- Generates (or reuses) the server's key pair at `/etc/wireguard/server_{private,public}.key`.
+- Writes `/etc/wireguard/wg0.conf` with the user's pubkey as the sole peer.
+- Sets up NAT masquerading (iptables POSTROUTING) so phone traffic can exit through the VPS's public interface.
+- `systemctl enable --now wg-quick@wg0`.
+- Exports the server's public key to `/tmp/slv-wg-server-pubkey.txt` (mode 0644) so the CLI can echo it to you without a second sudo.
+
+When the playbook finishes, SLV prints the **server public key**
+in a highlighted block. Copy that.
+
+### Step 3 — Finish the phone-side config
+
+Back on the user's phone, inside the tunnel they started in
+Step 1, tell them:
+
+> "Fill in these fields:
+>
+> **Addresses:** `10.0.0.2/32`
+>
+> **DNS servers:** `1.1.1.1` (or any public resolver)
+>
+> Then tap **Add peer** and fill:
+>
+> - **Public key:** (paste the server key I just showed you)
+> - **Endpoint:** `<this-host-public-ip>:51820`
+> - **Allowed IPs:** choose one:
+>   - `10.0.0.0/24` — **split-tunnel** (only SLV traffic goes through the VPN; faster, keeps your regular phone traffic direct). Recommended for most users.
+>   - `0.0.0.0/0` — **full-tunnel** (ALL phone traffic goes through the VPS; privacy-first, but slower and counts against your phone's perceived IP).
+>
+> Save. Slide the tunnel toggle to ON."
+
+### Step 4 — Verify
+
+Ask the user to try opening `http://10.0.0.1:20026/ui/` on their
+phone while the VPN is on. If the SLV chat UI loads, the VPN
+works — the phone is now reaching the gateway over the tunnel.
+
+If they previously had the gateway in `lan` mode (0.0.0.0 bound),
+suggest flipping back to loopback now:
+
+```bash
+slv gateway config set-mode local
+```
+
+The gateway is no longer directly exposed — only the WireGuard
+peers on 10.0.0.0/24 can reach it. Cloudflare-fronted HTTPS (if
+they ran `slv install nginx`) still works because nginx lives on
+the same box on loopback.
+
+---
+
+## Adding a second peer (new phone, laptop, co-worker)
+
+The current playbook only supports ONE peer at a time —
+re-running `slv install wireguard --iphone-pubkey <new-pubkey>`
+**replaces** the peer list. If the user needs multiple peers (e.g.
+phone + laptop + partner's phone), either:
+
+1. Run the playbook once per peer, and tell them only the
+   most-recently-added peer can connect at a time.
+2. Edit `/etc/wireguard/wg0.conf` manually to add more `[Peer]`
+   blocks and run `sudo wg syncconf wg0 <(wg-quick strip wg0)`.
+
+Proper multi-peer CLI is a future improvement tracked as a
+follow-up — for now flag this limitation if the user asks.
+
+---
+
+## Reference
+
+### `slv install wireguard`
+
+```
+slv install wireguard --iphone-pubkey '<44-char-pubkey>='
+```
+
+- Prompts interactively if `--iphone-pubkey` is missing.
+- Validates the key is 44 base64 chars (23 bytes + 1 char padding) ending in `=`.
+- Playbook: `template/latest/ansible/cmn/software/install-wireguard.yaml`.
+- Idempotent: the server private key is preserved across runs; only the peer list gets rewritten.
+
+### WireGuard apps (non-engineer friendly)
+
+| Platform | App | Link |
+|----------|-----|------|
+| iOS | WireGuard | App Store — search "WireGuard" (purple dragon) |
+| Android | WireGuard | Play Store — search "WireGuard" |
+| macOS | WireGuard | https://www.wireguard.com/install/ or Mac App Store |
+| Windows | WireGuard | https://www.wireguard.com/install/ |
+| Linux | wireguard-tools | `sudo apt install wireguard` + `wg-quick` |
+
+---
+
+## Common failure modes + fixes
+
+| User says | Likely cause | Fix |
+|-----------|-------------|-----|
+| "tunnel's on but I can't reach anything" | Endpoint IP or port wrong on the phone | Double-check `<public-ip>:51820` — `sudo ss -lun \| grep 51820` on the VPS confirms the port |
+| "I copied the wrong key" | Pasted phone's Private key instead of Public | Tell them explicitly: "the *Public* key is the one safe to share" |
+| "connection works but web browsing is broken" | split-tunnel with `10.0.0.0/24` but user wants full-tunnel | Change `Allowed IPs` on the phone to `0.0.0.0/0` |
+| "it worked yesterday, dead today" | VPS's public IP changed | Update **Endpoint** on the phone side to the new IP |
+| "playbook fails `Assert peer public key is present`" | Pasted the wrong string or includes whitespace | Re-copy the exact 44-char line ending in `=`, no extra spaces |
+
+---
+
+## Don't do
+
+- Don't paste the phone's **Private key** anywhere off the phone. Only the Public key travels.
+- Don't share the server's private key (`/etc/wireguard/server_private.key`). Only the public key does.
+- Don't run `slv install wireguard` with an empty or obviously wrong pubkey — the `Assert peer public key is present and well-formed` task will fail, but the server's *existing* key pair survives (so re-running with a valid key is safe).
+- Don't whitelist the WireGuard UDP port on nftables to "only your IP" — phones on mobile networks have highly dynamic IPs; the port needs to be reachable from the world. Token-auth + peer-pubkey-auth already gates who can actually use the tunnel.

--- a/dist/oss-skills/slv-wireguard/skill.json
+++ b/dist/oss-skills/slv-wireguard/skill.json
@@ -1,0 +1,8 @@
+{
+  "name": "slv-wireguard",
+  "version": "1.0.0",
+  "description": "WireGuard VPN setup for SLV hosts — phone / laptop peers with guided pubkey exchange",
+  "agent": "EL",
+  "author": "ELSOUL LABO B.V.",
+  "tags": ["security", "vpn", "wireguard", "mobile"]
+}

--- a/sh/install
+++ b/sh/install
@@ -200,7 +200,7 @@ install_skills() {
 
   SKILLS_REPO_URL="https://raw.githubusercontent.com/ValidatorsDAO/slv/main/dist/oss-skills"
 
-  for SKILL in slv-validator slv-rpc slv-grpc-geyser slv-benchmark slv-app slv-server-procurement slv-backup; do
+  for SKILL in slv-validator slv-rpc slv-grpc-geyser slv-benchmark slv-app slv-bot-trade-app slv-server-procurement slv-backup slv-firewall slv-wireguard; do
     echo "Downloading $SKILL..."
     SKILL_DIR="$SKILLS_DIR/$SKILL"
     mkdir -p "$SKILL_DIR"


### PR DESCRIPTION
## Summary
- After `slv upgrade`, `~/.slv/skills/` never received the new `slv-firewall` / `slv-wireguard` skills, so the gateway Web UI could not surface them. Two layers were broken:
  1. `SKILL_NAMES` in `cli/src/skills/syncSkills.ts` and the loop in `sh/install:203` didn't list the new skills
  2. `dist/oss-skills/` (what the installer curls from) didn't contain them
- Also fixes a pre-existing silent 404 on `slv-benchmark` (was in `SKILL_NAMES` but missing from `dist/oss-skills/`) and drift between the sh installer list and `SKILL_NAMES` (missing `slv-bot-trade-app`).

## Effect
After merge + `slv upgrade` on a target VPS:
- `~/.slv/skills/slv-firewall/SKILL.md`, `.../slv-wireguard/SKILL.md`, `.../slv-benchmark/SKILL.md` all present
- Gateway Web UI picks them up on the next WebSocket message — system prompt rebuilds from disk each `session.send`, so no gateway restart needed

## Test plan
- [x] `deno check cli/src/skills/syncSkills.ts` — type-check passes
- [x] All dist files present + non-empty
- [ ] Post-merge: run `slv upgrade` on a test VPS, verify `ls ~/.slv/skills/` contains the three new entries
- [ ] Open the chat UI, confirm EL is aware of the firewall + wireguard skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)