### PR TITLE
fix(skills): remove Japanese prose from skill markdowns

### DIFF
--- a/dist/oss-skills/slv-firewall/SKILL.md
+++ b/dist/oss-skills/slv-firewall/SKILL.md
@@ -47,23 +47,25 @@ support ticket (self-lockout from a rotating home IP).
 
 Ask, in plain language:
 
-> "自宅やスマホからこのサーバーに入る方法として、どちらを使いたい
-> ですか? 非エンジニアの方なら 1 を強くおすすめします。
+> "How do you want to reach this server from home / your phone?
+> For non-engineers we strongly recommend option 1.
 >
-> 1. **WireGuard VPN**（推奨）— スマホでも PC でも、どのデバイス
->    からでも対応します。VPN に繋ぐと、サーバーから見た接続元の
->    IP が『いつも同じ固定の IP』になります。ファイアウォールには
->    その固定 IP 1 つを登録すればいいので、家のルーターの IP がど
->    れだけ変わっても関係なくアクセスでき、しかも他の人は入れない
->    状態にできます。安心かつ日常使いでもラクです。
+> 1. **WireGuard VPN** (recommended) — works on any device (phone,
+>    desktop, laptop — all supported). Once you connect to the
+>    VPN, the server sees your traffic as coming from the same
+>    fixed IP every time. The firewall only has to allow that one
+>    IP, so it stops mattering how often your home router's IP
+>    rotates, and nobody else can get in. Safe and low-friction
+>    for everyday use.
 >
-> 2. **固定の公衆 IP を whitelist** — 会社のビジネス回線など、
->    『何があっても変わらない』と分かっている IP があればそれを
->    登録します。**家庭のインターネット回線の IP は ISP の都合で
->    数日〜数週間で変わるので、これを登録すると後日閉め出されま
->    す**。固定と明言できる IP 以外は登録しないでください。
+> 2. **Whitelist a fixed public IP** — if you have a business
+>    line / office address with a guaranteed-stable IP, register
+>    that. **Home internet IPs rotate every few days or weeks
+>    depending on the ISP, so whitelisting one will lock you out
+>    later.** Only register an IP you can personally guarantee is
+>    static.
 >
-> 3. **両方** — 固定 IP も登録しつつ、VPN も用意する。"
+> 3. **Both** — whitelist your static IP AND set up VPN."
 
 **Default recommendation: option 1.** If the user picks 1 or is
 unsure, proceed with firewall install WITHOUT any `--allow` IPs,
@@ -92,9 +94,9 @@ fail2ban-protected) and via WG once it's up.
 
 After the firewall install succeeds, and BEFORE SSH hardening:
 
-> "ファイアウォールは有効化できました。次は VPN を用意します。
-> **slv-wireguard** スキルに切り替えます — VPN 用の VPS を別で
-> 持っていないと進められないので、そこから確認します。"
+> "Firewall is live. Now let's set up the VPN. I'll switch to
+> the **slv-wireguard** skill — we can't proceed without a
+> separate VPS dedicated to the VPN, so we'll check that first."
 
 Invoke the slv-wireguard skill. It will (a) check whether the user
 has a dedicated core1 VPS for the VPN or needs to buy one, and

--- a/dist/oss-skills/slv-wireguard/SKILL.md
+++ b/dist/oss-skills/slv-wireguard/SKILL.md
@@ -26,13 +26,14 @@ Use this skill when the user says anything like:
 Before anything, make sure the user is installing WG on the **right
 box**. Explain this in plain language:
 
-> "WireGuard は『VPN の出口』専用の小さい VPS に建てるのがおすすめです。
-> 理由は 2 つ:
-> 1. 普段使っている本番機（validator とか SLV chat を動かしてる箱）と
->    同居させると、その本番機が落ちたとき VPN で入り直せないので
->    復旧が一気に大変になります。
-> 2. VPN は『ポートを待って転送するだけ』なので、いちばん安い core1
->    プランの VPS で十分。専用に 1 台用意しても負担は小さいです。"
+> "We recommend installing WireGuard on a small VPS dedicated to
+> being the VPN endpoint. Two reasons:
+> 1. If you put it on your main production box (the one running
+>    your validator / SLV chat), then when that box crashes you
+>    can't VPN back in to fix it — recovery gets a lot harder.
+> 2. A VPN server only sits there forwarding packets, so the
+>    cheapest **core1** plan is more than enough. A dedicated box
+>    is a small monthly cost."
 
 Then branch on what the user has. Fire the MCP probes in parallel to
 see their VPS inventory:
@@ -48,11 +49,11 @@ Good. Continue to Step 1 on THAT host (not on their main box).
 Strongly recommend buying a dedicated core1 VPS for the VPN endpoint.
 Tell them verbatim, non-engineer friendly:
 
-> "まず VPN 専用の VPS を 1 台用意してください。
-> - https://dashboard.erpc.global にログインして、core1 プランを
->   1 台買ってください。月額の負担は小さいです。
-> - 購入が完了したら、また『VPN 設定したい』と声をかけてください。
->   続きをこちらで案内します。"
+> "First, grab a VPS dedicated to the VPN.
+> - Log in at https://dashboard.erpc.global and buy one **core1**
+>   plan VPS. It's a small monthly cost.
+> - Once the purchase is done, come back and say `set up the VPN`
+>   again — I'll pick it up from here."
 
 STOP the WG flow here. Don't try to install on the production box as
 a workaround — the goal is isolation.
@@ -65,10 +66,11 @@ They have two paths:
    they already control), ask them for that IP and hand off to the
    **slv-firewall** skill with `--allow <that-ip>`.
 2. **Home ISP IP** — **refuse this**. Tell them explicitly:
-   > "家のルーターの IP は ISP の都合で数日〜数週間で変わります。
-   > 変わった瞬間に firewall で閉め出されて、現地に行かないと直せ
-   > なくなります。固定 IP でなければ WireGuard のほうが結局ラク
-   > なので、VPN 用 VPS を買う案を再度おすすめします。"
+   > "Home router IPs rotate every few days or weeks depending on
+   > the ISP. The moment it changes, the firewall locks you out
+   > and you need physical access to fix it. If you can't name a
+   > fixed IP, WireGuard ends up being easier overall — I'd
+   > recommend going back and buying the dedicated VPN VPS."
 
 Only proceed to Step 1 below once the user is on a dedicated VPN VPS
 (Case A, or Case B after purchase).

--- a/oss-skills/slv-firewall/SKILL.md
+++ b/oss-skills/slv-firewall/SKILL.md
@@ -47,23 +47,25 @@ support ticket (self-lockout from a rotating home IP).
 
 Ask, in plain language:
 
-> "自宅やスマホからこのサーバーに入る方法として、どちらを使いたい
-> ですか? 非エンジニアの方なら 1 を強くおすすめします。
+> "How do you want to reach this server from home / your phone?
+> For non-engineers we strongly recommend option 1.
 >
-> 1. **WireGuard VPN**（推奨）— スマホでも PC でも、どのデバイス
->    からでも対応します。VPN に繋ぐと、サーバーから見た接続元の
->    IP が『いつも同じ固定の IP』になります。ファイアウォールには
->    その固定 IP 1 つを登録すればいいので、家のルーターの IP がど
->    れだけ変わっても関係なくアクセスでき、しかも他の人は入れない
->    状態にできます。安心かつ日常使いでもラクです。
+> 1. **WireGuard VPN** (recommended) — works on any device (phone,
+>    desktop, laptop — all supported). Once you connect to the
+>    VPN, the server sees your traffic as coming from the same
+>    fixed IP every time. The firewall only has to allow that one
+>    IP, so it stops mattering how often your home router's IP
+>    rotates, and nobody else can get in. Safe and low-friction
+>    for everyday use.
 >
-> 2. **固定の公衆 IP を whitelist** — 会社のビジネス回線など、
->    『何があっても変わらない』と分かっている IP があればそれを
->    登録します。**家庭のインターネット回線の IP は ISP の都合で
->    数日〜数週間で変わるので、これを登録すると後日閉め出されま
->    す**。固定と明言できる IP 以外は登録しないでください。
+> 2. **Whitelist a fixed public IP** — if you have a business
+>    line / office address with a guaranteed-stable IP, register
+>    that. **Home internet IPs rotate every few days or weeks
+>    depending on the ISP, so whitelisting one will lock you out
+>    later.** Only register an IP you can personally guarantee is
+>    static.
 >
-> 3. **両方** — 固定 IP も登録しつつ、VPN も用意する。"
+> 3. **Both** — whitelist your static IP AND set up VPN."
 
 **Default recommendation: option 1.** If the user picks 1 or is
 unsure, proceed with firewall install WITHOUT any `--allow` IPs,
@@ -92,9 +94,9 @@ fail2ban-protected) and via WG once it's up.
 
 After the firewall install succeeds, and BEFORE SSH hardening:
 
-> "ファイアウォールは有効化できました。次は VPN を用意します。
-> **slv-wireguard** スキルに切り替えます — VPN 用の VPS を別で
-> 持っていないと進められないので、そこから確認します。"
+> "Firewall is live. Now let's set up the VPN. I'll switch to
+> the **slv-wireguard** skill — we can't proceed without a
+> separate VPS dedicated to the VPN, so we'll check that first."
 
 Invoke the slv-wireguard skill. It will (a) check whether the user
 has a dedicated core1 VPS for the VPN or needs to buy one, and

--- a/oss-skills/slv-wireguard/SKILL.md
+++ b/oss-skills/slv-wireguard/SKILL.md
@@ -26,13 +26,14 @@ Use this skill when the user says anything like:
 Before anything, make sure the user is installing WG on the **right
 box**. Explain this in plain language:
 
-> "WireGuard は『VPN の出口』専用の小さい VPS に建てるのがおすすめです。
-> 理由は 2 つ:
-> 1. 普段使っている本番機（validator とか SLV chat を動かしてる箱）と
->    同居させると、その本番機が落ちたとき VPN で入り直せないので
->    復旧が一気に大変になります。
-> 2. VPN は『ポートを待って転送するだけ』なので、いちばん安い core1
->    プランの VPS で十分。専用に 1 台用意しても負担は小さいです。"
+> "We recommend installing WireGuard on a small VPS dedicated to
+> being the VPN endpoint. Two reasons:
+> 1. If you put it on your main production box (the one running
+>    your validator / SLV chat), then when that box crashes you
+>    can't VPN back in to fix it — recovery gets a lot harder.
+> 2. A VPN server only sits there forwarding packets, so the
+>    cheapest **core1** plan is more than enough. A dedicated box
+>    is a small monthly cost."
 
 Then branch on what the user has. Fire the MCP probes in parallel to
 see their VPS inventory:
@@ -48,11 +49,11 @@ Good. Continue to Step 1 on THAT host (not on their main box).
 Strongly recommend buying a dedicated core1 VPS for the VPN endpoint.
 Tell them verbatim, non-engineer friendly:
 
-> "まず VPN 専用の VPS を 1 台用意してください。
-> - https://dashboard.erpc.global にログインして、core1 プランを
->   1 台買ってください。月額の負担は小さいです。
-> - 購入が完了したら、また『VPN 設定したい』と声をかけてください。
->   続きをこちらで案内します。"
+> "First, grab a VPS dedicated to the VPN.
+> - Log in at https://dashboard.erpc.global and buy one **core1**
+>   plan VPS. It's a small monthly cost.
+> - Once the purchase is done, come back and say `set up the VPN`
+>   again — I'll pick it up from here."
 
 STOP the WG flow here. Don't try to install on the production box as
 a workaround — the goal is isolation.
@@ -65,10 +66,11 @@ They have two paths:
    they already control), ask them for that IP and hand off to the
    **slv-firewall** skill with `--allow <that-ip>`.
 2. **Home ISP IP** — **refuse this**. Tell them explicitly:
-   > "家のルーターの IP は ISP の都合で数日〜数週間で変わります。
-   > 変わった瞬間に firewall で閉め出されて、現地に行かないと直せ
-   > なくなります。固定 IP でなければ WireGuard のほうが結局ラク
-   > なので、VPN 用 VPS を買う案を再度おすすめします。"
+   > "Home router IPs rotate every few days or weeks depending on
+   > the ISP. The moment it changes, the firewall locks you out
+   > and you need physical access to fix it. If you can't name a
+   > fixed IP, WireGuard ends up being easier overall — I'd
+   > recommend going back and buying the dedicated VPN VPS."
 
 Only proceed to Step 1 below once the user is on a dedicated VPN VPS
 (Case A, or Case B after purchase).


### PR DESCRIPTION
## Summary
- Skill source markdowns are English-only by repo convention; Japanese belongs only in the i18n tables under \`cli/src/ai/i18n/messages/\`
- slv-firewall and slv-wireguard SKILL.md had Japanese verbatim prompts embedded (my #324 mistake — I wrote them in JP directly). Non-JP locales were getting JP prose verbatim, which is broken
- Rewrote all the user-facing verbatim blocks back to English; EL translates to the user's chosen locale at runtime

## Files touched
- \`oss-skills/slv-firewall/SKILL.md\` + \`dist/oss-skills/slv-firewall/SKILL.md\`
- \`oss-skills/slv-wireguard/SKILL.md\` + \`dist/oss-skills/slv-wireguard/SKILL.md\`

## Test plan
- [x] \`grep -r '[ぁ-んァ-ン一-龯]' oss-skills/\` returns zero matches
- [ ] Post-merge: \`slv skills sync\` on the VPS, verify the English content pulls through

🤖 Generated with [Claude Code](https://claude.com/claude-code)