### PR TITLE
feat(dns): slv dns delete — remove a record via cloud MCP

### DIFF
--- a/cli/lib/slvCloudMcp.ts
+++ b/cli/lib/slvCloudMcp.ts
@@ -170,19 +170,18 @@ export const setDnsRecord = async (
 export type DnsDeleteSuccessResponse = {
   success: true
   fqdn: string
-  slug: string
-  message: string
+  // Absent when deleting the free default (server may omit).
+  slug?: string
+  message?: string
 }
 
 export type DnsDeleteResult =
   | { ok: true; data: DnsDeleteSuccessResponse }
-  | { ok: false; status: number; body: DnsApiError | null }
+  | { ok: false; kind: 'tool_not_found'; status: number; body: DnsApiError | null }
+  | { ok: false; kind: 'error'; status: number; body: DnsApiError | null }
 
-/**
- * Delete one of the caller's DNS records. Omit `slug` to target the
- * free default subdomain; pass `slug` for a custom record. Server
- * decides whether "delete" means unset the IP or release the slug.
- */
+// Server decides whether "delete" means unset the IP or release the
+// slug — wrapper passes args through as-is.
 export const deleteDnsRecord = async (
   apiKey: string,
   opts: { slug?: string } = {},
@@ -195,19 +194,37 @@ export const deleteDnsRecord = async (
     args,
   )
   if (r.ok) return { ok: true, data: r.data }
-  return { ok: false, status: r.status, body: r.body }
+  // Disambiguate "server doesn't know this tool" from "record not
+  // found" so the user gets an actionable error rather than a
+  // misleading "No record found."
+  const errCode = (r.body?.error ?? '').toString().toLowerCase()
+  if (
+    r.status === 404 &&
+    (errCode === 'tool_not_found' ||
+      errCode === 'unknown_tool' ||
+      errCode === 'method_not_found')
+  ) {
+    return { ok: false, kind: 'tool_not_found', status: r.status, body: r.body }
+  }
+  return { ok: false, kind: 'error', status: r.status, body: r.body }
 }
 
-/** Human-readable explanation for the common DNS delete errors. */
 export const explainDnsDeleteError = (result: {
+  kind?: 'tool_not_found' | 'error'
   status: number
   body: DnsApiError | null
 }): string => {
+  if (result.kind === 'tool_not_found') {
+    return 'The SLV Cloud MCP does not expose a DNS delete tool yet — update your server / CLI or delete from https://dashboard.erpc.global.'
+  }
   const err = result.body?.error ?? ''
   const msg = result.body?.message ?? ''
   switch (result.status) {
     case 401:
       return 'SLV API key missing or invalid — run `slv login`.'
+    case 402:
+      return msg ||
+        'Deleting a custom slug requires a paid subscription (not yet launched).'
     case 403:
       if (err === 'not_owner') {
         return msg || 'That slug is owned by another user.'

--- a/cli/lib/slvCloudMcp.ts
+++ b/cli/lib/slvCloudMcp.ts
@@ -167,6 +167,61 @@ export const setDnsRecord = async (
   return { ok: false, status: r.status, body: r.body }
 }
 
+export type DnsDeleteSuccessResponse = {
+  success: true
+  fqdn: string
+  slug: string
+  message: string
+}
+
+export type DnsDeleteResult =
+  | { ok: true; data: DnsDeleteSuccessResponse }
+  | { ok: false; status: number; body: DnsApiError | null }
+
+/**
+ * Delete one of the caller's DNS records. Omit `slug` to target the
+ * free default subdomain; pass `slug` for a custom record. Server
+ * decides whether "delete" means unset the IP or release the slug.
+ */
+export const deleteDnsRecord = async (
+  apiKey: string,
+  opts: { slug?: string } = {},
+): Promise<DnsDeleteResult> => {
+  const args: Record<string, unknown> = {}
+  if (opts.slug) args.slug = opts.slug
+  const r = await callMcpTool<DnsDeleteSuccessResponse>(
+    apiKey,
+    'delete_dns_delete',
+    args,
+  )
+  if (r.ok) return { ok: true, data: r.data }
+  return { ok: false, status: r.status, body: r.body }
+}
+
+/** Human-readable explanation for the common DNS delete errors. */
+export const explainDnsDeleteError = (result: {
+  status: number
+  body: DnsApiError | null
+}): string => {
+  const err = result.body?.error ?? ''
+  const msg = result.body?.message ?? ''
+  switch (result.status) {
+    case 401:
+      return 'SLV API key missing or invalid — run `slv login`.'
+    case 403:
+      if (err === 'not_owner') {
+        return msg || 'That slug is owned by another user.'
+      }
+      return msg || 'Forbidden.'
+    case 404:
+      return msg || 'No record found to delete.'
+    case 400:
+      return msg || 'Bad request.'
+    default:
+      return msg || `DNS delete failed with status ${result.status}.`
+  }
+}
+
 /** Human-readable explanation for the common DNS set errors. */
 export const explainDnsSetError = (result: {
   status: number

--- a/cli/src/dns/index.ts
+++ b/cli/src/dns/index.ts
@@ -2,6 +2,8 @@ import { Command } from '@cliffy'
 import { Confirm } from '@cliffy/prompt'
 import { colors } from '@cliffy/colors'
 import {
+  deleteDnsRecord,
+  explainDnsDeleteError,
   explainDnsSetError,
   getDnsStatus,
   setDnsRecord,
@@ -150,3 +152,41 @@ dnsCmd.command('set')
       )
     },
   )
+
+dnsCmd.command('delete')
+  .description(
+    'Delete a DNS record. Omit --slug to target your free default subdomain; pass --slug for a custom one. Destructive — the record stops resolving immediately.',
+  )
+  .option('--slug <slug:string>', 'Custom slug to delete (omit for the default)')
+  .option('-y, --yes', 'Skip the confirmation prompt', { default: false })
+  .action(async (opts: { slug?: string; yes?: boolean }) => {
+    const apiKey = await readSlvApiKey()
+    if (!apiKey) {
+      console.error(
+        colors.red('❌ no SLV API key — run `slv login` first.'),
+      )
+      Deno.exit(1)
+    }
+
+    const target = opts.slug
+      ? `${opts.slug}.erpc.global`
+      : 'your default <slug>.erpc.global'
+
+    if (!opts.yes) {
+      const ok = await Confirm.prompt({
+        message: colors.yellow(`⚠  Delete ${target}? This is permanent.`),
+        default: false,
+      })
+      if (!ok) {
+        console.log(colors.gray('cancelled.'))
+        return
+      }
+    }
+
+    const result = await deleteDnsRecord(apiKey, { slug: opts.slug })
+    if (!result.ok) {
+      console.error(colors.red(`❌ ${explainDnsDeleteError(result)}`))
+      Deno.exit(1)
+    }
+    console.log(colors.green(`✅ ${result.data.fqdn} deleted.`))
+  })

--- a/cli/src/dns/index.ts
+++ b/cli/src/dns/index.ts
@@ -11,12 +11,16 @@ import {
 import { getApiKeyFromYml } from '/lib/getApiKeyFromYml.ts'
 import { resolvePublicIp } from '/lib/publicIp.ts'
 
-const readSlvApiKey = async (): Promise<string | null> => {
+const requireSlvApiKey = async (): Promise<string> => {
+  let key: string | null = null
   try {
-    return await getApiKeyFromYml(true)
-  } catch {
-    return null
+    key = await getApiKeyFromYml(true)
+  } catch { /* treat as missing */ }
+  if (!key) {
+    console.error(colors.red('❌ no SLV API key — run `slv login` first.'))
+    Deno.exit(1)
   }
+  return key
 }
 
 /**
@@ -35,13 +39,7 @@ dnsCmd.command('status')
     'Show the caller\'s DNS state: the default `<slug>.erpc.global` subdomain and any paid custom slugs, with the IP they currently point at.',
   )
   .action(async () => {
-    const apiKey = await readSlvApiKey()
-    if (!apiKey) {
-      console.error(
-        colors.red('❌ no SLV API key — run `slv login` first.'),
-      )
-      Deno.exit(1)
-    }
+    const apiKey = await requireSlvApiKey()
     const result = await getDnsStatus(apiKey)
     if (!result.ok) {
       if (result.status === 401) {
@@ -95,13 +93,7 @@ dnsCmd.command('set')
       proxied?: boolean
       yes?: boolean
     }) => {
-      const apiKey = await readSlvApiKey()
-      if (!apiKey) {
-        console.error(
-          colors.red('❌ no SLV API key — run `slv login` first.'),
-        )
-        Deno.exit(1)
-      }
+      const apiKey = await requireSlvApiKey()
 
       let ip = opts.ip
       if (!ip) {
@@ -160,13 +152,7 @@ dnsCmd.command('delete')
   .option('--slug <slug:string>', 'Custom slug to delete (omit for the default)')
   .option('-y, --yes', 'Skip the confirmation prompt', { default: false })
   .action(async (opts: { slug?: string; yes?: boolean }) => {
-    const apiKey = await readSlvApiKey()
-    if (!apiKey) {
-      console.error(
-        colors.red('❌ no SLV API key — run `slv login` first.'),
-      )
-      Deno.exit(1)
-    }
+    const apiKey = await requireSlvApiKey()
 
     const target = opts.slug
       ? `${opts.slug}.erpc.global`


### PR DESCRIPTION
## Summary
- Adds the missing DELETE verb mirroring \`DELETE /v3/dns/delete\` on the erpc user-api / \`delete_dns_delete\` MCP tool
- Shape matches existing \`get_dns_status\` / \`post_dns_set\` wrappers — typed result union, explain-error helper, CLI subcommand with confirm

## CLI usage
\`\`\`bash
# Delete the free default subdomain
slv dns delete

# Delete a specific custom slug
slv dns delete --slug myapp

# Skip the confirm
slv dns delete --slug myapp -y
\`\`\`

Confirm defaults to **no** — delete is destructive and immediate.

## Why
A user wanting to rebuild a VPS from scratch has no way today to drop the existing DNS record without the dashboard UI. This closes that gap.

## Test plan
- [x] \`deno check\` — type-check green
- [ ] Post-merge: run \`slv dns delete\` on a test slug, verify the record disappears from \`slv dns status\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)