### PR TITLE
feat(el): surface firewall + WG skills; show slv version in UI header

### DIFF
--- a/cli/src/ai/console/systemPrompt.ts
+++ b/cli/src/ai/console/systemPrompt.ts
@@ -335,6 +335,22 @@ async function buildCorePrompt(userContext?: string): Promise<string> {
     )
   } catch { /* skill not synced yet — Core Rules line still applies */ }
 
+  // EL-owned operational skills: firewall + WireGuard. These aren't
+  // delegated to a specialist agent — EL walks the user through them
+  // directly, so the full SKILL.md has to be in the main prompt.
+  let firewallSkillMd = ''
+  try {
+    firewallSkillMd = await Deno.readTextFile(
+      resolveSkillMdPath('slv-firewall', home),
+    )
+  } catch { /* not synced yet */ }
+  let wireguardSkillMd = ''
+  try {
+    wireguardSkillMd = await Deno.readTextFile(
+      resolveSkillMdPath('slv-wireguard', home),
+    )
+  } catch { /* not synced yet */ }
+
   // Detect the user's primary focus (validator / rpc / app / mixed) so the
   // main agent can bias its proactive suggestions. See profile.ts for the
   // exact signal hierarchy.
@@ -463,6 +479,8 @@ ${
   ${DISCORD_LINK}
 
 ${backupSkillMd ? `## Backup & Storage (non-interactive reference)\n${backupSkillMd}\n` : ''}
+${firewallSkillMd ? `## Firewall (EL walkthrough)\n${firewallSkillMd}\n` : ''}
+${wireguardSkillMd ? `## WireGuard VPN (EL walkthrough)\n${wireguardSkillMd}\n` : ''}
 ## Working Environment
 - Home: ${home}
 - Agent dir: ${agentDir}/

--- a/cli/src/gateway/ui/static.ts
+++ b/cli/src/gateway/ui/static.ts
@@ -1,6 +1,7 @@
 import { GATEWAY_PROTOCOL_VERSION } from '/src/gateway/paths.ts'
 import type { GatewayMode } from '/src/gateway/config.ts'
 import { initI18n, t } from '/src/ai/i18n/index.ts'
+import { VERSION } from '@cmn/constants/version.ts'
 
 export type RenderOptions = {
   /**
@@ -128,6 +129,7 @@ export const renderChatHtml = async (opts: RenderOptions): Promise<string> => {
     border-radius: 4px;
   }
   header .badge.lan { background: #3d3218; color: #ffdf7a; }
+  header .badge.version { background: #1d2a38; color: #7a9abb; }
   header #clear {
     background: transparent;
     color: var(--muted);
@@ -398,6 +400,7 @@ export const renderChatHtml = async (opts: RenderOptions): Promise<string> => {
 <header>
   <span class="title">🌐 SLV Chat</span>
   <span class="badge ${opts.mode}">${opts.mode}</span>
+  <span class="badge version">v${VERSION}</span>
   <button id="clear" type="button" title="${html.clearTitle}">${html.clear}</button>
   <span id="status" class="status">${clientI18n.connecting}</span>
 </header>


### PR DESCRIPTION
## Summary
- **Bug fix**: EL didn't recognize slv-firewall / slv-wireguard skills. Root cause: the agent-config loader's auto-enable path only handles specialist agents (Cecil/Tina/Setzer/Figaro/Cid); EL has no registry entry. Skills tagged \`"agent": "EL"\` in their \`skill.json\` were being read but never surfaced. Fix: inject \`slv-firewall/SKILL.md\` + \`slv-wireguard/SKILL.md\` directly into the main prompt, matching the pattern \`slv-backup\` already uses. EL now knows about these skills and can guide the user through them.
- **UX**: the Web UI header now displays the running slv version as a small badge (next to the mode badge). Makes binary-vs-gateway-process drift visible at a glance.

## User-facing effect
Before:
> User: ファイアウォールのスキルある？
> EL: ファイアウォール専用のスキルは今のところ持ってないです…

After:
> User: ファイアウォールのスキルある？
> EL: はい、slv-firewall スキルで nftables + fail2ban + SSH hardening をセットで導入できます…

## Test plan
- [x] \`deno check\` — type-check green
- [ ] Post-merge: \`slv upgrade\` on a VPS, open chat UI, ask "do you have a firewall skill" → EL now confirms and walks through
- [ ] Verify version badge renders in the UI header

🤖 Generated with [Claude Code](https://claude.com/claude-code)