### PR TITLE
fix(dns-delete): correct MCP tool name

### DIFF
--- a/cli/lib/slvCloudMcp.ts
+++ b/cli/lib/slvCloudMcp.ts
@@ -190,7 +190,7 @@ export const deleteDnsRecord = async (
   if (opts.slug) args.slug = opts.slug
   const r = await callMcpTool<DnsDeleteSuccessResponse>(
     apiKey,
-    'delete_dns_delete',
+    'delete_dns',
     args,
   )
   if (r.ok) return { ok: true, data: r.data }


### PR DESCRIPTION
## Summary
- \`slv dns delete\` failed with \`Unknown tool: delete_dns_delete\`. The MCP registry actually names it \`delete_dns\` (HTTP verb + path without the redundant terminal "delete"). Confirmed via \`tools/list\`.
- One-char fix; the \`tool_not_found\` fallback I added in the simplify pass correctly covered this case but the user had already pasted their API key to diagnose — flagged for key rotation.

## Test plan
- [x] \`curl tools/list\` confirms \`delete_dns\` is registered
- [ ] Post-merge: \`slv upgrade\` → \`slv dns delete --slug <s>\` on a disposable slug → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)