### PR TITLE
docs(onboard): shorten 'ask AI for security setup' prompt

### DIFF
--- a/cli/src/ai/i18n/messages/en.ts
+++ b/cli/src/ai/i18n/messages/en.ts
@@ -369,8 +369,8 @@ export const messages: Record<string, string> = {
   'Creating support ticket...': 'Creating support ticket...',
   'Ticket creation failed: {err}': 'Ticket creation failed: {err}',
   'Ticket opened. Follow up here:': 'Ticket opened. Follow up here:',
-  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall (nftables) and WireGuard (with the app on your phone). The conversation happens right there — no terminal needed.':
-    'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall (nftables) and WireGuard (with the app on your phone). The conversation happens right there — no terminal needed.',
+  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall. The conversation happens right there — no terminal needed.':
+    'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall. The conversation happens right there — no terminal needed.',
   'For automatic HTTPS + a free *.erpc.global subdomain, run SLV on an SLV VPS or BareMetal (provision via the dashboard):':
     'For automatic HTTPS + a free *.erpc.global subdomain, run SLV on an SLV VPS or BareMetal (provision via the dashboard):',
   'Gateway is already running.': 'Gateway is already running.',
@@ -378,8 +378,8 @@ export const messages: Record<string, string> = {
     'Enable remote IP access (recommended for VPS)?',
   'Binds the gateway to 0.0.0.0 so you can open http://<server-ip>:{port}/ui/ directly from your phone/laptop. Token auth still gates every chat action.':
     'Binds the gateway to 0.0.0.0 so you can open http://<server-ip>:{port}/ui/ directly from your phone/laptop. Token auth still gates every chat action.',
-  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Video walkthrough: coming soon.':
-    'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Video walkthrough: coming soon.',
+  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall. Video walkthrough: coming soon.':
+    'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall. Video walkthrough: coming soon.',
   'Enable remote IP access now?': 'Enable remote IP access now?',
   'Remote IP access enabled — gateway restarted.':
     'Remote IP access enabled — gateway restarted.',
@@ -394,8 +394,8 @@ export const messages: Record<string, string> = {
   'Open SLV in your browser:': 'Open SLV in your browser:',
   'Gateway token (paste on first visit):':
     'Gateway token (paste on first visit):',
-  'Security: ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Run `slv c` to start.':
-    'Security: ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Run `slv c` to start.',
+  'Security: ask SLV AI to help you set up the firewall. Run `slv c` to start.':
+    'Security: ask SLV AI to help you set up the firewall. Run `slv c` to start.',
   'Video walkthrough: coming soon.': 'Video walkthrough: coming soon.',
   'Loopback-only mode — open the URL from elsewhere via SSH tunnel first:':
     'Loopback-only mode — open the URL from elsewhere via SSH tunnel first:',

--- a/cli/src/ai/i18n/messages/ja.ts
+++ b/cli/src/ai/i18n/messages/ja.ts
@@ -346,8 +346,8 @@ export const messages: Record<string, string> = {
   'Creating support ticket...': 'サポートチケットを作成中…',
   'Ticket creation failed: {err}': 'チケット作成に失敗しました: {err}',
   'Ticket opened. Follow up here:': 'チケットを作成しました。こちらで確認してください:',
-  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall (nftables) and WireGuard (with the app on your phone). The conversation happens right there — no terminal needed.':
-    'セキュリティ: 上記の URL をタップしてブラウザで SLV AI を開き、そのまま「ファイアウォール（nftables）とスマホで WireGuard の設定を手伝って」と頼んでください。ターミナル不要、チャット画面だけで進められます。',
+  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall. The conversation happens right there — no terminal needed.':
+    'セキュリティ: 上記の URL をタップしてブラウザで SLV AI を開き、そのまま「ファイアウォールの設定を手伝って」と頼んでください。ターミナル不要、チャット画面だけで進められます。',
   'For automatic HTTPS + a free *.erpc.global subdomain, run SLV on an SLV VPS or BareMetal (provision via the dashboard):':
     'HTTPS と無料の *.erpc.global サブドメインを自動で使うには、SLV VPS または BareMetal 上で SLV を動かしてください（ダッシュボードから調達できます）:',
   'Gateway is already running.': 'ゲートウェイは既に稼働中です。',
@@ -355,8 +355,8 @@ export const messages: Record<string, string> = {
     'IP でのリモートアクセスを有効にしますか？（VPS 推奨）',
   'Binds the gateway to 0.0.0.0 so you can open http://<server-ip>:{port}/ui/ directly from your phone/laptop. Token auth still gates every chat action.':
     'ゲートウェイを 0.0.0.0 に bind して、スマホやノート PC から直接 http://<server-ip>:{port}/ui/ を開けるようにします。チャットはすべてトークン認証でガードされます。',
-  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Video walkthrough: coming soon.':
-    '次のステップ: オンボードが完了したら `slv c` を実行して、SLV AI にファイアウォール（nftables）とスマホでの WireGuard 設定を手伝ってもらいましょう。動画解説は後日公開予定。',
+  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall. Video walkthrough: coming soon.':
+    '次のステップ: オンボードが完了したら `slv c` を実行して、SLV AI にファイアウォールの設定を手伝ってもらいましょう。動画解説は後日公開予定。',
   'Enable remote IP access now?': '今すぐリモート IP アクセスを有効にしますか？',
   'Remote IP access enabled — gateway restarted.':
     'リモート IP アクセスを有効化 — ゲートウェイを再起動しました。',
@@ -372,8 +372,8 @@ export const messages: Record<string, string> = {
   'Open SLV in your browser:': 'ブラウザから SLV を開けます:',
   'Gateway token (paste on first visit):':
     'ゲートウェイトークン（初回アクセス時に貼り付け）:',
-  'Security: ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Run `slv c` to start.':
-    'セキュリティ: `slv c` を実行して、SLV AI にファイアウォール（nftables）とスマホでの WireGuard 設定を手伝ってもらいましょう。',
+  'Security: ask SLV AI to help you set up the firewall. Run `slv c` to start.':
+    'セキュリティ: `slv c` を実行して、SLV AI にファイアウォールの設定を手伝ってもらいましょう。',
   'Video walkthrough: coming soon.': '動画解説: 後日公開予定。',
   'Loopback-only mode — open the URL from elsewhere via SSH tunnel first:':
     'ループバック限定モード — 外から開くには、まず SSH トンネルを張ってください:',

--- a/cli/src/ai/i18n/messages/ru.ts
+++ b/cli/src/ai/i18n/messages/ru.ts
@@ -357,8 +357,8 @@ export const messages: Record<string, string> = {
   'Creating support ticket...': 'Создание тикета поддержки…',
   'Ticket creation failed: {err}': 'Не удалось создать тикет: {err}',
   'Ticket opened. Follow up here:': 'Тикет открыт. Следите здесь:',
-  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall (nftables) and WireGuard (with the app on your phone). The conversation happens right there — no terminal needed.':
-    'Безопасность: откройте URL выше в браузере, чтобы запустить SLV AI, и попросите его помочь настроить брандмауэр (nftables) и WireGuard (с приложением на телефоне). Вся беседа — в браузере, терминал не нужен.',
+  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall. The conversation happens right there — no terminal needed.':
+    'Безопасность: откройте URL выше в браузере, чтобы запустить SLV AI, и попросите его помочь настроить брандмауэр. Вся беседа — в браузере, терминал не нужен.',
   'For automatic HTTPS + a free *.erpc.global subdomain, run SLV on an SLV VPS or BareMetal (provision via the dashboard):':
     'Для автоматического HTTPS + бесплатного *.erpc.global поддомена запускайте SLV на SLV VPS или BareMetal (закажите через панель управления):',
   'Gateway is already running.': 'Шлюз уже работает.',
@@ -366,8 +366,8 @@ export const messages: Record<string, string> = {
     'Включить удалённый доступ по IP? (рекомендуется для VPS)',
   'Binds the gateway to 0.0.0.0 so you can open http://<server-ip>:{port}/ui/ directly from your phone/laptop. Token auth still gates every chat action.':
     'Привязывает шлюз к 0.0.0.0, чтобы вы могли открыть http://<server-ip>:{port}/ui/ напрямую с телефона/ноутбука. Все действия чата по-прежнему защищены авторизацией токеном.',
-  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Video walkthrough: coming soon.':
-    'Следующий шаг: после завершения онбординга запустите `slv c` и попросите SLV AI помочь настроить брандмауэр (nftables) и WireGuard (с приложением на телефоне). Видео-руководство появится позже.',
+  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall. Video walkthrough: coming soon.':
+    'Следующий шаг: после завершения онбординга запустите `slv c` и попросите SLV AI помочь настроить брандмауэр. Видео-руководство появится позже.',
   'Enable remote IP access now?': 'Включить удалённый доступ по IP сейчас?',
   'Remote IP access enabled — gateway restarted.':
     'Удалённый доступ по IP включён — шлюз перезапущен.',
@@ -383,8 +383,8 @@ export const messages: Record<string, string> = {
   'Open SLV in your browser:': 'Откройте SLV в браузере:',
   'Gateway token (paste on first visit):':
     'Токен шлюза (вставьте при первом посещении):',
-  'Security: ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Run `slv c` to start.':
-    'Безопасность: запустите `slv c` и попросите SLV AI помочь настроить брандмауэр (nftables) и WireGuard (с приложением на телефоне).',
+  'Security: ask SLV AI to help you set up the firewall. Run `slv c` to start.':
+    'Безопасность: запустите `slv c` и попросите SLV AI помочь настроить брандмауэр.',
   'Video walkthrough: coming soon.': 'Видео-руководство: скоро будет.',
   'Loopback-only mode — open the URL from elsewhere via SSH tunnel first:':
     'Режим только loopback — чтобы открыть URL из другого места, сначала создайте SSH туннель:',

--- a/cli/src/ai/i18n/messages/vi.ts
+++ b/cli/src/ai/i18n/messages/vi.ts
@@ -354,8 +354,8 @@ export const messages: Record<string, string> = {
   'Creating support ticket...': 'Đang tạo ticket hỗ trợ…',
   'Ticket creation failed: {err}': 'Tạo ticket thất bại: {err}',
   'Ticket opened. Follow up here:': 'Đã mở ticket. Theo dõi tại:',
-  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall (nftables) and WireGuard (with the app on your phone). The conversation happens right there — no terminal needed.':
-    'Bảo mật: chạm URL phía trên để mở SLV AI trong trình duyệt, rồi nhờ nó hướng dẫn cài firewall (nftables) và WireGuard (với app trên điện thoại). Trò chuyện ngay trong trình duyệt — không cần terminal.',
+  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall. The conversation happens right there — no terminal needed.':
+    'Bảo mật: chạm URL phía trên để mở SLV AI trong trình duyệt, rồi nhờ nó hướng dẫn cài firewall. Trò chuyện ngay trong trình duyệt — không cần terminal.',
   'For automatic HTTPS + a free *.erpc.global subdomain, run SLV on an SLV VPS or BareMetal (provision via the dashboard):':
     'Để tự động có HTTPS và subdomain *.erpc.global miễn phí, hãy chạy SLV trên SLV VPS hoặc BareMetal (tạo qua dashboard):',
   'Gateway is already running.': 'Cổng đang chạy.',
@@ -363,8 +363,8 @@ export const messages: Record<string, string> = {
     'Bật truy cập từ xa bằng IP? (khuyến nghị cho VPS)',
   'Binds the gateway to 0.0.0.0 so you can open http://<server-ip>:{port}/ui/ directly from your phone/laptop. Token auth still gates every chat action.':
     'Bind cổng vào 0.0.0.0 để bạn có thể mở http://<server-ip>:{port}/ui/ trực tiếp từ điện thoại/laptop. Mọi thao tác chat vẫn được bảo vệ bằng token.',
-  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Video walkthrough: coming soon.':
-    'Bước tiếp theo: khi onboard hoàn tất, chạy `slv c` và nhờ SLV AI hướng dẫn cài firewall (nftables) và WireGuard (với app trên điện thoại). Video hướng dẫn sẽ có sau.',
+  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall. Video walkthrough: coming soon.':
+    'Bước tiếp theo: khi onboard hoàn tất, chạy `slv c` và nhờ SLV AI hướng dẫn cài firewall. Video hướng dẫn sẽ có sau.',
   'Enable remote IP access now?': 'Bật truy cập từ xa bằng IP ngay?',
   'Remote IP access enabled — gateway restarted.':
     'Đã bật truy cập từ xa bằng IP — cổng được khởi động lại.',
@@ -380,8 +380,8 @@ export const messages: Record<string, string> = {
   'Open SLV in your browser:': 'Mở SLV trong trình duyệt:',
   'Gateway token (paste on first visit):':
     'Token cổng (dán khi truy cập lần đầu):',
-  'Security: ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Run `slv c` to start.':
-    'Bảo mật: chạy `slv c` và nhờ SLV AI hướng dẫn cài firewall (nftables) và WireGuard (với app trên điện thoại).',
+  'Security: ask SLV AI to help you set up the firewall. Run `slv c` to start.':
+    'Bảo mật: chạy `slv c` và nhờ SLV AI hướng dẫn cài firewall.',
   'Video walkthrough: coming soon.': 'Video hướng dẫn: sẽ có sau.',
   'Loopback-only mode — open the URL from elsewhere via SSH tunnel first:':
     'Chế độ chỉ loopback — Trước khi mở URL từ nơi khác, hãy tạo SSH tunnel trước:',

--- a/cli/src/ai/i18n/messages/zh.ts
+++ b/cli/src/ai/i18n/messages/zh.ts
@@ -338,8 +338,8 @@ export const messages: Record<string, string> = {
   'Creating support ticket...': '正在创建支持工单…',
   'Ticket creation failed: {err}': '工单创建失败: {err}',
   'Ticket opened. Follow up here:': '工单已创建。请在此跟进:',
-  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall (nftables) and WireGuard (with the app on your phone). The conversation happens right there — no terminal needed.':
-    '安全建议: 点击上方 URL 在浏览器中打开 SLV AI，直接让它帮您配置防火墙（nftables）和手机 WireGuard。对话就在浏览器里进行，无需终端。',
+  'Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall. The conversation happens right there — no terminal needed.':
+    '安全建议: 点击上方 URL 在浏览器中打开 SLV AI，直接让它帮您配置防火墙。对话就在浏览器里进行，无需终端。',
   'For automatic HTTPS + a free *.erpc.global subdomain, run SLV on an SLV VPS or BareMetal (provision via the dashboard):':
     '要自动启用 HTTPS 和免费 *.erpc.global 子域名，请在 SLV VPS 或 BareMetal 上运行 SLV（通过仪表板开通）:',
   'Gateway is already running.': '网关已在运行。',
@@ -347,8 +347,8 @@ export const messages: Record<string, string> = {
     '启用 IP 远程访问吗？（VPS 推荐）',
   'Binds the gateway to 0.0.0.0 so you can open http://<server-ip>:{port}/ui/ directly from your phone/laptop. Token auth still gates every chat action.':
     '将网关绑定到 0.0.0.0，您可以直接从手机/笔记本打开 http://<server-ip>:{port}/ui/。所有聊天操作仍需令牌认证。',
-  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Video walkthrough: coming soon.':
-    '下一步：引导完成后运行 `slv c`，请 SLV AI 帮您配置防火墙（nftables）和手机 WireGuard。视频教程即将发布。',
+  'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall. Video walkthrough: coming soon.':
+    '下一步：引导完成后运行 `slv c`，请 SLV AI 帮您配置防火墙。视频教程即将发布。',
   'Enable remote IP access now?': '现在启用 IP 远程访问吗？',
   'Remote IP access enabled — gateway restarted.':
     'IP 远程访问已启用 — 网关已重启。',
@@ -363,8 +363,8 @@ export const messages: Record<string, string> = {
   'Open SLV in your browser:': '在浏览器中打开 SLV:',
   'Gateway token (paste on first visit):':
     '网关令牌（首次访问时粘贴）:',
-  'Security: ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Run `slv c` to start.':
-    '安全提醒: 运行 `slv c`，请 SLV AI 帮您配置防火墙（nftables）和手机 WireGuard。',
+  'Security: ask SLV AI to help you set up the firewall. Run `slv c` to start.':
+    '安全提醒: 运行 `slv c`，请 SLV AI 帮您配置防火墙。',
   'Video walkthrough: coming soon.': '视频教程：即将发布。',
   'Loopback-only mode — open the URL from elsewhere via SSH tunnel first:':
     '仅回环模式 — 从其他地方打开 URL 前，请先建立 SSH 隧道:',

--- a/cli/src/ai/onboard/onboardAction.ts
+++ b/cli/src/ai/onboard/onboardAction.ts
@@ -969,7 +969,7 @@ const maybeEnableLanMode = async (
     colors.bold.rgb24(
       `    ⚠ ${
         t(
-          'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall (nftables) and WireGuard (with the app on your phone). Video walkthrough: coming soon.',
+          'Next step: once onboard finishes, run `slv c` and ask SLV AI to help you set up the firewall. Video walkthrough: coming soon.',
         )
       }`,
       0xffdf7a,
@@ -1118,7 +1118,7 @@ const sendOnboardWebhook = async (opts: {
   }
   msg3Lines.push(
     `⚠️ ${
-      t('Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall (nftables) and WireGuard (with the app on your phone). The conversation happens right there — no terminal needed.')
+      t('Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall. The conversation happens right there — no terminal needed.')
     }`,
     `• ${t('Video walkthrough: coming soon.')}`,
   )


### PR DESCRIPTION
## Summary
Shorten the user-facing suggested prompt across all 5 locales:

**Before:** 「ファイアウォール（nftables）とスマホで WireGuard の設定を手伝って」
**After:**  「ファイアウォールの設定を手伝って」

The nftables + WireGuard breakdown belongs inside the skill walkthrough, not in the call-to-action line. Non-engineer users got confused by the parenthetical technical terms and the line was too long to read quickly.

EL (via slv-firewall skill) still offers WG as part of the firewall flow — users discover it naturally once the conversation starts.

## Changed strings (× 5 locales each)
1. "Security: tap the URL above to open SLV AI in your browser, and ask it to help you set up the firewall. The conversation happens right there — no terminal needed."
2. "Next step: once onboard finishes, run \`slv c\` and ask SLV AI to help you set up the firewall. Video walkthrough: coming soon."
3. "Security: ask SLV AI to help you set up the firewall. Run \`slv c\` to start."

## Test plan
- [x] \`deno check\` on all touched files
- [x] \`grep\` for the old phrase returns zero in-source matches
- [ ] Post-merge: onboard fresh VPS, verify the three messages render with the short form

🤖 Generated with [Claude Code](https://claude.com/claude-code)