### PR TITLE
feat(rpc): auto-apply optimized SHA256 patch during init.yml deploy

### DIFF
--- a/template/2026.4.27.1539/ansible/cmn/patch_sha256.yml
+++ b/template/2026.4.27.1539/ansible/cmn/patch_sha256.yml
@@ -5,7 +5,6 @@
   gather_facts: false
 
   vars:
-    solana_version: "v3.1.10-jito"
     is_jito_based: >-
       {{
         'jito' in (validator_type | default(''))
@@ -45,6 +44,24 @@
       when: conn_check.unreachable | default(false) or conn_check.failed | default(false)
 
   tasks:
+    - name: Resolve solana version for SHA256 patch
+      set_fact:
+        solana_version_resolved: >-
+          {{ solana_version
+             | default(jito_version_resolved
+                       | default(agave_version_resolved | default('', true),
+                                 true),
+                       true) }}
+
+    - name: Ensure solana version is resolved
+      assert:
+        that:
+          - solana_version_resolved | length > 0
+        fail_msg: >-
+          solana_version must be provided (via -e solana_version=, or set by
+          an upstream build play that defines jito_version_resolved /
+          agave_version_resolved)
+
     - name: Install build dependencies
       ansible.builtin.apt:
         name:
@@ -82,7 +99,7 @@
       ansible.builtin.git:
         repo: "{{ solana_repo_url }}"
         dest: "{{ solana_src_dir }}"
-        version: "{{ solana_version }}"
+        version: "{{ solana_version_resolved }}"
         force: yes
 
     - name: Clone optimized SHA256 repo

--- a/template/2026.4.27.1539/ansible/devnet-rpc/init.yml
+++ b/template/2026.4.27.1539/ansible/devnet-rpc/init.yml
@@ -35,6 +35,9 @@
 - import_playbook: ../cmn/setup_logrotate.yml
 - import_playbook: ../cmn/build_solana.yml
 
+- import_playbook: ../cmn/patch_sha256.yml
+  when: validator_type in ['agave', 'jito', 'jito-bam']
+
 - import_playbook: ../cmn/setup_unstaked_identity.yml
 
 - import_playbook: setup_firedancer.yml

--- a/template/2026.4.27.1539/ansible/mainnet-rpc/init.yml
+++ b/template/2026.4.27.1539/ansible/mainnet-rpc/init.yml
@@ -33,6 +33,8 @@
 - import_playbook: ../cmn/setup_norestart.yml
 - import_playbook: ../cmn/setup_logrotate.yml
 - import_playbook: ../cmn/build_solana.yml
+- import_playbook: ../cmn/patch_sha256.yml
+  when: validator_type in ['agave', 'jito', 'jito-bam']
 - import_playbook: create-symlink.yml
 
 - import_playbook: setup_firedancer.yml

--- a/template/2026.4.27.1539/ansible/testnet-rpc/init.yml
+++ b/template/2026.4.27.1539/ansible/testnet-rpc/init.yml
@@ -35,6 +35,9 @@
 - import_playbook: ../cmn/setup_logrotate.yml
 - import_playbook: ../cmn/build_solana.yml
 
+- import_playbook: ../cmn/patch_sha256.yml
+  when: validator_type in ['agave', 'jito', 'jito-bam']
+
 - import_playbook: ../cmn/setup_unstaked_identity.yml
 
 - import_playbook: setup_firedancer.yml


### PR DESCRIPTION
## Summary

- Run `cmn/patch_sha256.yml` automatically after `build_solana.yml` in each RPC `init.yml` (mainnet/testnet/devnet), gated to non-firedancer validator types (`agave`, `jito`, `jito-bam`).
- Drop the hardcoded `solana_version: "v3.1.10-jito"` default from `patch_sha256.yml`. It would silently downgrade hosts running newer versions. The version is now resolved from a fallback chain:
  1. `-e solana_version=` (CLI / explicit override)
  2. `jito_version_resolved` (set by `build_jito.yml` during init flow)
  3. `agave_version_resolved` (set by `build_agave.yml` during init flow)
  4. → fail with clear assert

## Why

Operators have been running `slv r patch:sha256` (and `slv v patch:sha256`) by hand after every deploy to apply the optimized PoH SHA256 patch. By inlining it into `init.yml`, fresh RPCs come up already patched. The version-resolution change protects against the hardcoded default downgrading newer hosts.

## Files changed

- `template/2026.4.27.1539/ansible/cmn/patch_sha256.yml` — drop hardcoded version, add `set_fact` resolver + `assert`
- `template/2026.4.27.1539/ansible/{mainnet,testnet,devnet}-rpc/init.yml` — import `patch_sha256.yml` after `build_solana.yml`

`slv r patch:sha256` (already exists for all networks via `r` → `rpc` alias) is unchanged — it still passes `solana_version` as an extraVar, which the new resolver picks up first.

## Test plan
- [ ] Deploy a fresh `agave` RPC via `init.yml` and confirm patched binary is in place (`/var/log/solana-validator-patch.log` written, `agave-validator --version` looks correct).
- [ ] Deploy a `firedancer-jito` RPC and confirm `patch_sha256` is **skipped** (no clone of `jito-solana-sha256`, no extra build time).
- [ ] Run `slv r patch:sha256 -p <host>` standalone and confirm `solana_version` extraVar still works.
- [ ] Re-run `init.yml` on an already-patched host and confirm idempotency (no errors from `replace`/`blockinfile` markers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)