### PR TITLE
feat(upgrade): auto-refresh ~/.slv/versions.yml after slv upgrade

### DIFF
--- a/cli/src/upgrade.ts
+++ b/cli/src/upgrade.ts
@@ -1,3 +1,46 @@
+import {
+  applyVersionUpdates,
+  checkSolanaReleases,
+  type VersionUpdate,
+} from '@/ai/console/checkRelease.ts'
+
+const refreshVersionsYml = async () => {
+  try {
+    console.log('\n📦 Checking for component version updates...')
+    const updates = await checkSolanaReleases()
+    if (updates.length === 0) {
+      console.log('  ✓ ~/.slv/versions.yml is up-to-date')
+      return
+    }
+
+    const seen = new Set<string>()
+    const display: VersionUpdate[] = []
+    for (const u of updates) {
+      const key = `${u.component}-${u.network}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      display.push(u)
+    }
+
+    for (const u of display) {
+      console.log(
+        `  • ${u.component} (${u.network}): ${u.current} → ${u.latest}`,
+      )
+    }
+
+    await applyVersionUpdates(updates)
+    const noun = display.length === 1 ? 'component' : 'components'
+    console.log(
+      `  ✅ ~/.slv/versions.yml updated (${display.length} ${noun})`,
+    )
+  } catch (error) {
+    console.error(
+      '  ⚠️  Failed to refresh versions.yml:',
+      error instanceof Error ? error.message : String(error),
+    )
+  }
+}
+
 const upgrade = async () => {
   const script = await (await fetch('https://storage.slv.dev/slv/install'))
     .text()
@@ -10,6 +53,13 @@ const upgrade = async () => {
   await writer.write(new TextEncoder().encode(script))
   await writer.close()
   const { code } = await process.status
+
+  // Best-effort refresh of ~/.slv/versions.yml from GitHub release tags.
+  // Skipped on install failure; network errors are logged but don't fail the upgrade.
+  if (code === 0) {
+    await refreshVersionsYml()
+  }
+
   // NOTE: skills are re-synced inside the shell installer via
   // `install_skills()` in sh/install. Do not run syncSkills() here — it
   // appends noisy "N unchanged" output after the welcome banner/ASCII


### PR DESCRIPTION
## Summary

After `slv upgrade` finishes installing the new binary, automatically run the same version-refresh logic the AI console's `/update` slash command uses — fetch latest release tags from GitHub for Agave / Jito / Firedancer / Richat / Yellowstone and apply deltas to `~/.slv/versions.yml`.

Eliminates the manual step where users had to launch `slv c` and type `/update` after every upgrade to keep their component versions current.

## Behaviour

- **Install failed** → skip the refresh entirely (no point updating versions if the binary swap broke).
- **Install succeeded, network fine** → print a short summary of bumped components and write `~/.slv/versions.yml`.
- **Install succeeded, network down or rate-limited** → warning logged, exit code unaffected.
- **Already up-to-date** → single line "✓ ~/.slv/versions.yml is up-to-date".

Reuses `checkSolanaReleases()` and `applyVersionUpdates()` from `cli/src/ai/console/checkRelease.ts` — same code path, same dedup-for-display rule.

## Out of scope

This PR only addresses the `slv upgrade` flow. The initial-install seeding (`genOrReadVersions()` falling back to `defaultVersionsYml.ts` / `cmn/constants/version.ts`) is unchanged. That requires a fallback story for the case where one of the upstream GitHub repos disappears, and will land in a follow-up.

## Test plan

- [ ] `slv upgrade` on a host with a stale `versions.yml` → confirm bumped components are listed and the file is written.
- [ ] `slv upgrade` with network blocked → confirm warning prints and upgrade still exits 0.
- [ ] `slv upgrade` with `~/.slv/versions.yml` already current → confirm "up-to-date" line.
- [ ] `slv upgrade` on a fresh box (no `~/.slv/versions.yml` yet) → confirm graceful no-op (the file doesn't exist so checkSolanaReleases returns []).

🤖 Generated with [Claude Code](https://claude.com/claude-code)