### PR TITLE
fix(testnet): bump expected shred version and bank hash

### DIFF
--- a/template/2026.5.1.1510/jinja/testnet-rpc/firedancer-config.toml.j2
+++ b/template/2026.5.1.1510/jinja/testnet-rpc/firedancer-config.toml.j2
@@ -107,8 +107,8 @@ dynamic_port_range = "{{ dynamic_port_range | default('8900-8925') }}"
     snapshot_fetch = true
     genesis_fetch = true
     expected_genesis_hash = "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY"
-    expected_bank_hash = "EJMzxv7JscF8WNZfDYqzsAyALCDCS52HuihabVgyz5mf"
-    expected_shred_version = 9604
+    expected_bank_hash = "YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA"
+    expected_shred_version = 57087
     known_validators = [
         "5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on",
         "dDzy5SR3AXdYWVqbDEkVFdvSPCtS9ihF5kJkHCtXoFs",

--- a/template/2026.5.1.1510/jinja/testnet-rpc/start-validator.sh.j2
+++ b/template/2026.5.1.1510/jinja/testnet-rpc/start-validator.sh.j2
@@ -20,8 +20,8 @@ exec agave-validator \
 --full-rpc-api \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --wal-recovery-mode skip_any_corrupted_record \
---expected-shred-version 9604 \
---expected-bank-hash EJMzxv7JscF8WNZfDYqzsAyALCDCS52HuihabVgyz5mf \
+--expected-shred-version 57087 \
+--expected-bank-hash YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA \
 {% if rpc_type == 'Geyser gRPC' -%}
 --limit-ledger-size 50000000 \
 --no-snapshot-fetch \

--- a/template/2026.5.1.1510/jinja/testnet-validator/firedancer-config-agave.toml.j2
+++ b/template/2026.5.1.1510/jinja/testnet-validator/firedancer-config-agave.toml.j2
@@ -48,8 +48,8 @@ dynamic_port_range = "{{ dynamic_port_range | default("8100-8125") }}"
     snapshot_fetch = true
     genesis_fetch = true
     expected_genesis_hash = "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY"
-    expected_bank_hash = "{{ expected_bank_hash | default("3zk4WMwk6wCTVJXu9UAk2dYWMedCKooDs15XL5u6FkvE") }}"
-    expected_shred_version = {{ expected_shred_version | default(27350) }}
+    expected_bank_hash = "{{ expected_bank_hash | default("YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA") }}"
+    expected_shred_version = {{ expected_shred_version | default(57087) }}
     wait_for_supermajority_at_slot = {{ wait_for_supermajority | default(383520372) }}
 
 [hugetlbfs]

--- a/template/2026.5.1.1510/jinja/testnet-validator/firedancer-config-jito.toml.j2
+++ b/template/2026.5.1.1510/jinja/testnet-validator/firedancer-config-jito.toml.j2
@@ -48,8 +48,8 @@ dynamic_port_range = "{{ dynamic_port_range | default("8100-8125", true) }}"
     snapshot_fetch = true
     genesis_fetch = true
     expected_genesis_hash = "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY"
-    expected_bank_hash = "{{ expected_bank_hash | default("3zk4WMwk6wCTVJXu9UAk2dYWMedCKooDs15XL5u6FkvE") }}"
-    expected_shred_version = {{ expected_shred_version | default(27350) }}
+    expected_bank_hash = "{{ expected_bank_hash | default("YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA") }}"
+    expected_shred_version = {{ expected_shred_version | default(57087) }}
     wait_for_supermajority_at_slot = {{ wait_for_supermajority | default(383520372) }}
 
 [hugetlbfs]

--- a/template/2026.5.1.1510/jinja/testnet-validator/firedancer-config.toml.j2
+++ b/template/2026.5.1.1510/jinja/testnet-validator/firedancer-config.toml.j2
@@ -47,8 +47,8 @@ dynamic_port_range = "{{ dynamic_port_range | default('8900-8925') }}"
     snapshot_fetch = true
     genesis_fetch = true
     expected_genesis_hash = "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY"
-    expected_bank_hash = "CJZAAtgdqYiqHTFKJ9XD9qw4W21wHqojkhrVJSfFF9b7"
-    expected_shred_version = 24207
+    expected_bank_hash = "YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA"
+    expected_shred_version = 57087
 
 [hugetlbfs]
     mount_path = "/mnt"

--- a/template/2026.5.1.1510/jinja/testnet-validator/start-validator-agave.sh.j2
+++ b/template/2026.5.1.1510/jinja/testnet-validator/start-validator-agave.sh.j2
@@ -15,8 +15,8 @@ exec agave-validator \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --wal-recovery-mode skip_any_corrupted_record \
 --wait-for-supermajority {{ wait_for_supermajority | default("383520372") }} \
---expected-shred-version {{ expected_shred_version | default("27350") }} \
---expected-bank-hash {{ expected_bank_hash | default("3zk4WMwk6wCTVJXu9UAk2dYWMedCKooDs15XL5u6FkvE") }} \
+--expected-shred-version {{ expected_shred_version | default("57087") }} \
+--expected-bank-hash {{ expected_bank_hash | default("YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA") }} \
 --limit-ledger-size {{ limit_ledger_size | default(200000000) }} \
 --no-port-check \
 --rpc-bind-address 0.0.0.0

--- a/template/2026.5.1.1510/jinja/testnet-validator/start-validator-jito.sh.j2
+++ b/template/2026.5.1.1510/jinja/testnet-validator/start-validator-jito.sh.j2
@@ -15,8 +15,8 @@ exec agave-validator \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --wal-recovery-mode skip_any_corrupted_record \
 --wait-for-supermajority {{ wait_for_supermajority | default("383520372") }} \
---expected-shred-version {{ expected_shred_version | default("27350") }} \
---expected-bank-hash {{ expected_bank_hash | default("3zk4WMwk6wCTVJXu9UAk2dYWMedCKooDs15XL5u6FkvE") }} \
+--expected-shred-version {{ expected_shred_version | default("57087") }} \
+--expected-bank-hash {{ expected_bank_hash | default("YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA") }} \
 --limit-ledger-size {{ limit_ledger_size | default(200000000) }} \
 --no-port-check \
 --rpc-bind-address 0.0.0.0 \

--- a/template/2026.5.1.1510/jinja/testnet-validator/start-validator.sh.j2
+++ b/template/2026.5.1.1510/jinja/testnet-validator/start-validator.sh.j2
@@ -15,7 +15,7 @@ exec agave-validator \
 {% if wait_for_supermajority is defined %}
 --wait-for-supermajority {{ wait_for_supermajority }} \
 {% endif %}
---expected-shred-version {{ expected_shred_version | default(27350) }} \
+--expected-shred-version {{ expected_shred_version | default(57087) }} \
 {% if expected_bank_hash is defined %}
 --expected-bank-hash {{ expected_bank_hash }} \
 {% endif %}


### PR DESCRIPTION
## Summary
- Update testnet validator/RPC jinja templates with the new network-level values:
  - `--expected-shred-version` → `57087`
  - `--expected-bank-hash` → `YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA`
- Touched 8 files in `template/2026.5.1.1510/jinja/{testnet-validator,testnet-rpc}/`:
  - `testnet-validator/`: `start-validator.sh.j2`, `start-validator-agave.sh.j2`, `start-validator-jito.sh.j2`, `firedancer-config.toml.j2`, `firedancer-config-agave.toml.j2`, `firedancer-config-jito.toml.j2`
  - `testnet-rpc/`: `start-validator.sh.j2`, `firedancer-config.toml.j2`

## Notes
- `template/latest` is a symlink to `2026.5.1.1510`, so this is the active template.
- `dist/oss-skills/` jinja mirror is **not** updated in this PR. It is documentation/reference only — actual user installs pull jinja from the R2 `template.tar.gz`, not from `dist/oss-skills/`. Existing drift in `dist/oss-skills/` (allnodes-jito additions, perf-tune cleanup, etc., from prior PRs that didn't rebuild it) is out of scope here and should be addressed separately, ideally by hooking `build-skill-oss.sh` into the release script.
- For these new values to actually reach existing nodes, the `template.tar.gz` for `2026.5.1.1510` needs to be re-uploaded to R2 (`deno task create:template && deno task upload:template`), or this rolls out with the next version bump.

## Test plan
- [ ] Confirm rendered `start-validator.sh` on a testnet node uses shred `57087` and bank hash `YFxSk…HEA`
- [ ] Confirm Firedancer-based testnet validator picks up the new values
- [ ] Confirm testnet RPC starts with the new values

🤖 Generated with [Claude Code](https://claude.com/claude-code)