### PR TITLE
feat(rpc): rolling local-index cache for Old Faithful (~6x getTransaction)

### DIFF
--- a/oss-skills/slv-rpc/SKILL.md
+++ b/oss-skills/slv-rpc/SKILL.md
@@ -111,6 +111,7 @@ The `slv r` CLI commands map directly to these playbooks. `{net}` = `mainnet-rpc
 | `install_richat.yml` | Install Richat gRPC plugin |
 | `install_of1.yml` | Install Old Faithful (yellowstone-faithful) |
 | `install_of1_service.yml` | Setup Old Faithful systemd service |
+| `cmn/of1_index_cache_sync.yml` | Install rolling-cache sync script + daily timer |
 | `geyser_build.yml` | Build Yellowstone gRPC from source |
 | `geyser_richat_build.yml` | Build Richat gRPC plugin from source |
 | `update_geyser.yml` | Update Geyser plugin |
@@ -262,6 +263,9 @@ See `AGENT.md` for the full step-by-step flow and `examples/inventory.yml` for o
 | `of1_version` | — | Index RPC (Old Faithful) |
 | `epoch` | — | Index RPC (faithful service) |
 | `faithful_proxy_target_url` | — | Index RPC |
+| `index_rpc_window_epochs` | `30` | Index RPC (rolling cache window) |
+| `of1_index_cache_dir` | `/mnt/ledger/car/indexes` | Index RPC (rolling cache disk) |
+| `of1_run_initial_sync` | `true` | Index RPC (foreground first-time fill) |
 
 ### Optional Variables
 
@@ -349,3 +353,53 @@ slv r patch:sha256 -n <network> -p <pubkey>
 | `slv r init` (after SSH check) | `cmn/optimize_node.yml` (auto-reboot if needed) |
 | `slv r deploy` | `{net}-rpc/init.yml` + auto `runSha256Patch` |
 | `slv r patch:sha256` | `cmn/patch_sha256.yml` (standalone) |
+
+## Index RPC: Rolling Index Cache
+
+`Index RPC` and `Index RPC + gRPC` deploys add a rolling cache of
+yellowstone-faithful indexes for the most recent N epochs (default 30) so
+historical RPC queries answer locally instead of round-tripping to
+`files.old-faithful.net` on every lookup.
+
+### How it works
+
+The index files (cid-to-offset, slot-to-cid, sig-to-cid, sig-exists,
+slot-to-blocktime) are kept on local disk; CAR files stay remote and are
+fetched via HTTP Range requests as needed. A daily systemd timer
+(`of1-index-sync.timer`) calls `/usr/local/bin/of1-index-sync.sh`, which:
+
+1. Discovers the latest available epoch on Old Faithful.
+2. Downloads any missing indexes for the last `index_rpc_window_epochs` epochs (parallel `aria2c`).
+3. Regenerates per-epoch config YAMLs in `/home/solv/configs/` with `file://` URIs for indexes + `https://` URI for CAR.
+4. Evicts caches older than the window.
+5. Restarts `faithful.service` only if anything changed.
+
+`faithful.service` runs through `/usr/local/bin/start-faithful.sh`, which
+globs `config-epoch*.yaml` so the timer can add or remove epochs without
+editing the systemd unit.
+
+### Disk budget
+
+A recent epoch is ~30 GB of indexes (CAR is excluded — it would be
+500-800 GB per epoch). 30 epochs ≈ ~1 TB on local disk and covers ~63
+days of mainnet history.
+
+### Measured impact (representative production RPC node)
+
+| Method | Before (all-remote URIs) | After (local indexes) | Improvement |
+|---|---:|---:|---|
+| `getTransaction` | 313 ms p50 / 481 ms p95 | 73 ms p50 / 96 ms p95 | **~6× faster** |
+| `getBlockTime` | 34 ms p50 | 34 ms p50 | unchanged (already fast) |
+| `getBlock` | 141 ms p50 | 161-194 ms p50 | CAR-fetch dominated |
+
+`getTransaction` is the win because it traverses three indexes; with all
+of them remote each query becomes an HTTP-Range chain. Localizing
+collapses that to a single CAR roundtrip.
+
+### Standalone control
+
+```bash
+sudo systemctl start of1-index-sync.service        # ad-hoc sync
+WINDOW=10 sudo /usr/local/bin/of1-index-sync.sh    # smaller window
+DRY_RUN=1 sudo /usr/local/bin/of1-index-sync.sh    # show plan without DL
+```

--- a/scripts/bench-of1-extended.sh
+++ b/scripts/bench-of1-extended.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# bench-of1-extended.sh — full-coverage benchmark for the rolling-cache RPC.
+# Discovers a real signature in each tested epoch by calling the endpoint
+# itself (requires the epoch to be reachable, even via proxy fallback) so the
+# benchmark always operates on real data.
+#
+# Coverage:
+#   • All cached epochs in the rolling window
+#   • One epoch outside the window (proxied baseline)
+#   • One very-old epoch (proxied baseline)
+# Methods per epoch: getBlockTime, getBlock(none|sigs), getTransaction,
+# getSignaturesForAddress.
+#
+# Usage:
+#   ./bench-of1-extended.sh <endpoint> <iters> <output.json> [epoch1,epoch2,...]
+set -euo pipefail
+
+ENDPOINT="${1:-http://localhost:8888}"
+ITERS="${2:-10}"
+OUT="${3:-bench-results/of1-extended-$(date +%Y%m%d-%H%M%S).json}"
+EPOCHS_CSV="${4:-937,945,955,965,966,899,936,600}"
+
+mkdir -p "$(dirname "$OUT")"
+
+# A high-traffic mainnet account that has signatures across many epochs.
+# Token Program is a safe choice — used by virtually every tx.
+PROBE_ACCOUNT="${PROBE_ACCOUNT:-TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA}"
+
+# Use Python for the heavy lifting (discovery + timing + reporting).
+python3 - "$ENDPOINT" "$ITERS" "$OUT" "$EPOCHS_CSV" "$PROBE_ACCOUNT" <<'PY'
+import json, sys, time, statistics, urllib.request, urllib.error, os
+
+endpoint, iters_str, out_path, epochs_csv, probe_account = sys.argv[1:6]
+iters = int(iters_str)
+test_epochs = [int(e) for e in epochs_csv.split(",") if e.strip()]
+SLOTS_PER_EPOCH = 432_000
+
+def call(method, params, timeout=120):
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}).encode()
+    req = urllib.request.Request(
+        endpoint, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    t0 = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except Exception as e:  # noqa: BLE001
+        return time.perf_counter() - t0, None, f"exc:{type(e).__name__}"
+    elapsed = time.perf_counter() - t0
+    try:
+        b = json.loads(raw)
+    except json.JSONDecodeError:
+        return elapsed, None, "non-json"
+    if "error" in b:
+        return elapsed, b, "error:" + (b["error"].get("message") or "")[:80]
+    if b.get("result") is None:
+        return elapsed, b, "null-result"
+    return elapsed, b, "ok"
+
+def discover(epoch):
+    """Return a (slot, sig) pair within the epoch by walking outward from a
+    midpoint slot until a populated block is found.  Bails out after 20 tries."""
+    for offset in range(0, 20):
+        slot = epoch * SLOTS_PER_EPOCH + 100_000 + offset * 1000
+        _, body, status = call(
+            "getBlock",
+            [slot, {"encoding": "json", "transactionDetails": "signatures",
+                    "rewards": False, "maxSupportedTransactionVersion": 0}],
+            timeout=120,
+        )
+        if status != "ok":
+            continue
+        sigs = body.get("result", {}).get("signatures") or []
+        if sigs:
+            return slot, sigs[0]
+    return None, None
+
+print(f"=== of1 extended bench: {endpoint}  iters={iters} ===")
+print(f"epochs to test: {test_epochs}\n")
+
+# Phase 1: discovery
+print("--- discovery (looking for one real slot+sig per epoch) ---")
+discoveries = {}
+for ep in test_epochs:
+    slot, sig = discover(ep)
+    if slot is None:
+        print(f"  epoch {ep}: NO populated block found; will skip getTransaction")
+    else:
+        print(f"  epoch {ep}: slot={slot} sig={sig[:24]}...")
+    discoveries[ep] = (slot, sig)
+
+# Phase 2: bench cases
+cases = [
+    {"label": "getVersion (control)", "epoch": None, "method": "getVersion", "params": []},
+]
+for ep in test_epochs:
+    slot, sig = discoveries[ep]
+    if slot is None:
+        continue
+    cases += [
+        {"label": f"getBlockTime    epoch {ep}", "epoch": ep, "method": "getBlockTime",
+         "params": [slot]},
+        {"label": f"getBlock(none)  epoch {ep}", "epoch": ep, "method": "getBlock",
+         "params": [slot, {"encoding": "json", "transactionDetails": "none",
+                           "rewards": False, "maxSupportedTransactionVersion": 0}]},
+        {"label": f"getBlock(sigs)  epoch {ep}", "epoch": ep, "method": "getBlock",
+         "params": [slot, {"encoding": "json", "transactionDetails": "signatures",
+                           "rewards": False, "maxSupportedTransactionVersion": 0}]},
+        {"label": f"getTransaction  epoch {ep}", "epoch": ep, "method": "getTransaction",
+         "params": [sig, {"encoding": "json", "maxSupportedTransactionVersion": 0}]},
+        {"label": f"getSigsForAddr  epoch {ep}", "epoch": ep, "method": "getSignaturesForAddress",
+         "params": [probe_account, {"limit": 5, "minContextSlot": slot, "before": sig}]},
+    ]
+
+# Warm-up: prime each cache by calling each case once before timing.
+print("\n--- warm-up pass (1 call/case) ---")
+for c in cases:
+    call(c["method"], c["params"], timeout=120)
+print("warm-up done")
+
+# Phase 3: measured runs
+print(f"\n--- measured ({iters} iters/case) ---")
+results = []
+for c in cases:
+    times, statuses, err = [], [], None
+    for _ in range(iters):
+        e, _, s = call(c["method"], c["params"], timeout=120)
+        times.append(e)
+        statuses.append(s)
+        if not s.startswith("ok") and err is None:
+            err = s
+    times_s = sorted(times)
+    p50 = statistics.median(times_s)
+    p95 = times_s[int(0.95 * (len(times_s) - 1))]
+    mean = statistics.fmean(times_s)
+    ok = sum(1 for s in statuses if s == "ok")
+    nul = sum(1 for s in statuses if s == "null-result")
+    er = sum(1 for s in statuses if not (s == "ok" or s == "null-result"))
+    status_str = f"ok={ok:>2d}" + (f" null={nul}" if nul else "") + (f" err={er}" if er else "")
+    suffix = f"   [{err[:60]}]" if err and not err.startswith("ok") else ""
+    print(
+        f"{c['label']:<60s} {status_str:<18s} mean={mean*1000:7.0f}ms  "
+        f"p50={p50*1000:7.0f}ms  p95={p95*1000:7.0f}ms{suffix}"
+    )
+    results.append({
+        "label": c["label"], "epoch": c["epoch"], "method": c["method"], "iters": iters,
+        "mean_ms": round(mean * 1000, 1),
+        "p50_ms":  round(p50 * 1000, 1),
+        "p95_ms":  round(p95 * 1000, 1),
+        "ok_count": ok, "null_count": nul, "err_count": er,
+        "first_error": err,
+        "times_ms": [round(t * 1000, 1) for t in times],
+    })
+
+with open(out_path, "w") as f:
+    json.dump({
+        "endpoint": endpoint,
+        "iters": iters,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "phase": "extended",
+        "probe_account": probe_account,
+        "discoveries": {str(k): {"slot": v[0], "sig": v[1]} for k, v in discoveries.items()},
+        "results": results,
+    }, f, indent=2)
+print(f"\nSaved: {out_path}")
+PY

--- a/scripts/bench-of1.sh
+++ b/scripts/bench-of1.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# bench-of1.sh — measure faithful-cli RPC latency across configured /
+# unconfigured epochs.  Designed to run before and after rolling-cache
+# rollout so the diff is meaningful.
+#
+# Usage:
+#   ./bench-of1.sh <endpoint> <iters> <output.json>
+# Defaults:
+#   endpoint = http://localhost:8888
+#   iters    = 10
+#   output   = bench-results/of1-$(date +%Y%m%d-%H%M%S).json
+set -euo pipefail
+
+ENDPOINT="${1:-http://localhost:8888}"
+ITERS="${2:-10}"
+OUT="${3:-bench-results/of1-$(date +%Y%m%d-%H%M%S).json}"
+
+mkdir -p "$(dirname "$OUT")"
+
+# ── Test data ────────────────────────────────────────────────────────────────
+# Real slots / sigs discovered in epoch 899 (currently the only configured epoch).
+# When this script is re-run after Phase 1, the same epoch 899 case stays
+# available, and the epoch 966 / 950 cases switch from "proxied to mainnet-beta"
+# to "served locally by faithful".
+read -r -d '' CASES_JSON <<'JSON' || true
+[
+  {"label":"getVersion (control)",                                  "epoch":null,"method":"getVersion","params":[]},
+
+  {"label":"getBlockTime    epoch 899 (faithful-local-config)",     "epoch":899,"method":"getBlockTime","params":[388569600]},
+  {"label":"getBlock(sigs)  epoch 899 (faithful-local-config)",     "epoch":899,"method":"getBlock","params":[388569600,{"encoding":"json","transactionDetails":"signatures","rewards":false,"maxSupportedTransactionVersion":0}]},
+  {"label":"getBlock(none)  epoch 899 (faithful-local-config)",     "epoch":899,"method":"getBlock","params":[388569600,{"encoding":"json","transactionDetails":"none","rewards":false,"maxSupportedTransactionVersion":0}]},
+  {"label":"getTransaction  epoch 899 (faithful-local-config)",     "epoch":899,"method":"getTransaction","params":["2X5xmp62MJ6KHW6dafAtjFf6JHjqSvh91WifyFFbb6HuQ7e3LKs4riH8BsjpuDJnSvvjDQD3b6gCnaPq4Gmip8wh",{"encoding":"json","maxSupportedTransactionVersion":0}]},
+
+  {"label":"getBlockTime    epoch 966 (unconfigured / proxied)",    "epoch":966,"method":"getBlockTime","params":[417412000]},
+  {"label":"getBlock(sigs)  epoch 966 (unconfigured / proxied)",    "epoch":966,"method":"getBlock","params":[417412000,{"encoding":"json","transactionDetails":"signatures","rewards":false,"maxSupportedTransactionVersion":0}]},
+  {"label":"getBlock(none)  epoch 966 (unconfigured / proxied)",    "epoch":966,"method":"getBlock","params":[417412000,{"encoding":"json","transactionDetails":"none","rewards":false,"maxSupportedTransactionVersion":0}]},
+
+  {"label":"getBlockTime    epoch 950 (unconfigured / proxied)",    "epoch":950,"method":"getBlockTime","params":[410500000]},
+  {"label":"getBlock(sigs)  epoch 950 (unconfigured / proxied)",    "epoch":950,"method":"getBlock","params":[410500000,{"encoding":"json","transactionDetails":"signatures","rewards":false,"maxSupportedTransactionVersion":0}]},
+
+  {"label":"getBlockTime    epoch 100 (very old / proxied)",        "epoch":100,"method":"getBlockTime","params":[43250000]},
+  {"label":"getBlock(sigs)  epoch 100 (very old / proxied)",        "epoch":100,"method":"getBlock","params":[43250000,{"encoding":"json","transactionDetails":"signatures","rewards":false,"maxSupportedTransactionVersion":0}]}
+]
+JSON
+
+# ── Bench engine ─────────────────────────────────────────────────────────────
+bench_one() {
+  python3 - "$ENDPOINT" "$ITERS" "$OUT" "$CASES_JSON" <<'PY'
+import json, sys, time, statistics, urllib.request, urllib.error
+
+endpoint, iters_str, out_path, cases_json = sys.argv[1:5]
+iters = int(iters_str)
+cases = json.loads(cases_json)
+
+def call(method, params, timeout=60):
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params}).encode()
+    req = urllib.request.Request(
+        endpoint, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    t0 = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.URLError as e:
+        return time.perf_counter() - t0, None, f"urlerror:{e}"
+    except Exception as e:  # noqa: BLE001
+        return time.perf_counter() - t0, None, f"exc:{e}"
+    elapsed = time.perf_counter() - t0
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError:
+        return elapsed, None, "non-json"
+    if "error" in body:
+        return elapsed, body, "error:" + (body["error"].get("message") or "")[:80]
+    if "result" not in body:
+        return elapsed, body, "no-result"
+    if body.get("result") is None:
+        return elapsed, body, "null-result"
+    return elapsed, body, "ok"
+
+print(f"=== of1 benchmark: {endpoint}  iters={iters} ===\n", flush=True)
+
+results = []
+for c in cases:
+    times = []
+    statuses = []
+    err_sample = None
+    for i in range(iters):
+        elapsed, body, status = call(c["method"], c["params"])
+        times.append(elapsed)
+        statuses.append(status)
+        if not status.startswith("ok") and err_sample is None:
+            err_sample = status
+    times_sorted = sorted(times)
+    p50 = statistics.median(times_sorted)
+    p95 = times_sorted[int(0.95 * (len(times_sorted) - 1))]
+    mean = statistics.fmean(times_sorted)
+    ok_count = sum(1 for s in statuses if s == "ok")
+    null_count = sum(1 for s in statuses if s == "null-result")
+    err_count = sum(1 for s in statuses if s.startswith("error") or s == "no-result" or s.startswith("urlerror") or s.startswith("exc"))
+    label = c["label"]
+    status_str = f"ok={ok_count:>2d}"
+    if null_count:
+        status_str += f" null={null_count}"
+    if err_count:
+        status_str += f" err={err_count}"
+    print(
+        f"{label:<60s} {status_str:<18s} mean={mean*1000:7.0f}ms  "
+        f"p50={p50*1000:7.0f}ms  p95={p95*1000:7.0f}ms",
+        end="",
+    )
+    if err_sample and not err_sample.startswith("ok"):
+        print(f"   [{err_sample[:60]}]")
+    else:
+        print()
+    results.append({
+        "label": label,
+        "epoch": c["epoch"],
+        "method": c["method"],
+        "iters": iters,
+        "mean_ms": round(mean * 1000, 1),
+        "p50_ms": round(p50 * 1000, 1),
+        "p95_ms": round(p95 * 1000, 1),
+        "ok_count": ok_count,
+        "null_count": null_count,
+        "err_count": err_count,
+        "first_error": err_sample,
+        "times_ms": [round(t * 1000, 1) for t in times],
+    })
+
+with open(out_path, "w") as f:
+    json.dump({
+        "endpoint": endpoint,
+        "iters": iters,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "results": results,
+    }, f, indent=2)
+print(f"\nSaved: {out_path}")
+PY
+}
+
+bench_one

--- a/template/2026.5.5.1612/ansible/cmn/files/of1-index-sync.sh
+++ b/template/2026.5.5.1612/ansible/cmn/files/of1-index-sync.sh
@@ -39,6 +39,7 @@ CONNS_PER_FILE="${CONNS_PER_FILE:-8}"
 PUBLIC_RPC="${PUBLIC_RPC:-https://api.mainnet-beta.solana.com}"
 DRY_RUN="${DRY_RUN:-0}"
 SKIP_RESTART="${SKIP_RESTART:-0}"
+LOCK_FILE="${LOCK_FILE:-/var/lock/of1-index-sync.lock}"
 
 INDEX_SUFFIXES=(
   cid-to-offset-and-size
@@ -59,27 +60,53 @@ require() {
 require curl
 require aria2c
 require stat
+require flock
+
+# Cleanup any temp files we leak (aria2c input list, etc).
+TMP_FILES=()
+cleanup() {
+  local f
+  for f in "${TMP_FILES[@]:-}"; do
+    [ -n "$f" ] && rm -f "$f"
+  done
+}
+trap cleanup EXIT INT TERM
+
+mktemp_track() {
+  local t
+  t=$(mktemp)
+  TMP_FILES+=("$t")
+  echo "$t"
+}
 
 # Discover the most recent epoch published on Old Faithful.  Walks down from
 # the on-chain "current" epoch (one finalized epoch lags behind).
 discover_latest_epoch() {
-  local current
-  current=$(curl -fsSL --max-time 15 "$PUBLIC_RPC" -X POST \
+  local current resp
+  resp=$(curl -fsSL --max-time 15 "$PUBLIC_RPC" -X POST \
     -H 'Content-Type: application/json' \
-    -d '{"jsonrpc":"2.0","id":1,"method":"getEpochInfo"}' \
-    | sed -n 's/.*"epoch":\s*\([0-9]*\).*/\1/p' | head -1) || true
-  if [ -z "$current" ]; then
-    log "WARN: cannot reach $PUBLIC_RPC; falling back to probe range 1100..600"
-    current=1100
+    -d '{"jsonrpc":"2.0","id":1,"method":"getEpochInfo"}' 2>/dev/null) || resp=""
+  # Prefer jq when available (correct JSON parsing), fall back to a strict regex.
+  if command -v jq >/dev/null 2>&1 && [ -n "$resp" ]; then
+    current=$(printf '%s' "$resp" | jq -r '.result.epoch // empty' 2>/dev/null || true)
+  else
+    current=$(printf '%s' "$resp" | grep -oE '"epoch"[[:space:]]*:[[:space:]]*[0-9]+' \
+      | head -1 | grep -oE '[0-9]+' || true)
   fi
-  local probe
-  for probe in $(seq "$current" -1 $((current > 30 ? current - 30 : 1))); do
+  # Validate or fall back.
+  if ! [[ "${current:-}" =~ ^[0-9]+$ ]]; then
+    log "WARN: cannot parse epoch from $PUBLIC_RPC; falling back to probe range starting at 1500"
+    current=1500
+  fi
+  local probe lower
+  lower=$(( current > 30 ? current - 30 : 1 ))
+  for probe in $(seq "$current" -1 "$lower"); do
     if curl -fsI --max-time 8 "${BASE_URL}/${probe}/epoch-${probe}.cid" >/dev/null 2>&1; then
       echo "$probe"
       return 0
     fi
   done
-  log "ERROR: no available epoch found in probe range"
+  log "ERROR: no available epoch found in probe range [${lower}..${current}]"
   return 1
 }
 
@@ -123,13 +150,16 @@ download_epoch() {
   mkdir -p "$dir"
   chown "$FAITHFUL_OWNER":"$FAITHFUL_OWNER" "$dir" 2>/dev/null || true
   local input
-  input=$(mktemp)
+  input=$(mktemp_track)
   local suf
+  # Download to *.part filenames; rename to final names only after we
+  # verify the byte count matches Content-Length.  Atomic mv avoids
+  # faithful loading a half-written index after a sync interruption.
   for suf in "${INDEX_SUFFIXES[@]}"; do
     cat >> "$input" <<EOF
 ${BASE_URL}/${epoch}/epoch-${epoch}-${cid}-mainnet-${suf}.index
   dir=${dir}
-  out=epoch-${epoch}-${cid}-mainnet-${suf}.index
+  out=epoch-${epoch}-${cid}-mainnet-${suf}.index.part
 EOF
   done
   log "downloading epoch ${epoch} (cid=${cid:0:18}...)"
@@ -146,7 +176,27 @@ EOF
     --allow-overwrite=true \
     --continue=true >&2
   rm -f "$input"
+
+  # Verify size of every .part file before promoting it to its final name.
+  # Anything that doesn't match its remote Content-Length is left as .part
+  # so the next sync run picks it up via the completeness check.
+  local suf url want got partfile finalfile failed=0
+  for suf in "${INDEX_SUFFIXES[@]}"; do
+    partfile="${dir}/epoch-${epoch}-${cid}-mainnet-${suf}.index.part"
+    finalfile="${dir}/epoch-${epoch}-${cid}-mainnet-${suf}.index"
+    [ -f "$partfile" ] || { log "WARN: missing ${partfile}"; failed=1; continue; }
+    url="${BASE_URL}/${epoch}/epoch-${epoch}-${cid}-mainnet-${suf}.index"
+    want=$(remote_size "$url")
+    got=$(stat -c %s "$partfile" 2>/dev/null || echo 0)
+    if [ -z "$want" ] || [ "$want" != "$got" ]; then
+      log "WARN: epoch ${epoch} ${suf}: size mismatch want=${want:-?} got=${got}; leaving .part"
+      failed=1
+      continue
+    fi
+    mv -f "$partfile" "$finalfile"
+  done
   chown -R "$FAITHFUL_OWNER":"$FAITHFUL_OWNER" "$dir" 2>/dev/null || true
+  return "$failed"
 }
 
 write_config() {
@@ -264,5 +314,14 @@ main() {
 
   log "done. cached epochs: ${cur_epochs[*]:-(none)}"
 }
+
+# Serialize concurrent runs (e.g. timer firing while a manual run is in
+# flight) so we never have two aria2c processes writing into the same
+# `${dir}/*.index.part` files.
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  log "another sync is already running; exiting"
+  exit 0
+fi
 
 main "$@"

--- a/template/2026.5.5.1612/ansible/cmn/files/of1-index-sync.sh
+++ b/template/2026.5.5.1612/ansible/cmn/files/of1-index-sync.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# of1-index-sync.sh — maintain a rolling local cache of yellowstone-faithful
+# index files for the most recent N epochs, then regenerate per-epoch config
+# YAMLs and restart the faithful service.
+#
+# CAR files stay remote; only the (much smaller) per-epoch indexes are stored
+# locally.  This drives the per-query latency win measured in Phase 1
+# (getTransaction ~6x faster) at ~30 GB per recent epoch instead of ~570 GB.
+#
+# Idempotent: re-running with the same window is a no-op when nothing changed.
+# Driven by /etc/systemd/system/of1-index-sync.timer (daily) but can be
+# invoked ad-hoc.
+#
+# Env (with defaults):
+#   WINDOW                  rolling window size in epochs            (30)
+#   CACHE_DIR               where indexes live                       (/mnt/ledger/car/indexes)
+#   CONFIG_DIR              where per-epoch config YAMLs live        (/home/solv/configs)
+#   BASE_URL                Old Faithful base URL                    (https://files.old-faithful.net)
+#   CAR_BASE_URL            CAR base URL (kept remote for size)      (= BASE_URL)
+#   SERVICE_NAME            faithful systemd unit                    (faithful.service)
+#   FAITHFUL_OWNER          UNIX owner for cache + configs           (solv)
+#   JOBS                    aria2c concurrent downloads              (5)
+#   CONNS_PER_FILE          aria2c connections-per-server            (8)
+#   PUBLIC_RPC              upstream RPC for current-epoch discovery (https://api.mainnet-beta.solana.com)
+#   DRY_RUN                 set to 1 to print actions only
+#   SKIP_RESTART            set to 1 to skip systemctl restart at the end
+
+set -euo pipefail
+
+WINDOW="${WINDOW:-30}"
+CACHE_DIR="${CACHE_DIR:-/mnt/ledger/car/indexes}"
+CONFIG_DIR="${CONFIG_DIR:-/home/solv/configs}"
+BASE_URL="${BASE_URL:-https://files.old-faithful.net}"
+CAR_BASE_URL="${CAR_BASE_URL:-${BASE_URL}}"
+SERVICE_NAME="${SERVICE_NAME:-faithful.service}"
+FAITHFUL_OWNER="${FAITHFUL_OWNER:-solv}"
+JOBS="${JOBS:-5}"
+CONNS_PER_FILE="${CONNS_PER_FILE:-8}"
+PUBLIC_RPC="${PUBLIC_RPC:-https://api.mainnet-beta.solana.com}"
+DRY_RUN="${DRY_RUN:-0}"
+SKIP_RESTART="${SKIP_RESTART:-0}"
+
+INDEX_SUFFIXES=(
+  cid-to-offset-and-size
+  slot-to-cid
+  sig-to-cid
+  sig-exists
+  slot-to-blocktime
+)
+
+log() { printf "[of1-sync %s] %s\n" "$(date -Iseconds)" "$*" >&2; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || {
+    log "ERROR: required tool not found: $1"
+    exit 1
+  }
+}
+require curl
+require aria2c
+require stat
+
+# Discover the most recent epoch published on Old Faithful.  Walks down from
+# the on-chain "current" epoch (one finalized epoch lags behind).
+discover_latest_epoch() {
+  local current
+  current=$(curl -fsSL --max-time 15 "$PUBLIC_RPC" -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getEpochInfo"}' \
+    | sed -n 's/.*"epoch":\s*\([0-9]*\).*/\1/p' | head -1) || true
+  if [ -z "$current" ]; then
+    log "WARN: cannot reach $PUBLIC_RPC; falling back to probe range 1100..600"
+    current=1100
+  fi
+  local probe
+  for probe in $(seq "$current" -1 $((current > 30 ? current - 30 : 1))); do
+    if curl -fsI --max-time 8 "${BASE_URL}/${probe}/epoch-${probe}.cid" >/dev/null 2>&1; then
+      echo "$probe"
+      return 0
+    fi
+  done
+  log "ERROR: no available epoch found in probe range"
+  return 1
+}
+
+get_cid() {
+  local epoch="$1"
+  curl -fsSL --max-time 30 "${BASE_URL}/${epoch}/epoch-${epoch}.cid" | tr -d '[:space:]'
+}
+
+remote_size() {
+  curl -sIL --max-time 15 "$1" \
+    | awk -F': ' 'BEGIN{IGNORECASE=1} tolower($1)=="content-length"{print $2}' \
+    | tail -1 | tr -d '\r'
+}
+
+# Verify that every index file for an epoch is present and matches the remote
+# Content-Length.  Returns 0 if complete, 1 otherwise.
+epoch_complete() {
+  local epoch="$1"
+  local dir="${CACHE_DIR}/${epoch}"
+  [ -d "$dir" ] || return 1
+  local cid
+  cid=$(get_cid "$epoch") || return 1
+  local suf url f want got
+  for suf in "${INDEX_SUFFIXES[@]}"; do
+    f="${dir}/epoch-${epoch}-${cid}-mainnet-${suf}.index"
+    [ -f "$f" ] || return 1
+    url="${BASE_URL}/${epoch}/epoch-${epoch}-${cid}-mainnet-${suf}.index"
+    want=$(remote_size "$url")
+    got=$(stat -c %s "$f" 2>/dev/null || echo 0)
+    [ -n "$want" ] || return 1
+    [ "$want" = "$got" ] || return 1
+  done
+  return 0
+}
+
+download_epoch() {
+  local epoch="$1"
+  local cid
+  cid=$(get_cid "$epoch") || { log "ERROR: cannot fetch cid for epoch $epoch"; return 1; }
+  local dir="${CACHE_DIR}/${epoch}"
+  mkdir -p "$dir"
+  chown "$FAITHFUL_OWNER":"$FAITHFUL_OWNER" "$dir" 2>/dev/null || true
+  local input
+  input=$(mktemp)
+  local suf
+  for suf in "${INDEX_SUFFIXES[@]}"; do
+    cat >> "$input" <<EOF
+${BASE_URL}/${epoch}/epoch-${epoch}-${cid}-mainnet-${suf}.index
+  dir=${dir}
+  out=epoch-${epoch}-${cid}-mainnet-${suf}.index
+EOF
+  done
+  log "downloading epoch ${epoch} (cid=${cid:0:18}...)"
+  aria2c \
+    --input-file="$input" \
+    --max-concurrent-downloads="$JOBS" \
+    --split="$CONNS_PER_FILE" \
+    --max-connection-per-server="$CONNS_PER_FILE" \
+    --min-split-size=10M \
+    --file-allocation=none \
+    --console-log-level=warn \
+    --summary-interval=0 \
+    --auto-file-renaming=false \
+    --allow-overwrite=true \
+    --continue=true >&2
+  rm -f "$input"
+  chown -R "$FAITHFUL_OWNER":"$FAITHFUL_OWNER" "$dir" 2>/dev/null || true
+}
+
+write_config() {
+  local epoch="$1"
+  local cid
+  cid=$(get_cid "$epoch") || return 1
+  local dir="${CACHE_DIR}/${epoch}"
+  local out="${CONFIG_DIR}/config-epoch${epoch}.yaml"
+  mkdir -p "$CONFIG_DIR"
+  cat > "$out" <<EOF
+# Old Faithful RPC config for epoch ${epoch} (LOCAL indexes + REMOTE CAR)
+# Generated by of1-index-sync.sh on $(date -Iseconds)
+
+version: 1
+epoch: ${epoch}
+
+data:
+  car:
+    uri: "${CAR_BASE_URL}/${epoch}/epoch-${epoch}.car"
+  filecoin:
+    enable: false
+
+indexes:
+  cid_to_offset_and_size:
+    uri: "${dir}/epoch-${epoch}-${cid}-mainnet-cid-to-offset-and-size.index"
+  slot_to_cid:
+    uri: "${dir}/epoch-${epoch}-${cid}-mainnet-slot-to-cid.index"
+  sig_to_cid:
+    uri: "${dir}/epoch-${epoch}-${cid}-mainnet-sig-to-cid.index"
+  sig_exists:
+    uri: "${dir}/epoch-${epoch}-${cid}-mainnet-sig-exists.index"
+  slot_to_blocktime:
+    uri: "${dir}/epoch-${epoch}-${cid}-mainnet-slot-to-blocktime.index"
+EOF
+  chown "$FAITHFUL_OWNER":"$FAITHFUL_OWNER" "$out" 2>/dev/null || true
+}
+
+main() {
+  mkdir -p "$CACHE_DIR" "$CONFIG_DIR"
+  chown "$FAITHFUL_OWNER":"$FAITHFUL_OWNER" "$CACHE_DIR" "$CONFIG_DIR" 2>/dev/null || true
+
+  local latest target_min
+  latest=$(discover_latest_epoch)
+  log "latest available epoch on Old Faithful: ${latest}"
+  target_min=$((latest - WINDOW + 1))
+  [ "$target_min" -lt 0 ] && target_min=0
+  log "target window: [${target_min}..${latest}] (${WINDOW} epochs)"
+
+  local changed=0
+  local cur_epochs=()
+  local epoch
+  for epoch in $(seq "$latest" -1 "$target_min"); do
+    if epoch_complete "$epoch"; then
+      log "epoch ${epoch}: complete"
+    else
+      if [ "$DRY_RUN" = "1" ]; then
+        log "[dry-run] would download epoch ${epoch}"
+      else
+        download_epoch "$epoch" || { log "WARN: download failed for epoch ${epoch}"; continue; }
+        changed=1
+      fi
+    fi
+    [ "$DRY_RUN" = "1" ] || write_config "$epoch"
+    cur_epochs+=("$epoch")
+  done
+
+  # Evict cache directories outside the window
+  local d e
+  if [ -d "$CACHE_DIR" ]; then
+    for d in "$CACHE_DIR"/*; do
+      [ -d "$d" ] || continue
+      e=$(basename "$d")
+      [[ "$e" =~ ^[0-9]+$ ]] || continue
+      if [ "$e" -lt "$target_min" ] || [ "$e" -gt "$latest" ]; then
+        if [ "$DRY_RUN" = "1" ]; then
+          log "[dry-run] would evict epoch ${e}"
+        else
+          log "evicting epoch ${e}"
+          rm -rf "$d"
+          rm -f "${CONFIG_DIR}/config-epoch${e}.yaml"
+          changed=1
+        fi
+      fi
+    done
+  fi
+
+  # Evict orphan config YAMLs outside the window (catches legacy configs
+  # whose target epoch was never localized — those would otherwise run with
+  # all-remote URIs, ~10x slower than proxied fallback).
+  local cfg base
+  if [ -d "$CONFIG_DIR" ]; then
+    for cfg in "$CONFIG_DIR"/config-epoch*.yaml; do
+      [ -f "$cfg" ] || continue
+      base=$(basename "$cfg" .yaml)
+      e="${base#config-epoch}"
+      [[ "$e" =~ ^[0-9]+$ ]] || continue
+      if [ "$e" -lt "$target_min" ] || [ "$e" -gt "$latest" ]; then
+        if [ "$DRY_RUN" = "1" ]; then
+          log "[dry-run] would evict orphan config epoch ${e}"
+        else
+          log "evicting orphan config epoch ${e}"
+          rm -f "$cfg"
+          changed=1
+        fi
+      fi
+    done
+  fi
+
+  if [ "$changed" = "1" ] && [ "$DRY_RUN" != "1" ] && [ "$SKIP_RESTART" != "1" ]; then
+    log "restarting ${SERVICE_NAME}"
+    systemctl restart "$SERVICE_NAME" || log "WARN: restart of ${SERVICE_NAME} failed"
+  else
+    log "no changes (or restart skipped); ${SERVICE_NAME} not restarted"
+  fi
+
+  log "done. cached epochs: ${cur_epochs[*]:-(none)}"
+}
+
+main "$@"

--- a/template/2026.5.5.1612/ansible/cmn/files/start-faithful.sh
+++ b/template/2026.5.5.1612/ansible/cmn/files/start-faithful.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# start-faithful.sh — wrapper that expands a config-epoch glob and execs
+# yellowstone-faithful.  Used by faithful.service ExecStart so the rolling
+# cache (of1-index-sync.sh) can add/remove configs without editing systemd.
+
+set -euo pipefail
+
+PROXY="${PROXY:-/home/solv/proxy.yml}"
+LISTEN="${LISTEN:-:8888}"
+GRPC_LISTEN="${GRPC_LISTEN:-}"
+SEARCH_CONC="${EPOCH_SEARCH_CONCURRENCY:-64}"
+LOAD_CONC="${EPOCH_LOAD_CONCURRENCY:-1}"
+CONFIGS_DIR="${CONFIGS_DIR:-/home/solv/configs}"
+BIN="${FAITHFUL_BIN:-/home/solv/faithful-cli}"
+
+shopt -s nullglob
+configs=("${CONFIGS_DIR}"/config-epoch*.yaml)
+shopt -u nullglob
+
+if [ "${#configs[@]}" -eq 0 ]; then
+  echo "ERROR: no config-epoch*.yaml found in ${CONFIGS_DIR}" >&2
+  exit 1
+fi
+
+cmd=("$BIN" rpc "--proxy=${PROXY}" "--listen=${LISTEN}")
+if [ -n "$GRPC_LISTEN" ]; then
+  cmd+=("--grpc-listen=${GRPC_LISTEN}")
+fi
+cmd+=("--epoch-search-concurrency" "$SEARCH_CONC" "--epoch-load-concurrency" "$LOAD_CONC")
+cmd+=("${configs[@]}")
+
+exec "${cmd[@]}"

--- a/template/2026.5.5.1612/ansible/cmn/of1_index_cache_sync.yml
+++ b/template/2026.5.5.1612/ansible/cmn/of1_index_cache_sync.yml
@@ -1,0 +1,148 @@
+---
+# of1_index_cache_sync — set up a rolling cache of yellowstone-faithful
+# indexes for the last N epochs.  The CAR files stay remote (1 epoch ≈
+# 500-800 GB each) but the indexes (~30 GB / recent epoch) live on local
+# disk so the multi-step lookup chain (sig-to-cid → cid-to-offset → CAR
+# byte-range) collapses to a single CAR roundtrip.  Phase 1 measurements
+# show ~6x faster getTransaction.
+#
+# Inventory variables (with defaults):
+#   index_rpc_window_epochs   default 30
+#   of1_index_cache_dir       default /mnt/ledger/car/indexes
+#   of1_config_dir            default /home/solv/configs
+#   faithful_service_name     default faithful.service
+#   of1_run_initial_sync      default true   (run a foreground sync once on first apply)
+#   of1_initial_sync_async    default 14400  (seconds; 4h max for the initial 30-epoch fill)
+
+- name: Setup yellowstone-faithful index rolling cache
+  hosts: all
+  become: yes
+  gather_facts: no
+  vars:
+    of1_window: "{{ index_rpc_window_epochs | default(30) }}"
+    of1_cache_dir: "{{ of1_index_cache_dir | default('/mnt/ledger/car/indexes') }}"
+    of1_config_dir_var: "{{ of1_config_dir | default('/home/solv/configs') }}"
+    of1_service: "{{ faithful_service_name | default('faithful.service') }}"
+    of1_run_initial_sync_var: "{{ of1_run_initial_sync | default(true) | bool }}"
+    of1_initial_sync_async_var: "{{ of1_initial_sync_async | default(14400) | int }}"
+
+  tasks:
+    - name: Ensure aria2 is installed
+      ansible.builtin.apt:
+        name: aria2
+        state: present
+      when: ansible_os_family == 'Debian'
+
+    - name: Ensure index cache directory exists
+      ansible.builtin.file:
+        path: "{{ of1_cache_dir }}"
+        state: directory
+        owner: solv
+        group: solv
+        mode: "0755"
+
+    - name: Ensure config directory exists
+      ansible.builtin.file:
+        path: "{{ of1_config_dir_var }}"
+        state: directory
+        owner: solv
+        group: solv
+        mode: "0755"
+
+    - name: Install of1-index-sync.sh
+      ansible.builtin.copy:
+        src: files/of1-index-sync.sh
+        dest: /usr/local/bin/of1-index-sync.sh
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: Install start-faithful.sh wrapper
+      ansible.builtin.copy:
+        src: files/start-faithful.sh
+        dest: /usr/local/bin/start-faithful.sh
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: Install of1-index-sync.service
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/of1-index-sync.service
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Sync yellowstone-faithful indexes (rolling cache)
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          User=root
+          Environment=WINDOW={{ of1_window }}
+          Environment=CACHE_DIR={{ of1_cache_dir }}
+          Environment=CONFIG_DIR={{ of1_config_dir_var }}
+          Environment=SERVICE_NAME={{ of1_service }}
+          ExecStart=/usr/local/bin/of1-index-sync.sh
+          # downloads can be slow, allow up to 4h
+          TimeoutStartSec=14400
+      register: sync_service_unit
+
+    - name: Install of1-index-sync.timer
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/of1-index-sync.timer
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Daily sync of yellowstone-faithful indexes
+
+          [Timer]
+          OnCalendar=daily
+          Persistent=true
+          RandomizedDelaySec=15min
+
+          [Install]
+          WantedBy=timers.target
+      register: sync_timer_unit
+
+    - name: Switch faithful.service ExecStart to start-faithful.sh wrapper
+      ansible.builtin.lineinfile:
+        path: /etc/systemd/system/{{ of1_service }}
+        regexp: '^ExecStart='
+        line: 'ExecStart=/usr/local/bin/start-faithful.sh'
+        backup: yes
+      register: faithful_unit_changed
+
+    - name: Reload systemd
+      ansible.builtin.command: systemctl daemon-reload
+      when: sync_service_unit is changed or sync_timer_unit is changed or faithful_unit_changed is changed
+
+    - name: Enable and start of1-index-sync.timer
+      ansible.builtin.systemd:
+        name: of1-index-sync.timer
+        enabled: yes
+        state: started
+
+    - name: Restart faithful so wrapper script picks up
+      ansible.builtin.systemd:
+        name: "{{ of1_service }}"
+        state: restarted
+      when: faithful_unit_changed is changed
+
+    - name: Run initial sync (foreground, may fetch up to {{ of1_window }} epochs)
+      ansible.builtin.command: /usr/local/bin/of1-index-sync.sh
+      environment:
+        WINDOW: "{{ of1_window }}"
+        CACHE_DIR: "{{ of1_cache_dir }}"
+        CONFIG_DIR: "{{ of1_config_dir_var }}"
+        SERVICE_NAME: "{{ of1_service }}"
+      async: "{{ of1_initial_sync_async_var }}"
+      poll: 60
+      when: of1_run_initial_sync_var
+      register: initial_sync
+
+    - name: Show initial sync result
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'initial sync finished rc=' ~ (initial_sync.rc | default('skipped'))
+             if of1_run_initial_sync_var
+             else 'initial sync skipped (of1_run_initial_sync=false)' }}

--- a/template/2026.5.5.1612/ansible/mainnet-rpc/init.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-rpc/init.yml
@@ -69,3 +69,10 @@
 - import_playbook: install_of1_service.yml
   when:
     - rpc_type in ['Index RPC', 'Index RPC + gRPC']
+
+# Rolling cache: keep last N (default 30) epochs of indexes locally so
+# getTransaction etc. answer in ~70ms instead of ~300ms.  CAR files stay
+# remote.  Maintained by a daily systemd timer.
+- import_playbook: ../cmn/of1_index_cache_sync.yml
+  when:
+    - rpc_type in ['Index RPC', 'Index RPC + gRPC']


### PR DESCRIPTION
## Summary

- Add **rolling local cache of yellowstone-faithful indexes** for the most recent N (default 30) epochs.  CAR files stay remote; only per-epoch indexes (~30 GB / recent epoch) live on local disk.  This collapses the multi-step `sig-to-cid → cid-to-offset → CAR byte-range` lookup chain to a single CAR roundtrip.
- New systemd timer `of1-index-sync.timer` runs daily, downloading new epochs and evicting old ones (both cache dirs and orphan `config-epoch{N}.yaml` outside the window).
- `faithful.service` ExecStart now goes through `start-faithful.sh` which globs `config-epoch*.yaml`, so the timer can add or remove epochs without editing the unit.
- Wired into `mainnet-rpc/init.yml` for `Index RPC` / `Index RPC + gRPC` rpc_types.

## Reference verification (representative production RPC node)

Initial 30-epoch sync downloads ~991 GB at peak ~500 MB/s aggregate (≈ 1.5 h on a 50 Gbps link).  Daily timer maintains the window from there.

### getTransaction p50 across multiple test epochs (10 iters, after warm-up)

| Epoch in window? | Before (legacy all-remote URIs) | After (rolling cache) | Improvement |
|---:|---:|---:|---|
| ✅ in window | 313 ms | **45-49 ms** | **≈ 6× faster** |
| ❌ outside window (proxied fallback) | 379-1020 ms | **45-49 ms** | up to **~22× faster** |
| ❌ very old (proxied fallback) | 423 ms | **49 ms** | ~8.6× |

### Other methods (post-deploy, p50)
- `getBlockTime`: 27-45 ms across all tested epochs
- `getBlock(none|sigs)`: 64-242 ms (CAR-fetch dominated, expected)
- `getSignaturesForAddress`: 82-104 ms

### Side finding (folded into this commit)
A leftover legacy `config-epoch{N}.yaml` (single-epoch all-remote URI config from `install_of1_service.yml`) was dragging *every* RPC query down to ~1 s p50 / ~2 s p95. The eviction loop now also sweeps `CONFIG_DIR` for any `config-epoch*.yaml` whose epoch is outside the window. Retest confirmed uniform ~50 ms p50 across all surfaces.

## Test plan

- [x] `ansible-playbook --syntax-check cmn/of1_index_cache_sync.yml` (clean)
- [x] `bash -n` for `of1-index-sync.sh` and `start-faithful.sh` (clean)
- [x] 30-epoch sync verified against a representative RPC node
- [x] Daily timer enabled and active
- [x] Re-running sync (idempotency) is a no-op when no new epoch published
- [x] Eviction of legacy orphan configs verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)