### PR TITLE
feat(rpc-gateway): JSON-RPC gateway with jet_* analytics on ClickHouse

### DIFF
--- a/api/rpc-gateway/README.md
+++ b/api/rpc-gateway/README.md
@@ -1,0 +1,77 @@
+# SLV RPC Gateway
+
+A small Deno+Hono JSON-RPC gateway that fronts `yellowstone-faithful` (of1)
+and routes `jet_*` analytics methods to ClickHouse (jetstreamer data).
+
+```
+client ── POST / ─► gateway ──► standard RPC (getTransaction, …)  ── of1
+                          └──► jet_* (analytics)                  ── ClickHouse
+```
+
+Standard Solana JSON-RPC methods are forwarded untouched. Methods starting
+with `jet_` are answered locally from ClickHouse using the schema produced
+by jetstreamer.
+
+## Run locally
+
+```bash
+PORT=8889 \
+OF1_URL=http://localhost:8888 \
+CLICKHOUSE_URL=http://localhost:8123 \
+deno task start
+```
+
+## Methods
+
+| Method | Backend | Params | Returns |
+|---|---|---|---|
+| `getTransaction`, `getBlock`, `getBlockTime`, … | of1 | (standard Solana) | (standard) |
+| `jet_topPrograms` | CH | `{since?, until?, includeVotes?, limit?}` | top-N programs by invocations |
+| `jet_programStats` | CH | `{programIdBase58, since?, until?, bucketSec?}` | time series for one program |
+| `jet_slotStats` | CH | `{slot}` or `{fromSlot, toSlot}` | per-slot tx counts |
+| `jet_tpsTimeseries` | CH | `{from, to, bucketSec?}` | TPS time series |
+| `jet_epochSummary` | CH | `{epoch}` | epoch-wide aggregates |
+
+`since` / `until` / `from` / `to` accept anything `toDateTime()` parses
+(e.g. `'2026-05-09 00:00:00'` or unix timestamps).
+
+## Examples
+
+```bash
+# Standard RPC (forwarded to of1)
+curl -sX POST http://localhost:8889/ -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getVersion"}'
+
+# Top 10 non-vote programs
+curl -sX POST http://localhost:8889/ -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"jet_topPrograms",
+       "params":{"includeVotes":false,"limit":10}}'
+
+# Epoch summary
+curl -sX POST http://localhost:8889/ -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"jet_epochSummary","params":{"epoch":967}}'
+
+# Batch
+curl -sX POST http://localhost:8889/ -H 'Content-Type: application/json' \
+  -d '[
+    {"jsonrpc":"2.0","id":1,"method":"getVersion"},
+    {"jsonrpc":"2.0","id":2,"method":"jet_topPrograms","params":{"limit":3}}
+  ]'
+```
+
+## Health probes
+
+- `GET /health` — cheap, doesn't touch upstreams
+- `GET /ready` — pings of1 + ClickHouse, returns 200 only if both up
+
+## Env
+
+| Var | Default |
+|---|---|
+| `PORT` | `8889` |
+| `OF1_URL` | `http://localhost:8888` |
+| `CLICKHOUSE_URL` | `http://localhost:8123` |
+| `CLICKHOUSE_DB` | `default` |
+| `CLICKHOUSE_USER` / `CLICKHOUSE_PASS` | (none) |
+| `CLICKHOUSE_TIMEOUT_MS` | `30000` |
+| `OF1_TIMEOUT_MS` | `60000` |

--- a/api/rpc-gateway/deno.json
+++ b/api/rpc-gateway/deno.json
@@ -1,0 +1,21 @@
+{
+  "name": "@slv/rpc-gateway",
+  "version": "0.1.0",
+  "tasks": {
+    "dev": "deno run --allow-net --allow-env --watch src/main.ts",
+    "start": "deno run --allow-net --allow-env src/main.ts",
+    "compile": "deno compile --allow-net --allow-env --output dist/rpc-gateway src/main.ts",
+    "check": "deno check src/main.ts",
+    "fmt": "deno fmt src/",
+    "lint": "deno lint src/"
+  },
+  "imports": {
+    "@hono/hono": "jsr:@hono/hono@4.7.6"
+  },
+  "fmt": {
+    "lineWidth": 100,
+    "indentWidth": 2,
+    "semiColons": false,
+    "singleQuote": true
+  }
+}

--- a/api/rpc-gateway/src/handlers/jet.ts
+++ b/api/rpc-gateway/src/handlers/jet.ts
@@ -1,0 +1,230 @@
+// jet_* JSON-RPC methods backed by ClickHouse (jetstreamer data).
+//
+// Method naming convention: `jet_<camelCase>`, never colliding with standard
+// Solana RPC.  Each handler validates params, builds a parametrized SQL query
+// (no raw user-string interpolation into expressions), and returns the rows
+// as the JSON-RPC `result`.
+
+import { ClickHouseClient, quoteString } from '../lib/clickhouse.ts'
+import { err, ERROR_CODES, ok, type JsonRpcRequest, type JsonRpcResponse } from '../jsonrpc.ts'
+
+const SLOTS_PER_EPOCH = 432_000
+
+function asInt(v: unknown, name: string, fallback?: number): number {
+  if (v === undefined || v === null) {
+    if (fallback !== undefined) return fallback
+    throw new Error(`missing ${name}`)
+  }
+  const n = typeof v === 'number' ? v : parseInt(String(v), 10)
+  if (!Number.isFinite(n) || n < 0) throw new Error(`invalid ${name}`)
+  return n
+}
+
+function asBool(v: unknown, fallback: boolean): boolean {
+  if (v === undefined || v === null) return fallback
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'string') return v === 'true' || v === '1'
+  if (typeof v === 'number') return v !== 0
+  return fallback
+}
+
+function asString(v: unknown, name: string): string {
+  if (typeof v !== 'string' || v.length === 0) throw new Error(`missing ${name}`)
+  return v
+}
+
+function paramObj(params: unknown): Record<string, unknown> {
+  if (Array.isArray(params)) return (params[0] as Record<string, unknown>) ?? {}
+  if (typeof params === 'object' && params !== null) return params as Record<string, unknown>
+  return {}
+}
+
+export class JetHandlers {
+  constructor(private ch: ClickHouseClient) {}
+
+  /**
+   * jet_topPrograms({ since?, until?, includeVotes?, limit? })
+   * Top-N programs by invocation count over a time window.
+   */
+  async topPrograms(req: JsonRpcRequest): Promise<JsonRpcResponse> {
+    try {
+      const p = paramObj(req.params)
+      const since = p.since ? quoteString(asString(p.since, 'since')) : null
+      const until = p.until ? quoteString(asString(p.until, 'until')) : null
+      const includeVotes = asBool(p.includeVotes, false)
+      const limit = Math.min(asInt(p.limit, 'limit', 20), 1000)
+
+      const where: string[] = []
+      if (since) where.push(`timestamp >= toDateTime(${since})`)
+      if (until) where.push(`timestamp <  toDateTime(${until})`)
+      if (!includeVotes) where.push('is_vote = 0')
+      const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : ''
+
+      const rows = await this.ch.query<{
+        program: string
+        invocations: string
+        errors: string
+        total_cus: string
+      }>(`
+        SELECT
+          base58Encode(toString(program_id)) AS program,
+          sum(count)        AS invocations,
+          sum(error_count)  AS errors,
+          sum(total_cus)    AS total_cus
+        FROM program_invocations
+        ${whereSql}
+        GROUP BY program_id
+        ORDER BY invocations DESC
+        LIMIT ${limit}
+      `)
+      return ok(req.id ?? null, rows)
+    } catch (e) {
+      return err(req.id ?? null, ERROR_CODES.INVALID_PARAMS, (e as Error).message)
+    }
+  }
+
+  /**
+   * jet_slotStats({ slot } | { fromSlot, toSlot })
+   * Per-slot transaction counts, vote/non-vote split, blocktime.
+   */
+  async slotStats(req: JsonRpcRequest): Promise<JsonRpcResponse> {
+    try {
+      const p = paramObj(req.params)
+      let where = ''
+      if (p.slot !== undefined) {
+        where = `WHERE slot = ${asInt(p.slot, 'slot')}`
+      } else {
+        const from = asInt(p.fromSlot, 'fromSlot')
+        const to = asInt(p.toSlot, 'toSlot')
+        if (to < from) throw new Error('toSlot must be >= fromSlot')
+        if (to - from > 100_000) throw new Error('range too large (max 100k slots)')
+        where = `WHERE slot BETWEEN ${from} AND ${to}`
+      }
+      const rows = await this.ch.query(`
+        SELECT
+          slot,
+          transaction_count,
+          vote_transaction_count,
+          non_vote_transaction_count,
+          toUnixTimestamp(block_time) AS block_time
+        FROM jetstreamer_slot_status
+        ${where}
+        ORDER BY slot
+      `)
+      return ok(req.id ?? null, rows)
+    } catch (e) {
+      return err(req.id ?? null, ERROR_CODES.INVALID_PARAMS, (e as Error).message)
+    }
+  }
+
+  /**
+   * jet_tpsTimeseries({ from, to, bucketSec? })
+   * TPS time series (non-vote and total) over a time window.
+   */
+  async tpsTimeseries(req: JsonRpcRequest): Promise<JsonRpcResponse> {
+    try {
+      const p = paramObj(req.params)
+      const from = quoteString(asString(p.from, 'from'))
+      const to = quoteString(asString(p.to, 'to'))
+      const bucketSec = Math.min(Math.max(asInt(p.bucketSec, 'bucketSec', 300), 1), 86_400)
+      const rows = await this.ch.query(`
+        SELECT
+          toUnixTimestamp(toStartOfInterval(block_time, INTERVAL ${bucketSec} SECOND)) AS bucket,
+          sum(non_vote_transaction_count) / ${bucketSec} AS non_vote_tps,
+          sum(transaction_count)          / ${bucketSec} AS total_tps
+        FROM jetstreamer_slot_status
+        WHERE block_time >= toDateTime(${from})
+          AND block_time <  toDateTime(${to})
+        GROUP BY bucket
+        ORDER BY bucket
+      `)
+      return ok(req.id ?? null, rows)
+    } catch (e) {
+      return err(req.id ?? null, ERROR_CODES.INVALID_PARAMS, (e as Error).message)
+    }
+  }
+
+  /**
+   * jet_epochSummary({ epoch })
+   * Aggregate stats for a single epoch.
+   */
+  async epochSummary(req: JsonRpcRequest): Promise<JsonRpcResponse> {
+    try {
+      const p = paramObj(req.params)
+      const epoch = asInt(p.epoch, 'epoch')
+      const fromSlot = epoch * SLOTS_PER_EPOCH
+      const toSlot = fromSlot + SLOTS_PER_EPOCH - 1
+      const row = await this.ch.queryOne<{
+        slots: string
+        non_vote_txs: string
+        vote_txs: string
+        total_txs: string
+        first_block_time: number
+        last_block_time: number
+      }>(`
+        SELECT
+          count() AS slots,
+          sum(non_vote_transaction_count) AS non_vote_txs,
+          sum(vote_transaction_count)     AS vote_txs,
+          sum(transaction_count)          AS total_txs,
+          toUnixTimestamp(min(block_time)) AS first_block_time,
+          toUnixTimestamp(max(block_time)) AS last_block_time
+        FROM jetstreamer_slot_status
+        WHERE slot BETWEEN ${fromSlot} AND ${toSlot}
+      `)
+      if (!row || asInt(row.slots, 'slots', 0) === 0) {
+        return ok(req.id ?? null, null)
+      }
+      const programInvocations = await this.ch.queryOne<{ programs: string; invocations: string }>(`
+        SELECT
+          uniqExact(program_id) AS programs,
+          sum(count)            AS invocations
+        FROM program_invocations
+        WHERE slot BETWEEN ${fromSlot} AND ${toSlot}
+      `)
+      return ok(req.id ?? null, {
+        epoch,
+        ...row,
+        distinct_programs: programInvocations?.programs ?? '0',
+        program_invocations: programInvocations?.invocations ?? '0',
+      })
+    } catch (e) {
+      return err(req.id ?? null, ERROR_CODES.INVALID_PARAMS, (e as Error).message)
+    }
+  }
+
+  /**
+   * jet_programStats({ programIdBase58, since?, until?, bucketSec? })
+   * Time series for a single program.
+   */
+  async programStats(req: JsonRpcRequest): Promise<JsonRpcResponse> {
+    try {
+      const p = paramObj(req.params)
+      const programB58 = asString(p.programIdBase58, 'programIdBase58')
+      const since = p.since ? quoteString(asString(p.since, 'since')) : null
+      const until = p.until ? quoteString(asString(p.until, 'until')) : null
+      const bucketSec = Math.min(Math.max(asInt(p.bucketSec, 'bucketSec', 3600), 60), 86_400)
+
+      const where: string[] = [
+        `program_id = base58Decode(${quoteString(programB58)})`,
+      ]
+      if (since) where.push(`timestamp >= toDateTime(${since})`)
+      if (until) where.push(`timestamp <  toDateTime(${until})`)
+
+      const rows = await this.ch.query(`
+        SELECT
+          toUnixTimestamp(toStartOfInterval(timestamp, INTERVAL ${bucketSec} SECOND)) AS bucket,
+          sum(count)        AS invocations,
+          sum(error_count)  AS errors,
+          sum(total_cus)    AS total_cus
+        FROM program_invocations
+        WHERE ${where.join(' AND ')}
+        GROUP BY bucket
+        ORDER BY bucket
+      `)
+      return ok(req.id ?? null, rows)
+    } catch (e) {
+      return err(req.id ?? null, ERROR_CODES.INVALID_PARAMS, (e as Error).message)
+    }
+  }
+}

--- a/api/rpc-gateway/src/handlers/jet.ts
+++ b/api/rpc-gateway/src/handlers/jet.ts
@@ -33,8 +33,42 @@ function asString(v: unknown, name: string): string {
   return v
 }
 
+/**
+ * Defense-in-depth whitelist for date/time strings that reach SQL via
+ * `toDateTime()`.  Accepts:
+ *   - integer unix seconds (10 digits) or millis (13 digits)
+ *   - 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS' (loose, no other chars)
+ * Although `toDateTime` would reject malformed input as a parse error,
+ * we'd rather not let arbitrary content into the SQL string at all.
+ */
+const DATE_RE = /^(?:\d{10}|\d{13}|\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?)$/
+
+function asDateString(v: unknown, name: string): string {
+  const s = asString(v, name)
+  if (!DATE_RE.test(s)) {
+    throw new Error(
+      `invalid ${name}: expected unix seconds/millis or 'YYYY-MM-DD[ HH:MM:SS]'`,
+    )
+  }
+  return s
+}
+
+/** Whitelist for Solana base58 pubkeys (32-44 chars, base58 alphabet). */
+const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/
+
+function asBase58Pubkey(v: unknown, name: string): string {
+  const s = asString(v, name)
+  if (!BASE58_RE.test(s)) throw new Error(`invalid ${name}: not a valid base58 pubkey`)
+  return s
+}
+
 function paramObj(params: unknown): Record<string, unknown> {
-  if (Array.isArray(params)) return (params[0] as Record<string, unknown>) ?? {}
+  if (Array.isArray(params)) {
+    if (params.length > 1) {
+      throw new Error('positional params not supported; pass a single object')
+    }
+    return (params[0] as Record<string, unknown>) ?? {}
+  }
   if (typeof params === 'object' && params !== null) return params as Record<string, unknown>
   return {}
 }
@@ -49,8 +83,8 @@ export class JetHandlers {
   async topPrograms(req: JsonRpcRequest): Promise<JsonRpcResponse> {
     try {
       const p = paramObj(req.params)
-      const since = p.since ? quoteString(asString(p.since, 'since')) : null
-      const until = p.until ? quoteString(asString(p.until, 'until')) : null
+      const since = p.since ? quoteString(asDateString(p.since, 'since')) : null
+      const until = p.until ? quoteString(asDateString(p.until, 'until')) : null
       const includeVotes = asBool(p.includeVotes, false)
       const limit = Math.min(asInt(p.limit, 'limit', 20), 1000)
 
@@ -124,8 +158,8 @@ export class JetHandlers {
   async tpsTimeseries(req: JsonRpcRequest): Promise<JsonRpcResponse> {
     try {
       const p = paramObj(req.params)
-      const from = quoteString(asString(p.from, 'from'))
-      const to = quoteString(asString(p.to, 'to'))
+      const from = quoteString(asDateString(p.from, 'from'))
+      const to = quoteString(asDateString(p.to, 'to'))
       const bucketSec = Math.min(Math.max(asInt(p.bucketSec, 'bucketSec', 300), 1), 86_400)
       const rows = await this.ch.query(`
         SELECT
@@ -200,9 +234,9 @@ export class JetHandlers {
   async programStats(req: JsonRpcRequest): Promise<JsonRpcResponse> {
     try {
       const p = paramObj(req.params)
-      const programB58 = asString(p.programIdBase58, 'programIdBase58')
-      const since = p.since ? quoteString(asString(p.since, 'since')) : null
-      const until = p.until ? quoteString(asString(p.until, 'until')) : null
+      const programB58 = asBase58Pubkey(p.programIdBase58, 'programIdBase58')
+      const since = p.since ? quoteString(asDateString(p.since, 'since')) : null
+      const until = p.until ? quoteString(asDateString(p.until, 'until')) : null
       const bucketSec = Math.min(Math.max(asInt(p.bucketSec, 'bucketSec', 3600), 60), 86_400)
 
       const where: string[] = [

--- a/api/rpc-gateway/src/handlers/proxy.ts
+++ b/api/rpc-gateway/src/handlers/proxy.ts
@@ -1,0 +1,55 @@
+// Forwards standard Solana JSON-RPC methods to the upstream of1
+// (yellowstone-faithful) endpoint.
+
+import { err, ERROR_CODES, ok, type JsonRpcRequest, type JsonRpcResponse } from '../jsonrpc.ts'
+
+export type ProxyConfig = {
+  upstream: string
+  timeoutMs?: number
+}
+
+export class StandardProxy {
+  private url: URL
+  private timeoutMs: number
+
+  constructor(cfg: ProxyConfig) {
+    this.url = new URL(cfg.upstream)
+    this.timeoutMs = cfg.timeoutMs ?? 60_000
+  }
+
+  async handle(req: JsonRpcRequest): Promise<JsonRpcResponse> {
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs)
+    try {
+      const res = await fetch(this.url.toString(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req),
+        signal: ctrl.signal,
+      })
+      if (!res.ok) {
+        return err(
+          req.id ?? null,
+          ERROR_CODES.UPSTREAM_ERROR,
+          `upstream returned HTTP ${res.status}`,
+        )
+      }
+      const body = await res.json()
+      // Upstream already returns a JsonRpcResponse — pass through.
+      if (
+        typeof body === 'object' &&
+        body !== null &&
+        'jsonrpc' in body
+      ) {
+        return body as JsonRpcResponse
+      }
+      // Unexpected: wrap as success.
+      return ok(req.id ?? null, body)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      return err(req.id ?? null, ERROR_CODES.UPSTREAM_ERROR, msg)
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/api/rpc-gateway/src/jsonrpc.ts
+++ b/api/rpc-gateway/src/jsonrpc.ts
@@ -58,3 +58,12 @@ export function validate(body: unknown): JsonRpcRequest | null {
   if (typeof obj.method !== 'string') return null
   return body as JsonRpcRequest
 }
+
+/**
+ * JSON-RPC 2.0 notifications have no `id` field at all.  The spec
+ * requires the server to NOT respond to notifications.  Note this is
+ * different from `id: null` (which is a regular request).
+ */
+export function isNotification(req: JsonRpcRequest): boolean {
+  return !('id' in req)
+}

--- a/api/rpc-gateway/src/jsonrpc.ts
+++ b/api/rpc-gateway/src/jsonrpc.ts
@@ -1,0 +1,60 @@
+// JSON-RPC 2.0 minimal types + helpers.
+
+export type JsonRpcId = string | number | null
+
+export type JsonRpcRequest = {
+  jsonrpc: '2.0'
+  method: string
+  params?: unknown
+  id?: JsonRpcId
+}
+
+export type JsonRpcSuccess = {
+  jsonrpc: '2.0'
+  result: unknown
+  id: JsonRpcId
+}
+
+export type JsonRpcError = {
+  jsonrpc: '2.0'
+  error: { code: number; message: string; data?: unknown }
+  id: JsonRpcId
+}
+
+export type JsonRpcResponse = JsonRpcSuccess | JsonRpcError
+
+export const ERROR_CODES = {
+  PARSE_ERROR: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL_ERROR: -32603,
+  // server-defined (-32000 to -32099)
+  UPSTREAM_ERROR: -32000,
+} as const
+
+export function ok(id: JsonRpcId, result: unknown): JsonRpcSuccess {
+  return { jsonrpc: '2.0', id, result }
+}
+
+export function err(
+  id: JsonRpcId,
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcError {
+  return { jsonrpc: '2.0', id, error: { code, message, data } }
+}
+
+/** Validate the shape of an incoming request. */
+export function validate(body: unknown): JsonRpcRequest | null {
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    Array.isArray(body)
+  ) return null
+  const obj = body as Record<string, unknown>
+  if (obj.jsonrpc !== '2.0') return null
+  if (typeof obj.method !== 'string') return null
+  return body as JsonRpcRequest
+}

--- a/api/rpc-gateway/src/lib/clickhouse.ts
+++ b/api/rpc-gateway/src/lib/clickhouse.ts
@@ -1,0 +1,77 @@
+// Minimal ClickHouse HTTP client.  HTTP only — no native protocol — keeps
+// the dependency surface to Deno's built-in fetch.
+
+export type ClickHouseConfig = {
+  url: string
+  database?: string
+  username?: string
+  password?: string
+  timeoutMs?: number
+}
+
+export class ClickHouseClient {
+  private base: URL
+  private headers: HeadersInit
+  private timeoutMs: number
+
+  constructor(cfg: ClickHouseConfig) {
+    this.base = new URL(cfg.url)
+    if (cfg.database) this.base.searchParams.set('database', cfg.database)
+    this.timeoutMs = cfg.timeoutMs ?? 30_000
+    this.headers = {}
+    if (cfg.username) {
+      const auth = btoa(`${cfg.username}:${cfg.password ?? ''}`)
+      ;(this.headers as Record<string, string>).Authorization = `Basic ${auth}`
+    }
+  }
+
+  /**
+   * Execute a SQL query and return parsed rows.  Always appends `FORMAT
+   * JSONEachRow` if the caller didn't include a FORMAT clause already.
+   */
+  async query<T = Record<string, unknown>>(sql: string): Promise<T[]> {
+    const finalSql = /\bFORMAT\s+\w+\s*$/i.test(sql.trim())
+      ? sql
+      : `${sql.trimEnd()} FORMAT JSONEachRow`
+
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs)
+    try {
+      const res = await fetch(this.base.toString(), {
+        method: 'POST',
+        headers: this.headers,
+        body: finalSql,
+        signal: ctrl.signal,
+      })
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        throw new Error(`ClickHouse HTTP ${res.status}: ${body.slice(0, 300)}`)
+      }
+      const text = await res.text()
+      if (!text.trim()) return []
+      // JSONEachRow returns one JSON object per line.
+      const rows: T[] = []
+      for (const line of text.split('\n')) {
+        if (!line) continue
+        rows.push(JSON.parse(line))
+      }
+      return rows
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  /** Fire a query and return the first row, or null. */
+  async queryOne<T = Record<string, unknown>>(sql: string): Promise<T | null> {
+    const rows = await this.query<T>(sql)
+    return rows[0] ?? null
+  }
+}
+
+/** Minimal SQL escaper for string literals.  Only safe for identifiers and
+ * literal substitution where input is already restricted to known shapes
+ * (e.g. base58 addresses, hex strings, integers).  Do NOT use for arbitrary
+ * user input. */
+export function quoteString(s: string): string {
+  return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+}

--- a/api/rpc-gateway/src/main.ts
+++ b/api/rpc-gateway/src/main.ts
@@ -22,6 +22,7 @@ import { StandardProxy } from './handlers/proxy.ts'
 import {
   err,
   ERROR_CODES,
+  isNotification,
   type JsonRpcRequest,
   type JsonRpcResponse,
   validate,
@@ -97,6 +98,13 @@ app.get('/ready', async (c) => {
 })
 
 // JSON-RPC entry point.  Accepts a single request or a batch.
+//
+// Conformance notes:
+// - A request whose JSON object has no `id` field is a *notification*; the
+//   server MUST process it but MUST NOT respond.
+// - An empty batch (`[]`) MUST be answered with a single Invalid Request
+//   error, not an empty array.
+// - For a batch of all-notifications, the server returns no body.
 app.post('/', async (c) => {
   let body: unknown
   try {
@@ -105,23 +113,39 @@ app.post('/', async (c) => {
     return c.json(err(null, ERROR_CODES.PARSE_ERROR, 'invalid JSON'), 400)
   }
 
-  const handle = async (raw: unknown): Promise<JsonRpcResponse> => {
+  // Returns null when the request was a notification (no response).
+  const handle = async (raw: unknown): Promise<JsonRpcResponse | null> => {
     const req = validate(raw)
-    if (!req) return err(null, ERROR_CODES.INVALID_REQUEST, 'invalid JSON-RPC request')
+    if (!req) {
+      // For an invalid request that *might* have been a notification we
+      // still respond with INVALID_REQUEST per spec — `id` of an invalid
+      // request is unknown, so we use null.
+      return err(null, ERROR_CODES.INVALID_REQUEST, 'invalid JSON-RPC request')
+    }
+    const notification = isNotification(req)
     try {
-      return await dispatch(req)
+      const resp = await dispatch(req)
+      return notification ? null : resp
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
       log('dispatch_error', { method: req.method, error: msg })
+      if (notification) return null
       return err(req.id ?? null, ERROR_CODES.INTERNAL_ERROR, msg)
     }
   }
 
   if (Array.isArray(body)) {
-    const out = await Promise.all(body.map(handle))
-    return c.json(out)
+    if (body.length === 0) {
+      return c.json(err(null, ERROR_CODES.INVALID_REQUEST, 'empty batch'), 200)
+    }
+    const responses = (await Promise.all(body.map(handle))).filter(
+      (r): r is JsonRpcResponse => r !== null,
+    )
+    if (responses.length === 0) return c.body(null, 204)
+    return c.json(responses)
   }
   const out = await handle(body)
+  if (out === null) return c.body(null, 204)
   return c.json(out)
 })
 

--- a/api/rpc-gateway/src/main.ts
+++ b/api/rpc-gateway/src/main.ts
@@ -1,0 +1,129 @@
+// SLV RPC Gateway — JSON-RPC 2.0 server that fronts of1 (yellowstone-faithful)
+// and routes `jet_*` analytics methods to ClickHouse (jetstreamer data).
+//
+// Standard Solana RPC methods (getTransaction, getBlock, …) are forwarded
+// untouched to OF1_URL. Methods starting with `jet_` are answered locally
+// from ClickHouse via CLICKHOUSE_URL.
+//
+// Configured via env:
+//   PORT              listen port (default 8889 — leaves 8888 for of1)
+//   OF1_URL           upstream JSON-RPC base (default http://localhost:8888)
+//   CLICKHOUSE_URL    ClickHouse HTTP base (default http://localhost:8123)
+//   CLICKHOUSE_DB     database name (default default)
+//   CLICKHOUSE_USER   optional Basic auth username
+//   CLICKHOUSE_PASS   optional Basic auth password
+//   CLICKHOUSE_TIMEOUT_MS  per-query timeout (default 30000)
+//   OF1_TIMEOUT_MS         per-proxy-call timeout (default 60000)
+
+import { Hono } from '@hono/hono'
+import { ClickHouseClient } from './lib/clickhouse.ts'
+import { JetHandlers } from './handlers/jet.ts'
+import { StandardProxy } from './handlers/proxy.ts'
+import {
+  err,
+  ERROR_CODES,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+  validate,
+} from './jsonrpc.ts'
+
+const PORT = parseInt(Deno.env.get('PORT') ?? '8889', 10)
+const OF1_URL = Deno.env.get('OF1_URL') ?? 'http://localhost:8888'
+const CLICKHOUSE_URL = Deno.env.get('CLICKHOUSE_URL') ?? 'http://localhost:8123'
+const CLICKHOUSE_DB = Deno.env.get('CLICKHOUSE_DB') ?? 'default'
+const CLICKHOUSE_USER = Deno.env.get('CLICKHOUSE_USER') ?? undefined
+const CLICKHOUSE_PASS = Deno.env.get('CLICKHOUSE_PASS') ?? undefined
+const CLICKHOUSE_TIMEOUT_MS = parseInt(Deno.env.get('CLICKHOUSE_TIMEOUT_MS') ?? '30000', 10)
+const OF1_TIMEOUT_MS = parseInt(Deno.env.get('OF1_TIMEOUT_MS') ?? '60000', 10)
+
+const ch = new ClickHouseClient({
+  url: CLICKHOUSE_URL,
+  database: CLICKHOUSE_DB,
+  username: CLICKHOUSE_USER,
+  password: CLICKHOUSE_PASS,
+  timeoutMs: CLICKHOUSE_TIMEOUT_MS,
+})
+const jet = new JetHandlers(ch)
+const proxy = new StandardProxy({ upstream: OF1_URL, timeoutMs: OF1_TIMEOUT_MS })
+
+const log = (msg: string, extra?: Record<string, unknown>) => {
+  const payload = { ts: new Date().toISOString(), msg, ...extra }
+  console.log(JSON.stringify(payload))
+}
+
+async function dispatch(req: JsonRpcRequest): Promise<JsonRpcResponse> {
+  // Whitelist of jet_* methods — any other jet_* is method-not-found.
+  switch (req.method) {
+    case 'jet_topPrograms':    return jet.topPrograms(req)
+    case 'jet_slotStats':      return jet.slotStats(req)
+    case 'jet_tpsTimeseries':  return jet.tpsTimeseries(req)
+    case 'jet_epochSummary':   return jet.epochSummary(req)
+    case 'jet_programStats':   return jet.programStats(req)
+  }
+  if (req.method.startsWith('jet_')) {
+    return err(req.id ?? null, ERROR_CODES.METHOD_NOT_FOUND, `unknown jet_ method: ${req.method}`)
+  }
+  // Anything else → forward to of1.
+  return proxy.handle(req)
+}
+
+const app = new Hono()
+
+app.use('*', async (c, next) => {
+  c.header('Access-Control-Allow-Origin', '*')
+  c.header('Access-Control-Allow-Headers', 'Content-Type')
+  c.header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS')
+  if (c.req.method === 'OPTIONS') return c.body(null, 204)
+  return await next()
+})
+
+// Health probe — does NOT touch upstreams (kept cheap).
+app.get('/health', (c) => c.json({ ok: true }))
+
+// Deeper readiness — pings of1 + CH.  Use sparingly.
+app.get('/ready', async (c) => {
+  const checks = await Promise.allSettled([
+    fetch(OF1_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getVersion' }),
+    }).then((r) => r.ok),
+    ch.queryOne('SELECT 1 AS ok').then(() => true),
+  ])
+  const of1Ok = checks[0].status === 'fulfilled' && checks[0].value === true
+  const chOk = checks[1].status === 'fulfilled' && checks[1].value === true
+  const status = of1Ok && chOk ? 200 : 503
+  return c.json({ of1: of1Ok, clickhouse: chOk }, status)
+})
+
+// JSON-RPC entry point.  Accepts a single request or a batch.
+app.post('/', async (c) => {
+  let body: unknown
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json(err(null, ERROR_CODES.PARSE_ERROR, 'invalid JSON'), 400)
+  }
+
+  const handle = async (raw: unknown): Promise<JsonRpcResponse> => {
+    const req = validate(raw)
+    if (!req) return err(null, ERROR_CODES.INVALID_REQUEST, 'invalid JSON-RPC request')
+    try {
+      return await dispatch(req)
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      log('dispatch_error', { method: req.method, error: msg })
+      return err(req.id ?? null, ERROR_CODES.INTERNAL_ERROR, msg)
+    }
+  }
+
+  if (Array.isArray(body)) {
+    const out = await Promise.all(body.map(handle))
+    return c.json(out)
+  }
+  const out = await handle(body)
+  return c.json(out)
+})
+
+log('starting', { port: PORT, of1: OF1_URL, clickhouse: CLICKHOUSE_URL })
+Deno.serve({ port: PORT }, app.fetch)

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,8 @@
 {
   "workspace": [
     "cli",
-    "api/slv-api"
+    "api/slv-api",
+    "api/rpc-gateway"
   ],
   "nodeModulesDir": "auto",
   "tasks": {

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@elsoul/child-process@1.2.0": "1.2.0",
     "jsr:@hono/hono@4.7.6": "4.7.6",
+    "jsr:@hono/hono@^4.6.13": "4.7.6",
     "jsr:@std/assert@0.224": "0.224.0",
     "jsr:@std/assert@1": "1.0.16",
     "jsr:@std/dotenv@0.225.2": "0.225.2",
@@ -372,7 +373,8 @@
       ],
       "optionalDependencies": [
         "koffi"
-      ]
+      ],
+      "deprecated": true
     },
     "@scalar/core@0.3.30": {
       "integrity": "sha512-eBp1phI8u/GZR+yy9SwRTr07n3+Va+xoZJVT6tczG799eynpXiQJuUQ4S2S1cb0cmOV0ZkwHRNG3ldMQHdJgWQ==",
@@ -1193,6 +1195,11 @@
       "npm:mysql2@3.16.0"
     ],
     "members": {
+      "api/rpc-gateway": {
+        "dependencies": [
+          "jsr:@hono/hono@^4.6.13"
+        ]
+      },
       "cli": {
         "dependencies": [
           "jsr:@std/assert@1",

--- a/oss-skills/slv-rpc-gateway/SKILL.md
+++ b/oss-skills/slv-rpc-gateway/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: slv-rpc-gateway
+description: A small Deno+Hono JSON-RPC gateway that fronts yellowstone-faithful (of1) and routes `jet_*` analytics methods to ClickHouse (jetstreamer data). Standard Solana RPC methods pass straight through; new analytic methods are answered from precomputed jetstreamer aggregates. Same pattern Helius uses for its Enhanced Transactions / DAS APIs.
+---
+
+# SLV RPC Gateway Skill
+
+A unified JSON-RPC entry point that combines the per-call latency of of1
+(yellowstone-faithful) with the bulk-analytics speed of jetstreamer's
+ClickHouse tables. Same architectural pattern Helius uses for its enhanced
+APIs (Enhanced Transactions, DAS, Priority Fee, …): standard methods go to
+the underlying RPC, new methods go to a custom indexer.
+
+```
+client ── POST / ─► rpc-gateway ──► standard RPC (getTransaction, …)  ── of1
+                              └──► jet_* (analytics)                  ── ClickHouse
+```
+
+## Why
+
+| Layer | Component | Responsibility |
+|---|---|---|
+| Per-call (read 1 tx) | `yellowstone-faithful` (of1) | `getTransaction`, `getBlock`, `getBlockTime`, `getSignaturesForAddress` |
+| Cross-epoch analytics | jetstreamer + ClickHouse | aggregations over millions of txs |
+| **Unified surface** | **rpc-gateway (this skill)** | dispatch by method name, return JSON-RPC |
+
+Without the gateway, clients have to know two endpoints and two protocols
+(JSON-RPC vs ClickHouse SQL). With it, everything is one JSON-RPC endpoint.
+
+## Methods (MVP)
+
+| Method | Backend | Notes |
+|---|---|---|
+| Standard Solana RPC | of1 | Forwarded transparently |
+| `jet_topPrograms` | CH | Top-N programs by invocation count over a time window |
+| `jet_programStats` | CH | Time series for a single program (calls, errors, CU) |
+| `jet_slotStats` | CH | Per-slot tx counts (single slot or range up to 100k) |
+| `jet_tpsTimeseries` | CH | Total + non-vote TPS in time buckets |
+| `jet_epochSummary` | CH | Aggregate stats for one epoch |
+
+All `jet_*` methods return JSON arrays of records (`{column: value, …}`)
+following the JSON-RPC `result` envelope.
+
+## Source
+
+`api/rpc-gateway/` in the slv repo:
+
+```
+api/rpc-gateway/
+├── deno.json
+├── README.md
+└── src/
+    ├── main.ts                # Hono app, env, dispatcher
+    ├── jsonrpc.ts             # JSON-RPC 2.0 helpers
+    ├── handlers/
+    │   ├── proxy.ts           # forward standard methods to of1
+    │   └── jet.ts             # jet_* implementations
+    └── lib/
+        └── clickhouse.ts      # minimal CH HTTP client
+```
+
+Single-file deploy: `deno run --allow-net --allow-env src/main.ts`.
+
+## Deployment
+
+`template/<VERSION>/ansible/cmn/install_rpc_gateway.yml` provisions
+end-to-end on any node that has of1 + ClickHouse reachable:
+
+1. Installs Deno for the `solv` user.
+2. Clones the slv repo (depth=1) and rsyncs `api/rpc-gateway/` to
+   `/opt/rpc-gateway/`.
+3. Pre-caches deno dependencies.
+4. Installs `rpc-gateway.service` systemd unit and enables/starts it.
+5. Waits for `/health` to return 200.
+
+Inventory variables: `rpc_gateway_port`, `rpc_gateway_of1_url`,
+`rpc_gateway_ch_url`, `rpc_gateway_ch_db`, `rpc_gateway_ch_user`,
+`rpc_gateway_ch_pass`.
+
+## Topology recommendations
+
+- Co-locate the gateway with each of1 RPC node (cheap, low latency to of1).
+- Point `CLICKHOUSE_URL` at the central jetstreamer node, or at a regional
+  ClickHouse read replica if cross-region latency matters.
+- Public-facing nodes should additionally:
+  - Add a read-only ClickHouse user and bind it via `CLICKHOUSE_USER`/`PASS`.
+  - Front the gateway with HTTPS termination (Caddy / nginx) and rate-limit
+    `jet_*` separately from standard methods (jet_ are heavier).
+
+## Health probes
+
+- `GET /health` — synchronous, doesn't touch upstreams (cheap; OK to poll
+  often).
+- `GET /ready` — pings of1 + CH; returns 200 only if both up. 503 otherwise.
+  Use sparingly.
+
+## Adding a new `jet_*` method
+
+1. Add a handler in `src/handlers/jet.ts`.
+2. Add the dispatch arm in `src/main.ts`'s `dispatch()`.
+3. Document in `api/rpc-gateway/README.md`.
+4. Smoke test: `curl -X POST http://localhost:8889 -d '{"jsonrpc":"2.0",…}'`.
+
+The handler should:
+- Validate params with the local helpers in `jet.ts` (`asInt`, `asString`,
+  `asBool`, `paramObj`).
+- Use `quoteString()` for any literal that ends up in SQL.
+- Return `ok(req.id, rows)` or `err(req.id, code, message)`.
+
+## Helius parallel
+
+Helius's Enhanced Transactions (`/v0/transactions`), DAS (`getAsset`,
+`searchAssets`), Priority Fee, etc. are exactly this pattern: standard
+methods reach the underlying validator/RPC; enhanced methods are answered
+from their own indexers (Photon for ZK Compression state, custom indexers
+for parsed transactions / NFT metadata). The mechanics are the same — only
+the dataset and method names differ.

--- a/template/2026.5.5.1612/ansible/cmn/install_rpc_gateway.yml
+++ b/template/2026.5.5.1612/ansible/cmn/install_rpc_gateway.yml
@@ -1,0 +1,119 @@
+---
+# Install + start the SLV RPC Gateway (Deno+Hono service that fronts
+# yellowstone-faithful and routes jet_* analytics methods to ClickHouse).
+#
+# Inventory variables (with defaults):
+#   rpc_gateway_repo        https://github.com/ValidatorsDAO/slv
+#   rpc_gateway_repo_ref    main
+#   rpc_gateway_install_dir /opt/rpc-gateway
+#   rpc_gateway_port        8889
+#   rpc_gateway_of1_url     http://localhost:8888
+#   rpc_gateway_ch_url      http://localhost:8123     (when CH lives elsewhere,
+#                                                      point to that host:port)
+#   rpc_gateway_ch_db       default
+#   rpc_gateway_ch_user     (unset)
+#   rpc_gateway_ch_pass     (unset)
+
+- name: Install + start the SLV RPC Gateway
+  hosts: all
+  become: yes
+  gather_facts: yes
+  vars:
+    rg_repo: "{{ rpc_gateway_repo | default('https://github.com/ValidatorsDAO/slv') }}"
+    rg_ref: "{{ rpc_gateway_repo_ref | default('main') }}"
+    rg_dir: "{{ rpc_gateway_install_dir | default('/opt/rpc-gateway') }}"
+    rg_port: "{{ rpc_gateway_port | default(8889) }}"
+    rg_of1: "{{ rpc_gateway_of1_url | default('http://localhost:8888') }}"
+    rg_ch: "{{ rpc_gateway_ch_url | default('http://localhost:8123') }}"
+    rg_ch_db: "{{ rpc_gateway_ch_db | default('default') }}"
+    rg_ch_user: "{{ rpc_gateway_ch_user | default('') }}"
+    rg_ch_pass: "{{ rpc_gateway_ch_pass | default('') }}"
+
+  tasks:
+    - name: Install unzip (deno installer needs it)
+      ansible.builtin.apt:
+        name: [unzip, curl, git]
+        state: present
+
+    - name: Install Deno for solv user
+      become_user: solv
+      ansible.builtin.shell: |
+        curl -fsSL https://deno.land/install.sh | sh -s -- -y
+      args:
+        creates: /home/solv/.deno/bin/deno
+
+    - name: Ensure install dir
+      ansible.builtin.file:
+        path: "{{ rg_dir }}"
+        state: directory
+        owner: solv
+        group: solv
+        mode: "0755"
+
+    - name: Clone slv repo (sparse — we only need api/rpc-gateway/)
+      become_user: solv
+      ansible.builtin.git:
+        repo: "{{ rg_repo }}"
+        dest: "{{ rg_dir }}/_src"
+        version: "{{ rg_ref }}"
+        force: no
+        depth: 1
+
+    - name: Sync api/rpc-gateway/ into {{ rg_dir }}
+      ansible.builtin.shell: |
+        rsync -aH --delete {{ rg_dir }}/_src/api/rpc-gateway/ {{ rg_dir }}/
+      args:
+        creates: "{{ rg_dir }}/src/main.ts"
+
+    - name: Pre-cache deno deps (one-shot warm-up)
+      become_user: solv
+      ansible.builtin.shell: |
+        /home/solv/.deno/bin/deno cache src/main.ts
+      args:
+        chdir: "{{ rg_dir }}"
+      changed_when: false
+
+    - name: Install rpc-gateway.service
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/rpc-gateway.service
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=SLV RPC Gateway (JSON-RPC; forwards to of1, routes jet_* to ClickHouse)
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=simple
+          User=solv
+          Group=solv
+          WorkingDirectory={{ rg_dir }}
+          Environment=PORT={{ rg_port }}
+          Environment=OF1_URL={{ rg_of1 }}
+          Environment=CLICKHOUSE_URL={{ rg_ch }}
+          Environment=CLICKHOUSE_DB={{ rg_ch_db }}
+          {% if rg_ch_user %}Environment=CLICKHOUSE_USER={{ rg_ch_user }}{% endif %}
+          {% if rg_ch_pass %}Environment=CLICKHOUSE_PASS={{ rg_ch_pass }}{% endif %}
+          ExecStart=/home/solv/.deno/bin/deno run --allow-net --allow-env src/main.ts
+          Restart=always
+          RestartSec=5
+          LimitNOFILE=65536
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Enable + start rpc-gateway.service
+      ansible.builtin.systemd:
+        name: rpc-gateway.service
+        daemon_reload: yes
+        enabled: yes
+        state: restarted
+
+    - name: Wait for /health to respond
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ rg_port }}/health"
+        status_code: 200
+      register: rg_health
+      retries: 10
+      delay: 2
+      until: rg_health.status == 200

--- a/template/2026.5.5.1612/ansible/cmn/install_rpc_gateway.yml
+++ b/template/2026.5.5.1612/ansible/cmn/install_rpc_gateway.yml
@@ -28,6 +28,7 @@
     rg_ch_db: "{{ rpc_gateway_ch_db | default('default') }}"
     rg_ch_user: "{{ rpc_gateway_ch_user | default('') }}"
     rg_ch_pass: "{{ rpc_gateway_ch_pass | default('') }}"
+    rg_deno_version: "{{ rpc_gateway_deno_version | default('v2.7.14') }}"
 
   tasks:
     - name: Install unzip (deno installer needs it)
@@ -35,10 +36,10 @@
         name: [unzip, curl, git]
         state: present
 
-    - name: Install Deno for solv user
+    - name: Install Deno for solv user (pinned to {{ rg_deno_version }})
       become_user: solv
       ansible.builtin.shell: |
-        curl -fsSL https://deno.land/install.sh | sh -s -- -y
+        curl -fsSL https://deno.land/install.sh | sh -s -- -y {{ rg_deno_version }}
       args:
         creates: /home/solv/.deno/bin/deno
 
@@ -58,12 +59,18 @@
         version: "{{ rg_ref }}"
         force: no
         depth: 1
+      register: rg_git
 
+    # Sync runs every play (no `creates:`) so updates propagate after a
+    # `git pull`.  rsync is itself idempotent — only files that differ
+    # are written.  When something changes, the registered handler at
+    # the bottom of the play restarts the gateway.
     - name: Sync api/rpc-gateway/ into {{ rg_dir }}
       ansible.builtin.shell: |
-        rsync -aH --delete {{ rg_dir }}/_src/api/rpc-gateway/ {{ rg_dir }}/
-      args:
-        creates: "{{ rg_dir }}/src/main.ts"
+        rsync -aH --delete --out-format='%n' {{ rg_dir }}/_src/api/rpc-gateway/ {{ rg_dir }}/
+      register: rg_sync
+      changed_when: rg_sync.stdout | length > 0
+      notify: restart rpc-gateway
 
     - name: Pre-cache deno deps (one-shot warm-up)
       become_user: solv
@@ -78,6 +85,7 @@
         dest: /etc/systemd/system/rpc-gateway.service
         mode: "0644"
         content: |
+          # systemd unit for slv-rpc-gateway
           [Unit]
           Description=SLV RPC Gateway (JSON-RPC; forwards to of1, routes jet_* to ClickHouse)
           After=network-online.target
@@ -101,13 +109,14 @@
 
           [Install]
           WantedBy=multi-user.target
+      notify: restart rpc-gateway
 
     - name: Enable + start rpc-gateway.service
       ansible.builtin.systemd:
         name: rpc-gateway.service
         daemon_reload: yes
         enabled: yes
-        state: restarted
+        state: started
 
     - name: Wait for /health to respond
       ansible.builtin.uri:
@@ -117,3 +126,13 @@
       retries: 10
       delay: 2
       until: rg_health.status == 200
+
+  handlers:
+    # Restart only on real change (rsync changed, unit file changed).
+    # `state: started` above keeps the service up without bouncing it on
+    # every play execution.
+    - name: restart rpc-gateway
+      ansible.builtin.systemd:
+        name: rpc-gateway.service
+        daemon_reload: yes
+        state: restarted


### PR DESCRIPTION
## Summary

A small Deno+Hono service (`api/rpc-gateway/`) that gives clients a single JSON-RPC endpoint combining:

- **Standard Solana JSON-RPC** (`getTransaction`, `getBlock`, `getBlockTime`, `getSignaturesForAddress`, …) — forwarded transparently to **of1** (yellowstone-faithful, see PR #354 rolling cache).
- **`jet_*` analytics methods** — answered locally from **ClickHouse** populated by **jetstreamer** (see PR #355).

```
client ── POST / ─► rpc-gateway ──► standard RPC (getTransaction, …)  ── of1
                              └──► jet_* (analytics)                  ── ClickHouse
```

This is the same architectural pattern Helius uses for its Enhanced Transactions / DAS / Priority Fee APIs: standard methods reach the underlying validator/RPC, new method names are answered from a custom indexer.

## Methods (MVP)

| Method | Backend | Params |
|---|---|---|
| Standard Solana RPC | of1 | (standard) |
| `jet_topPrograms` | CH | `{since?, until?, includeVotes?, limit?}` |
| `jet_programStats` | CH | `{programIdBase58, since?, until?, bucketSec?}` |
| `jet_slotStats` | CH | `{slot}` or `{fromSlot, toSlot}` (range capped at 100k) |
| `jet_tpsTimeseries` | CH | `{from, to, bucketSec?}` |
| `jet_epochSummary` | CH | `{epoch}` |

Anything outside `jet_` prefix is forwarded to OF1_URL. Batch requests supported. Unknown `jet_*` methods return `-32601 method-not-found`.

## What's in this PR

### Service (`api/rpc-gateway/`)
- `src/main.ts` — Hono app, env, dispatcher, `/health` and `/ready` probes
- `src/jsonrpc.ts` — JSON-RPC 2.0 helpers and validation
- `src/handlers/proxy.ts` — forward to of1
- `src/handlers/jet.ts` — `jet_*` handlers using `base58Encode` for program ids
- `src/lib/clickhouse.ts` — minimal HTTP-only CH client (no extra deps)
- `README.md` — usage, methods, env

### Ansible
- `template/2026.5.5.1612/ansible/cmn/install_rpc_gateway.yml` — installs Deno, clones+caches the source, drops a systemd unit, waits for `/health`. Inventory vars: `rpc_gateway_port`, `rpc_gateway_of1_url`, `rpc_gateway_ch_url`, `rpc_gateway_ch_db`, `rpc_gateway_ch_user`, `rpc_gateway_ch_pass`.

### Workspace
- `deno.json`: workspace += `api/rpc-gateway`

### OSS skill
- `oss-skills/slv-rpc-gateway/SKILL.md` — architecture, Helius parallel, deployment topology, how to add new `jet_*` methods.

## Production smoke test (against the live jetstreamer node)

| Call | Result |
|---|---|
| `jet_epochSummary({epoch:966})` | 431,307 slots, **499,567,351 txs**, 1,228,620,294 program invocations across 2,760 distinct programs |
| `jet_topPrograms({includeVotes:false,limit:5})` | Pump.fun (759 M), `4ckmDgGd…` (337 M), Associated Token (260 M), `EUqojw…` (216 M), … |
| `jet_slotStats({slot:417744002})` | 1 row: 834 vote txs, 0 non-vote, blocktime correct |
| Batch request (`getVersion` + `jet_epochSummary`) | both return correctly in one round-trip |
| `jet_doesNotExist` | proper `-32601 method-not-found` |

## Test plan

- [x] `deno check api/rpc-gateway/src/main.ts` clean
- [x] `ansible-playbook --syntax-check cmn/install_rpc_gateway.yml` clean
- [x] Service comes up and listens (`Listening on http://0.0.0.0:8889/`)
- [x] `/health` returns 200 instantly
- [x] `/ready` returns 200 when both of1 + CH up, 503 otherwise
- [x] Standard methods forwarded to of1 (verified through batch request)
- [x] All 5 jet_ methods return real data from epoch 966/967
- [x] Unknown `jet_*` returns `-32601`
- [ ] Bench: typical jet_topPrograms latency vs raw ClickHouse SQL (expect minimal overhead)

## Operational notes

- Co-locate one gateway per RPC node (near-zero-latency to of1).
- Point `CLICKHOUSE_URL` at the central jetstreamer node OR a regional ClickHouse read replica.
- Public endpoints should add `CLICKHOUSE_USER`/`PASS` for a read-only CH user, and front the gateway with HTTPS + rate limiting (jet_ are heavier than standard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)