### PR TITLE
feat(hermes,pythnet): self-hosted Pyth price feed stack (Hermes API + Pythnet RPC)

### DIFF
--- a/cli/src/hermes/deploy/deployHermesMainnet.ts
+++ b/cli/src/hermes/deploy/deployHermesMainnet.ts
@@ -1,0 +1,42 @@
+import { Confirm, prompt } from '@cliffy/prompt'
+import { colors } from '@cliffy/colors'
+import { runAnsilbe } from '/lib/runAnsible.ts'
+import { getTemplatePath } from '/lib/getTemplatePath.ts'
+import { getAnsibleHosts } from '/lib/yml/getAnsibleHost.ts'
+
+const deployHermesMainnet = async (limit?: string) => {
+  const inventoryType = 'mainnet_hermes'
+  const templateRoot = getTemplatePath()
+  const limitString = limit ?? 'all'
+  // Surface which hosts will be touched before asking for confirmation —
+  // mirrors the safety check in deployRPCMainnet so a fat-finger inventory
+  // doesn't accidentally rebuild every host in the group.
+  const ansibleHosts = await getAnsibleHosts(inventoryType, limitString)
+  console.log(
+    colors.cyan(
+      `Deploying Hermes to ${ansibleHosts.length} host(s) from inventory.mainnet.hermes.yml`,
+    ),
+  )
+  const confirm = await prompt([{
+    type: Confirm,
+    name: 'continue',
+    message: 'Do you want to continue?',
+    default: true,
+  }])
+  if (!confirm.continue) {
+    console.log(colors.blue('Cancelled...🌝'))
+    return false
+  }
+  const yml = `${templateRoot}/ansible/mainnet-hermes/init.yml`
+  const result = limit
+    ? await runAnsilbe(yml, inventoryType, limit)
+    : await runAnsilbe(yml, inventoryType)
+  if (result) {
+    console.log(colors.white('✅ Successfully deployed Hermes stack on mainnet'))
+    return true
+  }
+  console.log(colors.red('❌ Failed to deploy Hermes stack'))
+  return false
+}
+
+export { deployHermesMainnet }

--- a/cli/src/hermes/index.ts
+++ b/cli/src/hermes/index.ts
@@ -47,3 +47,22 @@ lifecycle('start', '🟢', 'Start Hermes stack', 'start_node.yml', 'Started Herm
 lifecycle('stop', '🔴', 'Stop Hermes stack', 'stop_node.yml', 'Stopped Hermes')
 lifecycle('restart', '♻️', 'Restart Hermes stack', 'restart_node.yml', 'Restarted Hermes')
 lifecycle('update', '🔄', 'Pull hermes_repo_ref + rebuild + restart', 'update_hermes.yml', 'Updated Hermes')
+
+// `firewall` calls the shared cmn/deploy_nftables.yml against the
+// mainnet_hermes inventory.  Operators must define `mgmt_ips_v4` (and
+// optionally `public_tcp_ports` / `public_udp_ports` / `restricted_ports`)
+// in their inventory or via `-e` — the playbook refuses to run with an
+// empty mgmt list to avoid SSH lockout.
+hermesCmd.command('firewall')
+  .description('🛡️ Apply nftables ruleset to Hermes hosts')
+  .option('-p, --pubkey <pubkey>', 'Limit to specific host')
+  .action(async (options) => {
+    const templateRoot = getTemplatePath()
+    const playbook = `${templateRoot}/ansible/cmn/deploy_nftables.yml`
+    const result = options.pubkey
+      ? await runAnsilbe(playbook, 'mainnet_hermes', options.pubkey)
+      : await runAnsilbe(playbook, 'mainnet_hermes')
+    if (result) {
+      console.log(colors.white('✅ Applied nftables to Hermes hosts'))
+    }
+  })

--- a/cli/src/hermes/index.ts
+++ b/cli/src/hermes/index.ts
@@ -1,0 +1,49 @@
+import { Command } from '@cliffy'
+import { colors } from '@cliffy/colors'
+import { runAnsilbe } from '/lib/runAnsible.ts'
+import { getTemplatePath } from '/lib/getTemplatePath.ts'
+import { deployHermesMainnet } from '@/hermes/deploy/deployHermesMainnet.ts'
+
+// `slv hermes` (alias `slv h`) — manage a self-hosted Pyth Hermes API
+// stack (nats + beacon + hermes).  Only mainnet is supported because Pyth
+// publishes one production Pythnet/Wormhole pair; if/when Pyth ships a
+// separate beta network we'd add a --network flag here.
+export const hermesCmd = new Command()
+  .description('🦤 Manage Self-hosted Pyth Hermes API 🦤')
+  .action(() => {
+    hermesCmd.showHelp()
+  })
+
+hermesCmd.command('deploy')
+  .description('📦 Deploy the Hermes stack (nats + beacon + hermes)')
+  .option('-p, --pubkey <pubkey>', 'Limit to specific host (inventory key)')
+  .action(async (options) => {
+    await deployHermesMainnet(options.pubkey)
+  })
+
+const lifecycle = (
+  name: 'start' | 'stop' | 'restart' | 'update',
+  emoji: string,
+  description: string,
+  playbookFile: string,
+  successMessage: string,
+) => {
+  hermesCmd.command(name)
+    .description(`${emoji} ${description}`)
+    .option('-p, --pubkey <pubkey>', 'Limit to specific host')
+    .action(async (options) => {
+      const templateRoot = getTemplatePath()
+      const playbook = `${templateRoot}/ansible/mainnet-hermes/${playbookFile}`
+      const result = options.pubkey
+        ? await runAnsilbe(playbook, 'mainnet_hermes', options.pubkey)
+        : await runAnsilbe(playbook, 'mainnet_hermes')
+      if (result) {
+        console.log(colors.white(`✅ ${successMessage}`))
+      }
+    })
+}
+
+lifecycle('start', '🟢', 'Start Hermes stack', 'start_node.yml', 'Started Hermes')
+lifecycle('stop', '🔴', 'Stop Hermes stack', 'stop_node.yml', 'Stopped Hermes')
+lifecycle('restart', '♻️', 'Restart Hermes stack', 'restart_node.yml', 'Restarted Hermes')
+lifecycle('update', '🔄', 'Pull hermes_repo_ref + rebuild + restart', 'update_hermes.yml', 'Updated Hermes')

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -5,6 +5,8 @@ import { skillsCmd } from '@/skills/index.ts'
 import { appCmd } from '@/app/index.ts'
 import { validatorCmd } from '@/validator/index.ts'
 import { rpcCmd } from '@/rpc/index.ts'
+import { hermesCmd } from '@/hermes/index.ts'
+import { pythnetCmd } from '@/pythnet/index.ts'
 import { metalCmd } from '@/metal/index.ts'
 import { loginCmd } from '@/login/index.ts'
 import { logoutCmd } from '@/login/logout.ts'
@@ -77,6 +79,13 @@ program
 program
   .command('rpc', rpcCmd)
   .alias('r')
+
+program
+  .command('hermes', hermesCmd)
+  .alias('h')
+
+program
+  .command('pythnet', pythnetCmd)
 
 program
   .command('install', installCmd)

--- a/cli/src/pythnet/deploy/deployPythnetMainnet.ts
+++ b/cli/src/pythnet/deploy/deployPythnetMainnet.ts
@@ -1,0 +1,46 @@
+import { Confirm, prompt } from '@cliffy/prompt'
+import { colors } from '@cliffy/colors'
+import { runAnsilbe } from '/lib/runAnsible.ts'
+import { getTemplatePath } from '/lib/getTemplatePath.ts'
+import { getAnsibleHosts } from '/lib/yml/getAnsibleHost.ts'
+
+const deployPythnetMainnet = async (limit?: string) => {
+  const inventoryType = 'mainnet_pythnet'
+  const templateRoot = getTemplatePath()
+  const limitString = limit ?? 'all'
+  const ansibleHosts = await getAnsibleHosts(inventoryType, limitString)
+  console.log(
+    colors.cyan(
+      `Deploying Pythnet RPC to ${ansibleHosts.length} host(s) from inventory.mainnet.pythnet.yml`,
+    ),
+  )
+  console.log(
+    colors.yellow(
+      '⚠️  First-time deploy builds Pythnet from source (~2-15 min depending on CPU)\n' +
+      '   and then fetches/applies a snapshot from the gossip entrypoint\n' +
+      '   (~10-20 min before getHealth returns "ok").',
+    ),
+  )
+  const confirm = await prompt([{
+    type: Confirm,
+    name: 'continue',
+    message: 'Do you want to continue?',
+    default: true,
+  }])
+  if (!confirm.continue) {
+    console.log(colors.blue('Cancelled...🌝'))
+    return false
+  }
+  const yml = `${templateRoot}/ansible/mainnet-pythnet/init.yml`
+  const result = limit
+    ? await runAnsilbe(yml, inventoryType, limit)
+    : await runAnsilbe(yml, inventoryType)
+  if (result) {
+    console.log(colors.white('✅ Successfully deployed Pythnet RPC on mainnet'))
+    return true
+  }
+  console.log(colors.red('❌ Failed to deploy Pythnet RPC'))
+  return false
+}
+
+export { deployPythnetMainnet }

--- a/cli/src/pythnet/index.ts
+++ b/cli/src/pythnet/index.ts
@@ -46,3 +46,21 @@ lifecycle('start', '🟢', 'Start Pythnet validator', 'start_node.yml', 'Started
 lifecycle('stop', '🔴', 'Stop Pythnet validator', 'stop_node.yml', 'Stopped Pythnet')
 lifecycle('restart', '♻️', 'Restart Pythnet validator', 'restart_node.yml', 'Restarted Pythnet')
 lifecycle('update', '🔄', 'Pull pythnet_ref + rebuild + restart', 'update_pythnet.yml', 'Updated Pythnet')
+
+// `firewall` calls the shared cmn/deploy_nftables.yml against the
+// mainnet_pythnet inventory.  Pythnet's typical setup needs gossip
+// (8001) + dynamic TPU range (8000-8020) public, JSON-RPC (8899/8900)
+// restricted to known clients (typically the Hermes VPS).
+pythnetCmd.command('firewall')
+  .description('🛡️ Apply nftables ruleset to Pythnet RPC hosts')
+  .option('-p, --pubkey <pubkey>', 'Limit to specific host')
+  .action(async (options) => {
+    const templateRoot = getTemplatePath()
+    const playbook = `${templateRoot}/ansible/cmn/deploy_nftables.yml`
+    const result = options.pubkey
+      ? await runAnsilbe(playbook, 'mainnet_pythnet', options.pubkey)
+      : await runAnsilbe(playbook, 'mainnet_pythnet')
+    if (result) {
+      console.log(colors.white('✅ Applied nftables to Pythnet hosts'))
+    }
+  })

--- a/cli/src/pythnet/index.ts
+++ b/cli/src/pythnet/index.ts
@@ -1,0 +1,48 @@
+import { Command } from '@cliffy'
+import { colors } from '@cliffy/colors'
+import { runAnsilbe } from '/lib/runAnsible.ts'
+import { getTemplatePath } from '/lib/getTemplatePath.ts'
+import { deployPythnetMainnet } from '@/pythnet/deploy/deployPythnetMainnet.ts'
+
+// `slv pythnet` — manage a self-hosted Pythnet RPC node (Pyth's
+// application-specific Solana 1.14 fork).  Only mainnet exists — Pythnet
+// is a single production chain operated by Pyth's data providers.
+export const pythnetCmd = new Command()
+  .description('🔮 Manage Self-hosted Pythnet RPC Node 🔮')
+  .action(() => {
+    pythnetCmd.showHelp()
+  })
+
+pythnetCmd.command('deploy')
+  .description('📦 Deploy a Pythnet RPC node')
+  .option('-p, --pubkey <pubkey>', 'Limit to specific host')
+  .action(async (options) => {
+    await deployPythnetMainnet(options.pubkey)
+  })
+
+const lifecycle = (
+  name: 'start' | 'stop' | 'restart' | 'update',
+  emoji: string,
+  description: string,
+  playbookFile: string,
+  successMessage: string,
+) => {
+  pythnetCmd.command(name)
+    .description(`${emoji} ${description}`)
+    .option('-p, --pubkey <pubkey>', 'Limit to specific host')
+    .action(async (options) => {
+      const templateRoot = getTemplatePath()
+      const playbook = `${templateRoot}/ansible/mainnet-pythnet/${playbookFile}`
+      const result = options.pubkey
+        ? await runAnsilbe(playbook, 'mainnet_pythnet', options.pubkey)
+        : await runAnsilbe(playbook, 'mainnet_pythnet')
+      if (result) {
+        console.log(colors.white(`✅ ${successMessage}`))
+      }
+    })
+}
+
+lifecycle('start', '🟢', 'Start Pythnet validator', 'start_node.yml', 'Started Pythnet')
+lifecycle('stop', '🔴', 'Stop Pythnet validator', 'stop_node.yml', 'Stopped Pythnet')
+lifecycle('restart', '♻️', 'Restart Pythnet validator', 'restart_node.yml', 'Restarted Pythnet')
+lifecycle('update', '🔄', 'Pull pythnet_ref + rebuild + restart', 'update_pythnet.yml', 'Updated Pythnet')

--- a/cli/src/rpc/index.ts
+++ b/cli/src/rpc/index.ts
@@ -13,6 +13,7 @@ import { deployRPCDevnet } from '/src/rpc/deploy/deployRPCDevnet.ts'
 import { genOrReadVersions } from '/lib/genOrReadVersions.ts'
 import { registerDoubleZeroCommands } from '/lib/doublezero.ts'
 import { registerSha256PatchCommands } from '/lib/sha256Patch.ts'
+import type { VersionSection } from '/lib/config/updateAllowedIps.ts'
 
 // rpc Command
 export const rpcCmd = new Command()
@@ -331,7 +332,10 @@ rpcCmd.command('update:allowed-ips')
   })
   .description('🛡️ Update allowed IPs for mainnet RPC nodes')
   .action(async (options) => {
-    const inventoryType = options.network + '_rpcs' as InventoryType
+    // `slv rpc update:allowed-ips` is rpc-only; cast narrows InventoryType
+    // (now also includes hermes/pythnet) to the VersionSection subset
+    // that allowed_ips actually supports.
+    const inventoryType = options.network + '_rpcs' as VersionSection
     await updateAllowedIps(inventoryType)
   })
 

--- a/cli/src/rpc/init.ts
+++ b/cli/src/rpc/init.ts
@@ -31,6 +31,8 @@ export async function copyTemplateDirs() {
     ['devnet-rpc', 'devnet-rpc'],
     ['mainnet-rpc', 'mainnet-rpc'],
     ['mainnet-validator', 'mainnet-validator'],
+    ['mainnet-hermes', 'mainnet-hermes'],
+    ['mainnet-pythnet', 'mainnet-pythnet'],
     ['cmn', 'cmn'],
   ] as const
   await Promise.all(

--- a/cli/src/rpc/listRPCs.ts
+++ b/cli/src/rpc/listRPCs.ts
@@ -2,14 +2,20 @@ import { colors } from '@cliffy/colors'
 import { Row, Table } from '@cliffy/table'
 import { genOrReadInventory } from '/lib/genOrReadInventory.ts'
 import type {
+  CmnType,
   InventoryType,
   NetworkType,
   RpcConfig,
 } from '@cmn/types/config.ts'
 import { genOrReadVersions } from '/lib/genOrReadVersions.ts'
 
+// `listRPCs` is rpc-only — narrow inventoryType to the keys of CmnType so
+// `versions[inventoryType]` indexes without InventoryType (which also
+// contains hermes/pythnet now) widening to `any`.
+type RpcInventoryType = Extract<InventoryType, keyof CmnType>
+
 const listRPCs = async (network: NetworkType, identityKey?: string) => {
-  const inventoryType = network + '_rpcs' as InventoryType
+  const inventoryType = `${network}_rpcs` as RpcInventoryType
   const inventory = await genOrReadInventory(inventoryType)
   const header = [
     'Identity Key',

--- a/cmn/types/config.ts
+++ b/cmn/types/config.ts
@@ -13,6 +13,8 @@ export type InventoryType =
   | 'mainnet_rpcs'
   | 'devnet_rpcs'
   | 'testnet_rpcs'
+  | 'mainnet_hermes'
+  | 'mainnet_pythnet'
 
 export type SolanaNodeType =
   | 'agave'

--- a/oss-skills/slv-hermes/SKILL.md
+++ b/oss-skills/slv-hermes/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: slv-hermes
+description: Deploy a self-hosted Pyth Hermes price feed API stack (NATS + Beacon + Hermes) on a VPS. Hermes serves Pyth Network's REST/WS price feeds (`/v2/updates/price/latest`, `/v2/price_feeds`, `/ws`) by listening to Pythnet for accumulator messages and to the Wormhole network (via Beacon, a highly-available spy) for VAAs. The recipe builds all three components from source, drops systemd units, and validates `/v2/price_feeds` returns 200.
+---
+
+# SLV Hermes Skill
+
+Ansible recipe + skill docs for deploying a self-hosted Pyth Hermes API
+(REST + WebSocket price feeds) on a single VPS.
+
+## What is Hermes?
+
+> Hermes is a web service designed to monitor both Pythnet and the
+> Wormhole Network for the next generation of Pyth price updates.
+> It supersedes the Pyth Price Service, offering these updates through
+> a user-friendly web API.
+> — [hermes server README](https://github.com/pyth-network/pyth-crosschain/blob/main/apps/hermes/server/README.md)
+
+Public endpoint is `https://hermes.pyth.network` (10 req/10s/IP rate
+limit).  Self-hosting removes the rate limit, lets you pin a region, and
+— combined with `slv-pythnet` — gives you full control over the data path.
+
+## Stack components
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ VPS (single host)                                            │
+│                                                              │
+│  nats-server :4222 ◄──┐                                      │
+│  (JetStream)          │ writes VAAs                          │
+│                       │                                      │
+│                  ┌────┴──────────┐         REST/WS           │
+│                  │ beacon         │◄────────────────────┐   │
+│                  │  spy gRPC :7072│                     │   │
+│                  └────┬───────────┘                     │   │
+│                       │                                 │   │
+│                       │ reads accumulator               │   │
+│                       │                            ┌────┴───┐│
+│                       └────► Pythnet HTTP/WS ────► │ hermes ││ ◄── clients
+│                              (public or self-hosted) │ :7575 ││
+│                                                    └────────┘│
+└──────────────────────────────────────────────────────────────┘
+                       ▲
+                       │ Wormhole P2P gossip
+                       ▼
+                Wormhole guardian network
+                (3 bootstrap peers, UDP :8999)
+```
+
+| Component | Purpose | Port |
+|---|---|---|
+| `nats-server` (JetStream) | VAA dedup/stream broker for Beacon | `:4222` |
+| `pyth-network/beacon` | HA rewrite of Wormhole `spy`; writes VAAs to NATS, exposes spy gRPC | `:7072` (loopback), `:8999/udp` (P2P) |
+| `pyth-network/pyth-crosschain` (apps/hermes/server) | Rust REST/WS API | `:7575` |
+
+## VPS sizing
+
+Hermes is light — the whole stack idles under 1 core and ~1 GB resident.
+The constraint is network: Wormhole P2P + Pythnet WS combined run at a
+few Mbps each way.
+
+| Spec | Recommended | Minimum |
+|---|---|---|
+| vCPU | 4 | 2 |
+| RAM | 8 GB | 4 GB |
+| Disk | 80 GB SSD | 40 GB |
+| Network | 1 Gbps (effective 100 Mbps suffices) | 100 Mbps |
+| OS | Ubuntu 22.04 / 24.04 | — |
+
+## Directory Structure
+
+```
+ansible/
+  mainnet-hermes/  — orchestrator + lifecycle playbooks
+  cmn/             — shared common playbooks (install_hermes_stack.yml lives here)
+jinja/
+  mainnet-hermes/  — systemd unit templates (nats/beacon/hermes)
+```
+
+## CLI Command ↔ Playbook Mapping
+
+The `slv hermes` (alias `slv h`) CLI commands map to these playbooks.
+
+| CLI Command | Playbook | Description |
+|---|---|---|
+| `slv h deploy` | `mainnet-hermes/init.yml` | Full Hermes stack deployment |
+| `slv h start` | `mainnet-hermes/start_node.yml` | Start NATS → Beacon → Hermes |
+| `slv h stop` | `mainnet-hermes/stop_node.yml` | Stop in reverse order |
+| `slv h restart` | `mainnet-hermes/restart_node.yml` | Restart all three |
+| `slv h update` | `mainnet-hermes/update_hermes.yml` | Rebuild from `hermes_repo_ref` and restart |
+
+## Key Variables (extra_vars)
+
+All optional — defaults work for a public-Pythnet bootstrap.
+
+| Variable | Default | Description |
+|---|---|---|
+| `hermes_repo` | `https://github.com/pyth-network/pyth-crosschain` | Upstream repo |
+| `hermes_repo_ref` | `main` | Branch / tag / SHA |
+| `beacon_repo` | `https://github.com/pyth-network/beacon` | Upstream repo |
+| `beacon_repo_ref` | `main` | Branch / tag / SHA |
+| `nats_version` | `v2.10.22` | nats-server release tag |
+| `hermes_rust_toolchain` | `1.82.0` | Rust toolchain for hermes build |
+| `hermes_pythnet_http_addr` | `https://pythnet.rpcpool.com` | Pythnet HTTP RPC URL |
+| `hermes_pythnet_ws_addr` | `wss://pythnet.rpcpool.com` | Pythnet WS RPC URL |
+| `hermes_wormhole_env` | `mainnet` | `mainnet` or `testnet` |
+| `hermes_rpc_listen_addr` | `0.0.0.0:7575` | REST/WS bind |
+| `hermes_metrics_listen_addr` | `127.0.0.1:7576` | Prometheus metrics bind |
+| `beacon_listen_port` | `8999` | UDP/QUIC port for Wormhole P2P |
+| `beacon_spy_grpc_addr` | `127.0.0.1:7072` | spy gRPC bind (loopback recommended) |
+| `nats_port` | `4222` | NATS client port |
+
+## Usage
+
+### 1. Write inventory
+
+Copy `examples/inventory.yml` to `~/.slv/inventory.mainnet.hermes.yml` and
+fill in your VPS:
+
+```yaml
+all:
+  hosts:
+    hermes-1:
+      ansible_host: "<vps-ip>"
+      ansible_user: "solv"
+      ansible_ssh_private_key_file: "~/.ssh/id_rsa"
+  vars:
+    # Bootstrap with public Pythnet first, swap to self-hosted later.
+    hermes_pythnet_http_addr: "https://pythnet.rpcpool.com"
+    hermes_pythnet_ws_addr: "wss://pythnet.rpcpool.com"
+```
+
+### 2. Deploy
+
+```bash
+slv hermes deploy
+# or directly:
+ansible-playbook -i ~/.slv/inventory.mainnet.hermes.yml \
+  ~/.slv/mainnet-hermes/init.yml
+```
+
+### 3. Verify
+
+```bash
+SOL_USD=ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d
+curl -s "http://<vps-ip>:7575/v2/updates/price/latest?ids[]=${SOL_USD}" \
+  | jq '.parsed[0] | {price: .price.price, expo: .price.expo, time: .price.publish_time}'
+```
+
+### 4. (Optional) Switch to self-hosted Pythnet
+
+After deploying a Pythnet RPC node via the `slv-pythnet` skill, edit the
+inventory:
+
+```yaml
+    hermes_pythnet_http_addr: "http://<pythnet-rpc-ip>:8899"
+    hermes_pythnet_ws_addr:   "ws://<pythnet-rpc-ip>:8900"
+```
+
+Then redeploy or restart:
+
+```bash
+slv hermes restart
+```
+
+## API surface
+
+The standard Hermes API spec applies — anything the public
+`hermes.pyth.network` endpoint serves works against the self-hosted
+instance.  Common endpoints:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /v2/price_feeds` | List all feed IDs + metadata (~3000 entries) |
+| `GET /v2/updates/price/latest?ids[]=<id>` | Latest parsed price + binary VAA for given feed ID(s) |
+| `GET /v2/updates/price/<publish_time>?ids[]=<id>` | Historical update at a unix timestamp |
+| `GET /ws` (WebSocket) | Subscribe to price updates |
+
+Reference: <https://hermes.pyth.network/docs/>
+
+## Known gotchas
+
+- **UDP port `:8999` must be reachable from the public internet.**
+  Wormhole P2P uses QUIC over UDP and the gossip mesh expects this peer
+  to be externally addressable.  If your VPS provider has a firewall by
+  default, add an allow rule for UDP/8999 inbound.
+- **Beacon auto-generates `/home/solv/beacon-node.key`** on first start.
+  This is a libp2p identity, not a wallet — you can delete it to rotate.
+- The receive-buffer warning `failed to sufficiently increase receive
+  buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB)` is benign
+  but indicates UDP throughput is suboptimal; bump
+  `net.core.rmem_max=2097152` if you want it gone.

--- a/oss-skills/slv-hermes/examples/inventory.yml
+++ b/oss-skills/slv-hermes/examples/inventory.yml
@@ -1,0 +1,36 @@
+# SLV Hermes — Example Inventory
+#
+# Usage:
+#   cp examples/inventory.yml ~/.slv/inventory.mainnet.hermes.yml
+#   # edit ansible_host + (optionally) endpoints
+#   ansible-playbook -i ~/.slv/inventory.mainnet.hermes.yml \
+#     ~/.slv/mainnet-hermes/init.yml
+
+all:
+  hosts:
+    hermes-1:
+      ansible_host: "<vps-ip>"
+      ansible_user: "solv"
+      ansible_ssh_private_key_file: "~/.ssh/id_rsa"
+
+  vars:
+    # --- Pythnet RPC endpoints (Hermes reads accumulator from here) ---
+    # Defaults below talk to public Pythnet — fine for bootstrap.  Once
+    # you have a self-hosted Pythnet RPC (see slv-pythnet skill), swap
+    # these for your own and run `slv hermes restart`.
+    hermes_pythnet_http_addr: "https://pythnet.rpcpool.com"
+    hermes_pythnet_ws_addr:   "wss://pythnet.rpcpool.com"
+
+    # --- Wormhole environment ---
+    hermes_wormhole_env: "mainnet"
+
+    # --- Repo refs (pin to a tag if you want reproducible builds) ---
+    # hermes_repo_ref: "v2.5.0"        # default: main
+    # beacon_repo_ref: "v0.4.0"        # default: main
+
+    # --- Listen addresses ---
+    hermes_rpc_listen_addr: "0.0.0.0:7575"
+    hermes_metrics_listen_addr: "127.0.0.1:7576"
+    beacon_listen_port: 8999
+    beacon_spy_grpc_addr: "127.0.0.1:7072"
+    nats_port: 4222

--- a/oss-skills/slv-hermes/examples/inventory.yml
+++ b/oss-skills/slv-hermes/examples/inventory.yml
@@ -34,3 +34,17 @@ all:
     beacon_listen_port: 8999
     beacon_spy_grpc_addr: "127.0.0.1:7072"
     nats_port: 4222
+
+    # --- nftables (used by `slv hermes firewall`) ---
+    # ★ mgmt_ips_v4 must contain every IP that should retain admin / SSH
+    # access.  The playbook refuses to deploy with an empty list because
+    # applying nftables without mgmt IPs would drop the current SSH session.
+    mgmt_ips_v4:
+      - "<your-admin-ip>"
+    # ban_ips_v4: []
+    # ssh_port: 22
+    public_tcp_ports:
+      - 7575          # Hermes REST/WS API
+    public_udp_ports:
+      - 8999          # Wormhole P2P (QUIC) — must be externally reachable
+    # restricted_ports: []

--- a/oss-skills/slv-hermes/examples/inventory.yml
+++ b/oss-skills/slv-hermes/examples/inventory.yml
@@ -47,4 +47,11 @@ all:
       - 7575          # Hermes REST/WS API
     public_udp_ports:
       - 8999          # Wormhole P2P (QUIC) — must be externally reachable
-    # restricted_ports: []
+    # Optional :443 whitelist for Cloudflare.  `cf_ipv4` is auto-loaded
+    # from ~/.slv/cmn/files/cf_ipv4.yml (shipped with slv, refreshed
+    # against https://www.cloudflare.com/ips-v4).  Remove this block if
+    # the Hermes node does not sit behind a CF Worker / Tunnel.
+    # restricted_ports:
+    #   - port: 443
+    #     tcp: true
+    #     allow_ipv4: "{{ cf_ipv4 | default([]) }}"

--- a/oss-skills/slv-nftables/SKILL.md
+++ b/oss-skills/slv-nftables/SKILL.md
@@ -121,6 +121,33 @@ all:
     public_udp_ports: [8999]         # Wormhole P2P
 ```
 
+## Example: Hermes node behind Cloudflare (:443 whitelist)
+
+The slv templates ship `cmn/files/cf_ipv4.yml` containing the official
+Cloudflare IPv4 ranges (refreshed against
+<https://www.cloudflare.com/ips-v4>).  The playbook auto-loads it via
+`include_vars` if present, exposing the `cf_ipv4` list to your
+inventory:
+
+```yaml
+all:
+  hosts:
+    hermes-1: { ansible_host: "<vps-ip>", ansible_user: "solv" }
+  vars:
+    mgmt_ips_v4: ["<your-admin-ip>"]
+    public_tcp_ports: [7575]
+    public_udp_ports: [8999]
+    restricted_ports:
+      - port: 443
+        tcp: true
+        allow_ipv4: "{{ cf_ipv4 | default([]) }}"
+```
+
+Refresh the list any time CF updates its ranges — edit
+`template/<version>/jinja/cmn/files/cf_ipv4.yml`, re-run
+`slv hermes deploy` (or just re-copy the file into `~/.slv/cmn/files/`),
+then re-run `slv hermes firewall`.
+
 ## Example: Pythnet RPC (restricted JSON-RPC + public gossip)
 
 ```yaml

--- a/oss-skills/slv-nftables/SKILL.md
+++ b/oss-skills/slv-nftables/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: slv-nftables
+description: Deploy an OSS-clean nftables ruleset to any slv-managed host (Hermes, Pythnet RPC, validator, RPC, …). Inventory-driven — mgmt IPs, public ports, and per-port allow lists all come from `~/.slv/inventory.{network}.{role}.yml`, nothing is hardcoded. Atomic + rollback-safe (failed validation restores the previous config) and persistent across reboot. Used by `slv hermes firewall` and `slv pythnet firewall`; the same `cmn/deploy_nftables.yml` playbook works against any inventory.
+---
+
+# SLV nftables Skill
+
+Inventory-driven nftables ruleset deployer.  One playbook
+(`cmn/deploy_nftables.yml`) serves every slv role — Hermes, Pythnet
+RPC, Solana RPC, validators — by reading the firewall description from
+the same inventory that already configures the service itself.
+
+## What it does
+
+1. Renders `/etc/nftables.conf` + fragments under `/etc/nftables.d/`
+   and `/etc/nftables.sets.d/` from Jinja2 templates.
+2. Validates the rendered config (`nft -c`) before applying.  If
+   validation fails, the previous config is restored and the playbook
+   aborts — you cannot lock yourself out via a bad template.
+3. Applies atomically (`nft -f`).
+4. Seeds allowlist sets with IPs from inventory, preserving any
+   elements added at runtime with `nft add element …` so re-running the
+   playbook never wipes manual additions.
+5. Exports the live ruleset back into `/etc/nftables.conf` and enables
+   `nftables.service` so the same ruleset is restored on reboot.
+
+## Ruleset shape
+
+```
+chain input  (default: drop)
+  ├─ accept loopback
+  ├─ accept established/related
+  ├─ accept icmp / icmpv6
+  ├─ banAll_v4 drop                       (highest priority)
+  ├─ mgmt_ips_v4 accept                   (full access)
+  ├─ allowAll_v4 accept                   (runtime additions, full access)
+  ├─ mgmt_ips_v4 → tcp dport ssh_port accept   (belt-and-suspenders)
+  ├─ public_tcp_ports / public_udp_ports accept
+  └─ restricted_ports[]: allow_<port>_v4 accept else drop
+```
+
+## Inventory variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `mgmt_ips_v4` | **yes** | — | List of IPv4/CIDR with full access.  Empty list aborts the playbook. |
+| `mgmt_ips_v6` | no | `[]` | Same for IPv6 |
+| `ban_ips_v4` | no | `[]` | Hard-deny list (evaluated first) |
+| `ssh_port` | no | `22` | SSH port to keep open from mgmt |
+| `public_tcp_ports` | no | `[]` | TCP ports/ranges accepted from any source |
+| `public_udp_ports` | no | `[]` | UDP ports/ranges accepted from any source |
+| `restricted_ports` | no | `[]` | Per-port allowlist (see below) |
+| `disable_ufw` | no | `true` | Stop/disable ufw to avoid conflict |
+| `preserve_existing` | no | `true` | Preserve runtime `nft add element` additions |
+
+### `restricted_ports` schema
+
+```yaml
+restricted_ports:
+  - port: 8899              # int or range string ("8000-8020")
+    tcp: true               # default true
+    udp: false              # default false
+    allow_ipv4:
+      - "203.0.113.10"
+      - "198.51.100.0/24"
+```
+
+Set + counter names are derived from `port` automatically:
+
+| `port` | set | counter (allow / drop) |
+|---|---|---|
+| `8899` | `allow_8899_v4` | `c_8899_allow` / `c_8899_drop` |
+| `"8000-8020"` | `allow_8000_8020_v4` | `c_8000_8020_allow` / `c_8000_8020_drop` |
+
+## Runtime management
+
+```bash
+# Add an IP to an allow list (effective immediately, no playbook re-run)
+sudo nft add element inet filter allowAll_v4 { 198.51.100.42 }
+sudo nft add element inet filter allow_8899_v4 { 203.0.113.10 }
+
+# Remove
+sudo nft delete element inet filter allowAll_v4 { 198.51.100.42 }
+
+# Inspect
+sudo nft list set inet filter allow_8899_v4
+
+# Counter check (how many packets dropped / accepted per port)
+sudo nft list counter inet filter c_8899_drop
+sudo nft list counter inet filter c_8899_allow
+```
+
+Runtime changes survive reboot **only after** the next playbook run,
+which re-exports the live ruleset back into `/etc/nftables.conf`.  If
+you need an addition to persist immediately, run the playbook again
+(it's idempotent and preserves runtime state by design).
+
+## CLI Command ↔ Playbook Mapping
+
+| CLI Command | Inventory | Description |
+|---|---|---|
+| `slv hermes firewall` | `mainnet_hermes` | Apply to Hermes hosts |
+| `slv pythnet firewall` | `mainnet_pythnet` | Apply to Pythnet RPC hosts |
+
+The playbook itself (`cmn/deploy_nftables.yml`) is role-agnostic.
+Adding a `slv <other> firewall` subcommand is one TypeScript dispatch
++ an `InventoryType` variant — see how `slv hermes firewall` is wired
+in `cli/src/hermes/index.ts`.
+
+## Example: Hermes node (public API)
+
+```yaml
+all:
+  hosts:
+    hermes-1:
+      ansible_host: "<vps-ip>"
+      ansible_user: "solv"
+  vars:
+    mgmt_ips_v4: ["<your-admin-ip>"]
+    public_tcp_ports: [7575]         # REST/WS API
+    public_udp_ports: [8999]         # Wormhole P2P
+```
+
+## Example: Pythnet RPC (restricted JSON-RPC + public gossip)
+
+```yaml
+all:
+  hosts:
+    pythnet-1:
+      ansible_host: "<bm-ip>"
+      ansible_user: "solv"
+  vars:
+    mgmt_ips_v4: ["<your-admin-ip>"]
+    public_tcp_ports: [8001, "8000-8020"]   # gossip + TPU
+    public_udp_ports: [8001, "8000-8020"]
+    restricted_ports:
+      - port: 8899
+        tcp: true
+        allow_ipv4: ["<hermes-vps-ip>"]
+      - port: 8900
+        tcp: true
+        allow_ipv4: ["<hermes-vps-ip>"]
+```
+
+## Safety properties
+
+- **Lockout-resistant.** `mgmt_ips_v4` empty → playbook aborts before
+  any change.
+- **Atomic.** `nft -c` validates before `nft -f` applies.
+- **Rollback.** Validation failure restores `/etc/nftables.conf.bak`.
+- **Idempotent.** Re-runs preserve runtime allowlist additions.
+- **Reboot-survivable.** Live ruleset exported back to
+  `/etc/nftables.conf`; `nftables.service` enabled.
+
+## Known gotchas
+
+- **UFW conflicts.**  `disable_ufw: true` (default) stops + disables
+  ufw before applying.  If you have a custom ufw setup you want to
+  keep, set `disable_ufw: false` — but at that point you should
+  probably not be using nftables directly anyway.
+- **`ssh_port` ≠ inventory's `ansible_port`.**  If you SSH on a
+  non-default port, set `ssh_port` to match — the playbook only
+  carves out the value you pass it.
+- **Set names with hyphens are illegal in nftables.**  We derive set
+  names from `port` by `regex_replace('[^0-9]+', '_')`, so any range
+  string (`"8000-8020"`) becomes a valid identifier (`allow_8000_8020_v4`).

--- a/oss-skills/slv-nftables/examples/inventory.yml
+++ b/oss-skills/slv-nftables/examples/inventory.yml
@@ -1,0 +1,55 @@
+# SLV nftables — Example inventory snippets.
+#
+# nftables vars live INSIDE the same inventory that drives the service
+# itself (slv-hermes, slv-pythnet, …) — there's no separate inventory
+# file.  Copy the snippet that matches your host's role into your
+# `~/.slv/inventory.<network>.<role>.yml` and edit the IPs.
+#
+# Then apply:
+#   slv hermes firewall    # uses mainnet_hermes inventory
+#   slv pythnet firewall   # uses mainnet_pythnet inventory
+#   # or directly:
+#   ansible-playbook -i ~/.slv/inventory.<n>.<r>.yml \
+#     template/<version>/ansible/cmn/deploy_nftables.yml
+
+# ---------------------------------------------------------------------
+# Hermes (public REST/WS API + Wormhole P2P)
+# ---------------------------------------------------------------------
+hermes_example:
+  mgmt_ips_v4:
+    - "<your-admin-ip>"
+  public_tcp_ports:
+    - 7575          # Hermes REST/WS
+  public_udp_ports:
+    - 8999          # Wormhole P2P (QUIC)
+
+# ---------------------------------------------------------------------
+# Pythnet RPC (public gossip + TPU range, restricted JSON-RPC)
+# ---------------------------------------------------------------------
+pythnet_example:
+  mgmt_ips_v4:
+    - "<your-admin-ip>"
+  public_tcp_ports:
+    - 8001          # gossip
+    - "8000-8020"   # TPU dynamic range
+  public_udp_ports:
+    - 8001
+    - "8000-8020"
+  restricted_ports:
+    - port: 8899
+      tcp: true
+      allow_ipv4:
+        - "<hermes-vps-ip>"
+    - port: 8900
+      tcp: true
+      allow_ipv4:
+        - "<hermes-vps-ip>"
+
+# ---------------------------------------------------------------------
+# Locked-down (mgmt only) — useful for build hosts, ClickHouse boxes,
+# anything that should not expose any public service.
+# ---------------------------------------------------------------------
+locked_down_example:
+  mgmt_ips_v4:
+    - "<your-admin-ip>"
+  # No public_*_ports, no restricted_ports — only mgmt SSH allowed.

--- a/oss-skills/slv-pythnet/SKILL.md
+++ b/oss-skills/slv-pythnet/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: slv-pythnet
+description: Run a self-hosted Pythnet RPC node — the application-specific Solana fork operated by Pyth's data providers. Pythnet RPC is what `slv-hermes` reads from for accumulator messages; running it locally completes a fully self-hosted Pyth price feed stack. Recipe handles disk mount, sysctl tuning, Solana 1.14 fork build (with cstdint workaround for modern GCC), identity gen, and systemd. Snapshot fetch + catch-up typically finishes in 10-20 minutes.
+---
+
+# SLV Pythnet Skill
+
+Ansible recipe + skill docs for running a self-hosted **Pythnet RPC**
+node — the application-specific Solana fork operated by Pyth's data
+providers.
+
+## What is Pythnet?
+
+> Pythnet is an application-specific blockchain operated by Pyth's data
+> providers.  This blockchain is a computation substrate to securely
+> combine the data provider's prices into a single aggregate price for
+> each Pyth price feed.  Pythnet forms the core of Pyth's off-chain
+> price feeds that serve all blockchains.
+> — [pyth-network/pythnet README](https://github.com/pyth-network/pythnet)
+
+It's a Solana 1.14.17 fork.  Running it as a no-voting RPC node lets you
+serve Pythnet HTTP+WS directly to a self-hosted Hermes (see
+`slv-hermes`), eliminating the dependency on public Pythnet endpoints
+(Triton, P2P, Blockdaemon, Figment).
+
+## Why self-host?
+
+Pyth Network's documentation notes that running Pythnet RPC yourself is
+"discouraged due to the potential high cost and maintenance involved" —
+which is true relative to using a managed provider, but **wildly
+overstated** when compared to running a Solana mainnet RPC.  Pythnet's
+traffic is tiny: only Pyth oracle operations, ~21 validators, no DeFi
+mints, no NFT spam.  Ledger growth is ~10 GB/day.  Catch-up from a fresh
+snapshot fetch finishes in 10-20 minutes (vs hours on mainnet).
+
+If you already run Solana RPC infrastructure, Pythnet RPC is an order of
+magnitude smaller across every dimension.
+
+## Hardware target
+
+Pythnet is light enough that **mid-range commodity hardware suffices**:
+
+| Resource | Recommended | Note |
+|---|---|---|
+| CPU | 16-32 cores | Solana validator binary is multi-threaded but Pythnet TPS is bounded by Pyth oracle ops only |
+| RAM | 128 GB (256 GB safety margin) | AccountsDB + RocksDB block cache |
+| Disk | 2 TB NVMe (single) | Mainnet needs 4-8 TB RAID0; Pythnet doesn't |
+| Network | 1 Gbps | Mainnet needs 10 Gbps+; Pythnet doesn't |
+| OS | Ubuntu 22.04 / 24.04 | — |
+
+A second NVMe is optional — the recipe can format and mount it as
+`/mnt/ledger` if you set `pythnet_format_disk=true`, otherwise it uses
+whatever directory you point `pythnet_ledger_mount` at.
+
+## Directory Structure
+
+```
+ansible/
+  mainnet-pythnet/  — playbooks (init.yml + supporting + lifecycle)
+  cmn/              — shared common (create_user, fix_permissions, etc.)
+jinja/
+  mainnet-pythnet/  — start-pythnet.sh.j2 + pythnet.service.j2
+```
+
+## CLI Command ↔ Playbook Mapping
+
+The `slv pythnet` CLI commands map to these playbooks.
+
+| CLI Command | Playbook | Description |
+|---|---|---|
+| `slv pythnet deploy` | `mainnet-pythnet/init.yml` | Full Pythnet RPC deployment |
+| `slv pythnet start` | `mainnet-pythnet/start_node.yml` | Start validator |
+| `slv pythnet stop` | `mainnet-pythnet/stop_node.yml` | Stop validator |
+| `slv pythnet restart` | `mainnet-pythnet/restart_node.yml` | Restart validator |
+| `slv pythnet update` | `mainnet-pythnet/update_pythnet.yml` | Pull pythnet_ref, rebuild, restart |
+
+## Network parameters (fixed by Pyth)
+
+These are immutable network constants — verifiable via the public
+Pythnet RPC at any time:
+
+```bash
+curl -s https://pythnet.rpcpool.com -X POST -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getGenesisHash"}'
+# → GLKkBUr6r72nBtGrtBPJLRqtsh8wXZanX4xfnqKnWwKq
+```
+
+| Constant | Value |
+|---|---|
+| `expected_genesis_hash` | `GLKkBUr6r72nBtGrtBPJLRqtsh8wXZanX4xfnqKnWwKq` |
+| `expected_shred_version` | `35891` |
+| `feature_set` | `1435444185` |
+| Validator version | `1.14.180` (Pyth-built; `solana-v1.14.180` base) |
+
+## Key Variables (extra_vars)
+
+| Variable | Default | Description |
+|---|---|---|
+| `pythnet_repo` | `https://github.com/pyth-network/pythnet` | Upstream |
+| `pythnet_ref` | `pyth-v1.14.17` | Branch — currently the only supported one |
+| `pythnet_rust_toolchain` | `1.78.0` | Bootstrap toolchain (build itself pins 1.60.0 via rust-toolchain) |
+| `pythnet_ledger_mount` | `/mnt/ledger` | Where ledger/accounts/snapshots live |
+| `pythnet_ledger_device` | `/dev/nvme0n1` | Disk to format if `pythnet_format_disk=true` |
+| `pythnet_format_disk` | `false` | Set true to mkfs.xfs the secondary disk |
+| `pythnet_force_format` | `false` | Required to wipe a device that already has a filesystem |
+| `pythnet_rpc_port` | `8899` | JSON-RPC HTTP |
+| `pythnet_rpc_bind` | `0.0.0.0` | Bind address |
+| `pythnet_dynamic_port_range` | `8000-8020` | TPU/QUIC port range |
+| `pythnet_gossip_port` | `8001` | Gossip port |
+| `pythnet_entrypoint` | `pythnet.rpcpool.com:8001` | Boot peer for gossip+snapshot |
+| `pythnet_known_validators` | (2 published Pyth validators) | `--known-validator` list |
+| `pythnet_genesis_hash` | (constant above) | Sanity gate against wrong cluster |
+| `pythnet_shred_version` | `35891` | Sanity gate against wrong cluster |
+| `pythnet_limit_ledger_size` | `50000000` | Shred count cap |
+
+## Usage
+
+### 1. Write inventory
+
+```yaml
+all:
+  hosts:
+    pythnet-1:
+      ansible_host: "<bm-ip>"
+      ansible_user: "solv"
+      ansible_ssh_private_key_file: "~/.ssh/id_rsa"
+  vars:
+    pythnet_format_disk: true        # only if you want the recipe to mkfs nvme0n1
+    pythnet_ledger_mount: "/mnt/ledger"
+```
+
+### 2. Deploy
+
+```bash
+slv pythnet deploy
+# or:
+ansible-playbook -i ~/.slv/inventory.mainnet.pythnet.yml \
+  ~/.slv/mainnet-pythnet/init.yml
+```
+
+### 3. Watch catch-up
+
+```bash
+ssh solv@<bm-ip> 'tail -f /mnt/ledger/pythnet/log/validator.log | grep -E "snapshot|known validator|optimistic"'
+```
+
+### 4. Verify
+
+```bash
+curl -fsS http://<bm-ip>:8899 -X POST -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}'
+# → {"jsonrpc":"2.0","result":"ok","id":1}
+```
+
+### 5. Point Hermes at it
+
+In your hermes inventory:
+
+```yaml
+    hermes_pythnet_http_addr: "http://<bm-ip>:8899"
+    hermes_pythnet_ws_addr:   "ws://<bm-ip>:8900"
+```
+
+Then `slv hermes restart`.
+
+## Known gotchas
+
+- **`--account-index program-id` is mandatory** on Pythnet — the
+  validator panics on startup without it.  The recipe sets this; if you
+  customize the start script, do not remove it.
+- **rocksdb fails to build under GCC 13+** without
+  `CXXFLAGS="-include cstdint"`.  The build playbook handles this; if
+  you build by hand, copy that env var verbatim.  *Do not* set CFLAGS
+  with the same flag — blake3's build script uses `cc` to assemble `.S`
+  files and `-include cstdint` corrupts the assembly source.
+- **sysctl rmem/wmem must be 128 MiB** — the validator's startup
+  self-check fails fast otherwise.  The recipe writes
+  `/etc/sysctl.d/99-pythnet.conf` to enforce this.
+- **Identity key has no monetary value** — Pythnet RPC nodes run with
+  `--no-voting`, the identity is just a gossip pubkey.  Losing it costs
+  nothing; the validator rejoins under a new pubkey on next start.
+- **Disk usage**: expect ~10 GB/day ledger growth.  With
+  `--limit-ledger-size 50000000` the ledger holds ~30 days of slots
+  before rotation.

--- a/oss-skills/slv-pythnet/examples/inventory.yml
+++ b/oss-skills/slv-pythnet/examples/inventory.yml
@@ -39,3 +39,32 @@ all:
     # pythnet_known_validators:
     #   - DzZov8p2kwXJeYx2hnVyaxNFugYVF4up9AWwRvtYWU4u
     #   - 6Rr1vUgRZmqDuzzU6Sf3QAfUTYV3aa4wqxKrL6uBGXdU
+
+    # --- nftables (used by `slv pythnet firewall`) ---
+    # ★ mgmt_ips_v4 must contain every IP that should retain admin / SSH
+    # access.  The playbook refuses to deploy with an empty list.
+    mgmt_ips_v4:
+      - "<your-admin-ip>"
+    # ban_ips_v4: []
+    # ssh_port: 22
+    # Gossip (8001) + the TPU/QUIC dynamic-port range are public so the
+    # validator can fan-out to gossip peers; downsize to your actual
+    # pythnet_dynamic_port_range if you customized it above.
+    public_tcp_ports:
+      - 8001
+      - "8000-8020"
+    public_udp_ports:
+      - 8001
+      - "8000-8020"
+    # JSON-RPC is restricted to known clients (typically your Hermes
+    # node).  Each entry maps a port (or range string) → list of IPv4
+    # addresses/CIDRs allowed to connect.
+    restricted_ports:
+      - port: 8899          # HTTP RPC
+        tcp: true
+        allow_ipv4:
+          - "<hermes-vps-ip>"
+      - port: 8900          # WebSocket RPC
+        tcp: true
+        allow_ipv4:
+          - "<hermes-vps-ip>"

--- a/oss-skills/slv-pythnet/examples/inventory.yml
+++ b/oss-skills/slv-pythnet/examples/inventory.yml
@@ -1,0 +1,41 @@
+# SLV Pythnet — Example Inventory
+#
+# Usage:
+#   cp examples/inventory.yml ~/.slv/inventory.mainnet.pythnet.yml
+#   # edit ansible_host + (optionally) device/mount
+#   ansible-playbook -i ~/.slv/inventory.mainnet.pythnet.yml \
+#     ~/.slv/mainnet-pythnet/init.yml
+
+all:
+  hosts:
+    pythnet-1:
+      ansible_host: "<bm-ip>"
+      ansible_user: "solv"
+      ansible_ssh_private_key_file: "~/.ssh/id_rsa"
+
+  vars:
+    # --- Disk layout ---
+    # If your BM has an unused secondary NVMe you want the recipe to
+    # format and mount, set pythnet_format_disk: true.  Otherwise leave
+    # this false and ensure pythnet_ledger_mount already exists with
+    # enough free space (~500 GB recommended; 50 GB minimum for testing).
+    pythnet_format_disk: false
+    pythnet_ledger_device: "/dev/nvme0n1"
+    pythnet_ledger_mount: "/mnt/ledger"
+
+    # --- Repo pinning (optional) ---
+    # pythnet_ref: "pyth-v1.14.17"   # default; currently the only supported branch
+
+    # --- RPC binding ---
+    pythnet_rpc_port: 8899
+    pythnet_rpc_bind: "0.0.0.0"
+    pythnet_dynamic_port_range: "8000-8020"
+    pythnet_gossip_port: 8001
+
+    # --- Network parameters (immutable Pythnet constants — leave as-is) ---
+    # pythnet_entrypoint:      "pythnet.rpcpool.com:8001"
+    # pythnet_genesis_hash:    "GLKkBUr6r72nBtGrtBPJLRqtsh8wXZanX4xfnqKnWwKq"
+    # pythnet_shred_version:   35891
+    # pythnet_known_validators:
+    #   - DzZov8p2kwXJeYx2hnVyaxNFugYVF4up9AWwRvtYWU4u
+    #   - 6Rr1vUgRZmqDuzzU6Sf3QAfUTYV3aa4wqxKrL6uBGXdU

--- a/template/2026.5.5.1612/ansible/cmn/deploy_nftables.yml
+++ b/template/2026.5.5.1612/ansible/cmn/deploy_nftables.yml
@@ -54,9 +54,23 @@
     nft_python_interpreter: "{{ ansible_facts.python.executable | default('/usr/bin/python3') }}"
 
   pre_tasks:
-    # Hard fail-safe: empty mgmt_ips_v4 + nonzero restricted/public means
-    # the operator likely forgot to pass their IP, which would lock them
-    # out the moment we apply.  Refuse to proceed.
+    # Load the optional shared variable files.  `cf_ipv4.yml` ships with
+    # the slv templates (refreshed against https://www.cloudflare.com/ips-v4)
+    # — operators referring to `{{ cf_ipv4 | default([]) }}` in inventory
+    # get the current list without copying it by hand.  The lookup is
+    # best-effort: missing file → variable just stays undefined, default
+    # filter handles the empty case.
+    - name: Load optional cmn/files/cf_ipv4.yml (Cloudflare IPv4 ranges)
+      ansible.builtin.include_vars:
+        file: "{{ lookup('env', 'HOME') }}/.slv/cmn/files/cf_ipv4.yml"
+      failed_when: false
+      delegate_to: localhost
+      run_once: true
+      become: false
+
+    # Hard fail-safe: empty mgmt_ips_v4 means the operator likely forgot
+    # to pass their IP, which would lock them out the moment we apply.
+    # Refuse to proceed.
     - name: Sanity-check that mgmt_ips_v4 is non-empty
       ansible.builtin.assert:
         that:

--- a/template/2026.5.5.1612/ansible/cmn/deploy_nftables.yml
+++ b/template/2026.5.5.1612/ansible/cmn/deploy_nftables.yml
@@ -1,0 +1,322 @@
+---
+# Deploy an nftables ruleset on a single host.  OSS-clean version: no
+# hardcoded management IPs, no external service integrations.  All
+# allow lists come from inventory or `-e` extra-vars.
+#
+# Required inventory variables (deploy refuses to run without them):
+#   mgmt_ips_v4    list of IPv4 addresses that should retain full
+#                  access.  ★ Lockout warning ★ — this list MUST
+#                  include the operator's own source IP, otherwise the
+#                  SSH session will be dropped the moment the ruleset
+#                  is applied.
+#
+# Optional inventory variables (all default to empty / sensible):
+#   mgmt_ips_v6        list of IPv6 mgmt addresses
+#   ban_ips_v4         list of IPv4 (or CIDR) to block at highest priority
+#   ssh_port           SSH listen port (default 22)
+#   public_tcp_ports   list of TCP ports/ranges to accept from anywhere
+#   public_udp_ports   list of UDP ports/ranges to accept from anywhere
+#   restricted_ports   list of dicts — each declares a port + tcp/udp
+#                      flags + an allow_ipv4 list.  Example:
+#                        restricted_ports:
+#                          - port: 8899
+#                            tcp: true
+#                            allow_ipv4: ["198.51.100.10"]
+#                          - port: "8000-8020"
+#                            tcp: true
+#                            udp: true
+#                            allow_ipv4: []
+#   disable_ufw        true (default) — stop ufw to avoid conflict
+#   preserve_existing  true (default) — keep current allowAll_v4 /
+#                      banAll_v4 elements across re-runs
+#
+# Usage:
+#   ansible-playbook -i <inventory> \
+#     template/.../ansible/cmn/deploy_nftables.yml \
+#     -e '{"mgmt_ips_v4": ["1.2.3.4"], "public_tcp_ports": [7575], "public_udp_ports": [8999]}'
+
+- name: Deploy slv-nftables ruleset (atomic + rollback-safe)
+  hosts: all
+  gather_facts: yes
+  become: yes
+
+  # Internal-state vars only.  All operator-tunable inputs
+  # (mgmt_ips_v4, public_tcp_ports, restricted_ports, …) come from
+  # inventory; do NOT put their defaults here — playbook-vars override
+  # inventory-vars, so any default here silently masks what the
+  # operator wrote in inventory.yml.  Default values are applied
+  # inline via the `| default(...)` filter at point of use.
+  vars:
+    nft_conf_path: /etc/nftables.conf
+    nft_frag_dir: /etc/nftables.d
+    nft_sets_dir: /etc/nftables.sets.d
+    nft_template_root: "~/.slv/cmn/nftables"
+    nft_python_interpreter: "{{ ansible_facts.python.executable | default('/usr/bin/python3') }}"
+
+  pre_tasks:
+    # Hard fail-safe: empty mgmt_ips_v4 + nonzero restricted/public means
+    # the operator likely forgot to pass their IP, which would lock them
+    # out the moment we apply.  Refuse to proceed.
+    - name: Sanity-check that mgmt_ips_v4 is non-empty
+      ansible.builtin.assert:
+        that:
+          - (mgmt_ips_v4 | default([]) | length) > 0
+        fail_msg: >-
+          mgmt_ips_v4 is empty.  Applying nftables now would drop your
+          SSH session.  Pass at least one admin IP via inventory or
+          `-e '{"mgmt_ips_v4": ["YOUR.IP.HERE"]}'`.
+
+    - name: Ensure nftables package
+      ansible.builtin.apt:
+        name: nftables
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Optionally disable ufw to avoid rule conflicts
+      when: (disable_ufw | default(true)) | bool
+      ansible.builtin.service:
+        name: ufw
+        state: stopped
+        enabled: false
+      ignore_errors: true
+
+  tasks:
+    # ---- Preserve existing runtime additions ----------------------------
+    - name: Initialize preserved set fact lists
+      ansible.builtin.set_fact:
+        existing_allowAll_v4: []
+        existing_banAll_v4: []
+        existing_restricted_sets: {}
+
+    - name: Capture existing allowAll_v4 elements
+      when: (preserve_existing | default(true)) | bool
+      ansible.builtin.shell: |
+        set -o pipefail
+        nft list set inet filter allowAll_v4 2>/dev/null | {{ nft_python_interpreter }} - <<'PY'
+        import re, sys
+        data = sys.stdin.read()
+        m = re.search(r'elements\s*=\s*\{([^}]*)\}', data, re.S)
+        if not m:
+            sys.exit(0)
+        for tok in m.group(1).split(','):
+            tok = tok.strip()
+            if tok:
+                print(tok)
+        PY
+      args: { executable: /bin/bash }
+      register: current_allowAll_v4
+      changed_when: false
+      failed_when: false
+
+    - name: Capture existing banAll_v4 elements
+      when: (preserve_existing | default(true)) | bool
+      ansible.builtin.shell: |
+        set -o pipefail
+        nft list set inet filter banAll_v4 2>/dev/null | {{ nft_python_interpreter }} - <<'PY'
+        import re, sys
+        data = sys.stdin.read()
+        m = re.search(r'elements\s*=\s*\{([^}]*)\}', data, re.S)
+        if not m:
+            sys.exit(0)
+        for tok in m.group(1).split(','):
+            tok = tok.strip()
+            if tok:
+                print(tok)
+        PY
+      args: { executable: /bin/bash }
+      register: current_banAll_v4
+      changed_when: false
+      failed_when: false
+
+    - name: Set preserved seed lists
+      ansible.builtin.set_fact:
+        seed_allowAll_v4: >-
+          {{
+            ((current_allowAll_v4.stdout_lines | default([])
+              if (current_allowAll_v4.rc | default(1) == 0) else []))
+            | map('trim') | reject('equalto','') | list | unique
+          }}
+        seed_banAll_v4: >-
+          {{
+            ((current_banAll_v4.stdout_lines | default([])
+              if (current_banAll_v4.rc | default(1) == 0) else [])
+            + (ban_ips_v4 | default([])))
+            | map('trim') | reject('equalto','') | list | unique
+          }}
+
+    # ---- Render fragments ------------------------------------------------
+    - name: Ensure fragment directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      loop:
+        - "{{ nft_frag_dir }}"
+        - "{{ nft_sets_dir }}"
+
+    - name: Backup current nftables.conf if present
+      ansible.builtin.copy:
+        src: "{{ nft_conf_path }}"
+        dest: "{{ nft_conf_path }}.bak"
+        owner: root
+        group: root
+        mode: "0644"
+        remote_src: true
+      failed_when: false
+
+    - name: Clean old fragments
+      ansible.builtin.shell: |
+        rm -f {{ nft_frag_dir }}/*.nft {{ nft_sets_dir }}/*.nft
+        mkdir -p {{ nft_frag_dir }} {{ nft_sets_dir }}
+      changed_when: true
+
+    - name: Render base + sets + rules
+      block:
+        - name: Render nftables.conf (base)
+          ansible.builtin.template:
+            src: "{{ nft_template_root }}/nftables.conf.j2"
+            dest: "{{ nft_conf_path }}"
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: Render common set definitions
+          ansible.builtin.template:
+            src: "{{ nft_template_root }}/00-sets-common.nft.j2"
+            dest: "{{ nft_sets_dir }}/00-sets-common.nft"
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: Render ban check
+          ansible.builtin.template:
+            src: "{{ nft_template_root }}/00-ban-check.nft.j2"
+            dest: "{{ nft_frag_dir }}/00-ban-check.nft"
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: Render mgmt allow-all
+          ansible.builtin.template:
+            src: "{{ nft_template_root }}/01-mgmt-allow.nft.j2"
+            dest: "{{ nft_frag_dir }}/01-mgmt-allow.nft"
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: Render SSH safety net
+          ansible.builtin.template:
+            src: "{{ nft_template_root }}/01-ssh-accept.nft.j2"
+            dest: "{{ nft_frag_dir }}/01-ssh-accept.nft"
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: Render public ports
+          ansible.builtin.template:
+            src: "{{ nft_template_root }}/02-public-ports.nft.j2"
+            dest: "{{ nft_frag_dir }}/02-public-ports.nft"
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: Render restricted ports
+          ansible.builtin.template:
+            src: "{{ nft_template_root }}/03-restricted-ports.nft.j2"
+            dest: "{{ nft_frag_dir }}/03-restricted-ports.nft"
+            owner: root
+            group: root
+            mode: "0644"
+
+        - name: Validate the rendered config (dry-run)
+          ansible.builtin.command: "nft -c -f {{ nft_conf_path }}"
+          changed_when: false
+
+      rescue:
+        - name: Restore previous nftables.conf
+          ansible.builtin.copy:
+            src: "{{ nft_conf_path }}.bak"
+            dest: "{{ nft_conf_path }}"
+            owner: root
+            group: root
+            mode: "0644"
+            remote_src: true
+          failed_when: false
+
+        - name: Fail after restore
+          ansible.builtin.fail:
+            msg: "nftables config validation failed; previous config restored."
+
+    - name: Apply the new ruleset atomically
+      ansible.builtin.command: "nft -f {{ nft_conf_path }}"
+
+    # ---- Seed set elements (idempotent — `nft add` is a no-op on dup) ---
+    - name: Seed banAll_v4
+      vars: { ip_list: "{{ seed_banAll_v4 | default([]) }}" }
+      when: ip_list | length > 0
+      ansible.builtin.shell: |
+        set -e
+        for ip in {{ ip_list | join(' ') }}; do
+          nft add element inet filter banAll_v4 { $ip } || true
+        done
+      args: { executable: /bin/bash }
+      changed_when: true
+
+    - name: Seed allowAll_v4
+      vars: { ip_list: "{{ seed_allowAll_v4 | default([]) }}" }
+      when: ip_list | length > 0
+      ansible.builtin.shell: |
+        set -e
+        for ip in {{ ip_list | join(' ') }}; do
+          nft add element inet filter allowAll_v4 { $ip } || true
+        done
+      args: { executable: /bin/bash }
+      changed_when: true
+
+    - name: Seed restricted port allow lists
+      vars:
+        ip_list: "{{ (item.allow_ipv4 | default([])) | map('trim') | reject('equalto','') | list | unique }}"
+        slug: "{{ item.port | string | regex_replace('[^0-9]+', '_') }}"
+      when: ip_list | length > 0
+      ansible.builtin.shell: |
+        set -e
+        for ip in {{ ip_list | join(' ') }}; do
+          nft add element inet filter allow_{{ slug }}_v4 { $ip } || true
+        done
+      args: { executable: /bin/bash }
+      loop: "{{ restricted_ports | default([]) }}"
+      loop_control:
+        label: "{{ item.port }} (allow_{{ item.port | string | regex_replace('[^0-9]+', '_') }}_v4)"
+      changed_when: true
+
+    # ---- Persist live ruleset (survives reboot) ------------------------
+    - name: Persist live nftables ruleset
+      ansible.builtin.import_tasks: tasks/persist_nftables_ruleset.yml
+
+    - name: Show effective ruleset summary
+      vars:
+        sets: >-
+          {{
+            ['allowAll_v4', 'banAll_v4']
+            + ((restricted_ports | default([]))
+               | map(attribute='port')
+               | map('string')
+               | map('regex_replace', '[^0-9]+', '_')
+               | map('regex_replace', '^', 'allow_')
+               | map('regex_replace', '$', '_v4')
+               | list)
+          }}
+      ansible.builtin.shell: |
+        for s in {{ sets | join(' ') }}; do
+          echo "--- $s ---"
+          nft list set inet filter "$s" 2>/dev/null || echo "(not present)"
+        done
+      register: effective_summary
+      changed_when: false
+
+    - name: Display summary
+      ansible.builtin.debug:
+        var: effective_summary.stdout_lines

--- a/template/2026.5.5.1612/ansible/cmn/install_hermes_stack.yml
+++ b/template/2026.5.5.1612/ansible/cmn/install_hermes_stack.yml
@@ -1,0 +1,240 @@
+---
+# Install the full Pyth Hermes stack on a single host:
+#   - nats-server (JetStream)        for Beacon VAA dedup/stream
+#   - pyth-network/beacon            HA Wormhole spy that pushes VAAs into NATS
+#   - pyth-network/pyth-crosschain   apps/hermes/server (Rust) — REST/WS API
+#
+# Hermes needs a Pythnet RPC (HTTP + WS) as a *source* of accumulator
+# messages and a Wormhole spy (or Beacon) for VAAs.  Both endpoints come
+# from inventory variables — by default they point to public infrastructure,
+# but the recommended pattern is to swap them for a self-hosted Pythnet RPC
+# deployed via `mainnet-pythnet/init.yml`.
+#
+# Inventory variables (with defaults — override per-host or per-group):
+#   hermes_repo                 https://github.com/pyth-network/pyth-crosschain
+#   hermes_repo_ref             main
+#   beacon_repo                 https://github.com/pyth-network/beacon
+#   beacon_repo_ref             main
+#   nats_version                v2.10.22
+#   hermes_rust_toolchain       1.82.0
+#   hermes_pythnet_http_addr    https://pythnet.rpcpool.com
+#   hermes_pythnet_ws_addr      wss://pythnet.rpcpool.com
+#   hermes_wormhole_env         mainnet
+#   hermes_rpc_listen_addr      0.0.0.0:7575
+#   hermes_metrics_listen_addr  127.0.0.1:7576
+#   beacon_listen_port          8999
+#   beacon_spy_grpc_addr        127.0.0.1:7072
+#   nats_port                   4222
+
+- name: Install Pyth Hermes stack (nats + beacon + hermes)
+  hosts: all
+  become: yes
+  gather_facts: yes
+  vars:
+    hermes_repo: "{{ hermes_repo | default('https://github.com/pyth-network/pyth-crosschain') }}"
+    hermes_repo_ref: "{{ hermes_repo_ref | default('main') }}"
+    beacon_repo: "{{ beacon_repo | default('https://github.com/pyth-network/beacon') }}"
+    beacon_repo_ref: "{{ beacon_repo_ref | default('main') }}"
+    nats_version: "{{ nats_version | default('v2.10.22') }}"
+    rust_toolchain: "{{ hermes_rust_toolchain | default('1.82.0') }}"
+
+    # Endpoints — override these in inventory.  The defaults talk to the
+    # public Pyth infrastructure so a fresh install boots end-to-end; in
+    # production swap pythnet_http/ws for your own pythnet RPC.
+    pythnet_http_addr: "{{ hermes_pythnet_http_addr | default('https://pythnet.rpcpool.com') }}"
+    pythnet_ws_addr: "{{ hermes_pythnet_ws_addr | default('wss://pythnet.rpcpool.com') }}"
+    wormhole_env: "{{ hermes_wormhole_env | default('mainnet') }}"
+
+    rpc_listen_addr: "{{ hermes_rpc_listen_addr | default('0.0.0.0:7575') }}"
+    metrics_listen_addr: "{{ hermes_metrics_listen_addr | default('127.0.0.1:7576') }}"
+    beacon_listen_port: "{{ beacon_listen_port | default(8999) }}"
+    beacon_spy_grpc_addr: "{{ beacon_spy_grpc_addr | default('127.0.0.1:7072') }}"
+    nats_port: "{{ nats_port | default(4222) }}"
+
+    hermes_src_dir: "/home/solv/src/pyth-crosschain"
+    hermes_binary: "/home/solv/src/pyth-crosschain/apps/hermes/server/target/release/hermes"
+    beacon_src_dir: "/home/solv/src/beacon"
+    beacon_binary: "/home/solv/beacon-bin"
+
+  tasks:
+    - name: Install OS packages (build deps + nats prerequisites)
+      ansible.builtin.apt:
+        name:
+          - build-essential
+          - pkg-config
+          - libssl-dev
+          - clang
+          - protobuf-compiler
+          - git
+          - curl
+          - jq
+          - golang-go
+          - ca-certificates
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+
+    # nats-server is shipped as a single static binary.  We install it
+    # ourselves because Ubuntu's repo lags releases and we want to pin a
+    # version that matches the Beacon NATS client we build below.
+    - name: Check installed nats-server version
+      ansible.builtin.command: /usr/local/bin/nats-server --version
+      register: nats_installed
+      changed_when: false
+      failed_when: false
+
+    - name: Download nats-server {{ nats_version }} tarball
+      ansible.builtin.get_url:
+        url: "https://github.com/nats-io/nats-server/releases/download/{{ nats_version }}/nats-server-{{ nats_version }}-linux-amd64.tar.gz"
+        dest: "/tmp/nats-{{ nats_version }}.tgz"
+        mode: "0644"
+      when: nats_version not in nats_installed.stdout
+
+    - name: Unpack nats-server
+      ansible.builtin.unarchive:
+        src: "/tmp/nats-{{ nats_version }}.tgz"
+        dest: /tmp
+        remote_src: yes
+      when: nats_version not in nats_installed.stdout
+
+    - name: Install nats-server binary
+      ansible.builtin.copy:
+        src: "/tmp/nats-server-{{ nats_version }}-linux-amd64/nats-server"
+        dest: /usr/local/bin/nats-server
+        mode: "0755"
+        remote_src: yes
+      when: nats_version not in nats_installed.stdout
+
+    - name: Install Rust toolchain for solv
+      become_user: solv
+      ansible.builtin.shell: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+          | sh -s -- -y --default-toolchain {{ rust_toolchain }} --profile minimal
+      args:
+        creates: /home/solv/.cargo/bin/cargo
+
+    - name: Ensure source dir exists
+      ansible.builtin.file:
+        path: /home/solv/src
+        state: directory
+        owner: solv
+        group: solv
+        mode: "0755"
+
+    # Build Beacon (Go) first — it's fast (~30s) and lets us start NATS+spy
+    # while the heavier Hermes (Rust) compile runs.
+    - name: Clone beacon repo
+      become_user: solv
+      ansible.builtin.git:
+        repo: "{{ beacon_repo }}"
+        dest: "{{ beacon_src_dir }}"
+        version: "{{ beacon_repo_ref }}"
+        depth: 1
+        force: yes
+      register: beacon_git
+
+    - name: Build beacon binary
+      become_user: solv
+      ansible.builtin.shell: |
+        export PATH=$PATH:/usr/local/go/bin
+        go build -o {{ beacon_binary }} .
+      args:
+        chdir: "{{ beacon_src_dir }}"
+        executable: /bin/bash
+      when: beacon_git.changed or not (beacon_binary | length > 0)
+      register: beacon_build
+      changed_when: beacon_build.rc == 0
+
+    # Clone Hermes server crate.  The crate lives at apps/hermes/server in the
+    # pyth-crosschain monorepo; the build pulls in ~200 Cargo deps but
+    # finishes in ~60s on modern hardware (Cargo build cache reuses across
+    # re-runs).
+    - name: Clone pyth-crosschain repo
+      become_user: solv
+      ansible.builtin.git:
+        repo: "{{ hermes_repo }}"
+        dest: "{{ hermes_src_dir }}"
+        version: "{{ hermes_repo_ref }}"
+        depth: 1
+        force: yes
+      register: hermes_git
+
+    - name: Build hermes binary
+      become_user: solv
+      ansible.builtin.shell: |
+        source $HOME/.cargo/env
+        cargo build --release
+      args:
+        chdir: "{{ hermes_src_dir }}/apps/hermes/server"
+        executable: /bin/bash
+      register: hermes_build
+      changed_when: hermes_build.rc == 0
+      when: hermes_git.changed
+
+    - name: NATS data dir
+      ansible.builtin.file:
+        path: /home/solv/nats-data
+        state: directory
+        owner: solv
+        group: solv
+        mode: "0755"
+
+    - name: Install nats-server systemd unit
+      ansible.builtin.template:
+        src: "~/.slv/mainnet-hermes/nats-server.service.j2"
+        dest: /etc/systemd/system/nats-server.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: reload systemd
+
+    - name: Install beacon systemd unit
+      ansible.builtin.template:
+        src: "~/.slv/mainnet-hermes/beacon.service.j2"
+        dest: /etc/systemd/system/beacon.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: reload systemd
+
+    - name: Install hermes systemd unit
+      ansible.builtin.template:
+        src: "~/.slv/mainnet-hermes/hermes.service.j2"
+        dest: /etc/systemd/system/hermes.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: reload systemd
+
+    - name: Flush handlers so daemon-reload runs before enable+start
+      ansible.builtin.meta: flush_handlers
+
+    - name: Enable and start the stack (nats → beacon → hermes)
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        enabled: yes
+        state: started
+      loop:
+        - nats-server.service
+        - beacon.service
+        - hermes.service
+
+    # Smoke test — fail fast if the API isn't responding.  Hermes binds
+    # its REST/WS listener as soon as it starts so this should be ready
+    # within a few seconds; the retry loop forgives slow boot.
+    - name: Wait for hermes /v2/price_feeds
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ rpc_listen_addr.split(':')[1] }}/v2/price_feeds"
+        status_code: 200
+      register: hermes_health
+      retries: 15
+      delay: 2
+      until: hermes_health.status == 200
+
+    - name: Report endpoint
+      ansible.builtin.debug:
+        msg: "Hermes API listening on {{ rpc_listen_addr }} — POST/GET /v2/* and /ws supported."
+
+  handlers:
+    - name: reload systemd
+      ansible.builtin.command: systemctl daemon-reload

--- a/template/2026.5.5.1612/ansible/cmn/tasks/persist_nftables_ruleset.yml
+++ b/template/2026.5.5.1612/ansible/cmn/tasks/persist_nftables_ruleset.yml
@@ -1,0 +1,52 @@
+---
+# Export the live nftables ruleset (including set elements added after
+# deploy) into /etc/nftables.conf so the same ruleset is restored on
+# reboot by nftables.service.
+#
+# Designed to be `import_tasks`'d from playbooks, not run standalone.
+
+- name: Resolve nftables.conf path
+  ansible.builtin.set_fact:
+    nft_conf_path_effective: "{{ nft_conf_path | default('/etc/nftables.conf') }}"
+
+- name: Export live nftables ruleset
+  ansible.builtin.command: nft list ruleset
+  register: nft_live_ruleset
+  changed_when: false
+
+- name: Write generated persistent nftables.conf (temp)
+  ansible.builtin.copy:
+    dest: "{{ nft_conf_path_effective }}.generated"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # Managed by slv (generated from live ruleset on {{ ansible_date_time.iso8601 | default('deploy') }})
+      flush ruleset
+
+      {{ nft_live_ruleset.stdout | regex_replace('packets \\d+ bytes \\d+', '') }}
+
+- name: Validate generated persistent config
+  ansible.builtin.command: "nft -c -f {{ nft_conf_path_effective }}.generated"
+  changed_when: false
+
+- name: Install generated nftables.conf
+  ansible.builtin.copy:
+    src: "{{ nft_conf_path_effective }}.generated"
+    dest: "{{ nft_conf_path_effective }}"
+    remote_src: true
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Remove generated temp file
+  ansible.builtin.file:
+    path: "{{ nft_conf_path_effective }}.generated"
+    state: absent
+  changed_when: false
+
+- name: Enable + start nftables service (boot restore)
+  ansible.builtin.service:
+    name: nftables
+    enabled: true
+    state: started

--- a/template/2026.5.5.1612/ansible/mainnet-hermes/init.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-hermes/init.yml
@@ -1,0 +1,17 @@
+---
+# Full Hermes node initialization.  Delegates the heavy lift (build +
+# systemd) to cmn/install_hermes_stack.yml so the same recipe can be
+# reused if Pyth ever ships a separate beta/testnet with its own Pythnet RPC.
+#
+# Usage:
+#   ansible-playbook -i ~/.slv/inventory.mainnet.hermes.yml \
+#     template/2026.5.5.1612/ansible/mainnet-hermes/init.yml
+#
+# Hermes does not need an identity key, snapshots, or ledger storage — it's
+# a stateless API service.  All it does is bridge Pythnet + Wormhole to
+# REST/WS, so a modest VPS (4 vCPU / 8 GB / 80 GB) handles it comfortably.
+
+- import_playbook: ../cmn/fix_permissions.yml
+- import_playbook: ../cmn/create_user.yml
+- import_playbook: ../cmn/update_ubuntu.yml
+- import_playbook: ../cmn/install_hermes_stack.yml

--- a/template/2026.5.5.1612/ansible/mainnet-hermes/restart_node.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-hermes/restart_node.yml
@@ -1,0 +1,21 @@
+---
+# Restart the Hermes stack.  Beacon and Hermes pick up env changes on
+# restart (e.g. switching PYTHNET_HTTP_ADDR from a public URL to a
+# self-hosted Pythnet RPC).
+- name: Restart Hermes stack
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - name: Restart nats-server
+      ansible.builtin.systemd:
+        name: nats-server.service
+        state: restarted
+    - name: Restart beacon
+      ansible.builtin.systemd:
+        name: beacon.service
+        state: restarted
+    - name: Restart hermes
+      ansible.builtin.systemd:
+        name: hermes.service
+        state: restarted

--- a/template/2026.5.5.1612/ansible/mainnet-hermes/start_node.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-hermes/start_node.yml
@@ -1,0 +1,23 @@
+---
+# Start the Hermes stack (nats → beacon → hermes).  Useful after a host
+# reboot or as a no-op idempotent kickstart.
+- name: Start Hermes stack
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - name: Start nats-server
+      ansible.builtin.systemd:
+        name: nats-server.service
+        state: started
+        enabled: yes
+    - name: Start beacon
+      ansible.builtin.systemd:
+        name: beacon.service
+        state: started
+        enabled: yes
+    - name: Start hermes
+      ansible.builtin.systemd:
+        name: hermes.service
+        state: started
+        enabled: yes

--- a/template/2026.5.5.1612/ansible/mainnet-hermes/stop_node.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-hermes/stop_node.yml
@@ -1,0 +1,20 @@
+---
+# Stop the Hermes stack.  Reverse dependency order so dependents shut down
+# before their backing services.
+- name: Stop Hermes stack
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - name: Stop hermes
+      ansible.builtin.systemd:
+        name: hermes.service
+        state: stopped
+    - name: Stop beacon
+      ansible.builtin.systemd:
+        name: beacon.service
+        state: stopped
+    - name: Stop nats-server
+      ansible.builtin.systemd:
+        name: nats-server.service
+        state: stopped

--- a/template/2026.5.5.1612/ansible/mainnet-hermes/update_hermes.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-hermes/update_hermes.yml
@@ -1,0 +1,6 @@
+---
+# Re-run the build step against a (possibly updated) hermes_repo_ref to pull
+# in upstream changes.  Safe to run any time — the install_hermes_stack
+# playbook is idempotent and only restarts services when the binary
+# actually changed.
+- import_playbook: ../cmn/install_hermes_stack.yml

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/build_pythnet.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/build_pythnet.yml
@@ -1,0 +1,77 @@
+---
+# Clone pyth-network/pythnet and build solana-validator + solana-keygen +
+# solana-gossip.
+#
+# Pythnet is a Solana 1.14 fork — the bundled rocksdb (v7.4.4) fails to
+# compile under modern GCC because it relies on the legacy implicit-include
+# behavior for <cstdint>.  We work around this by setting CXXFLAGS for the
+# build only (NOT CFLAGS — blake3 uses cc to assemble .S files and
+# -include cstdint would be prepended to assembly source, breaking it).
+
+- name: Build Pythnet validator from source
+  hosts: all
+  become: true
+  vars:
+    pythnet_repo: "{{ pythnet_repo | default('https://github.com/pyth-network/pythnet') }}"
+    pythnet_ref: "{{ pythnet_ref | default('pyth-v1.14.17') }}"
+    pythnet_ledger_mount: "{{ pythnet_ledger_mount | default('/mnt/ledger') }}"
+    src_dir: "{{ pythnet_ledger_mount }}/src/pythnet"
+
+  tasks:
+    - name: Ensure src dir exists
+      ansible.builtin.file:
+        path: "{{ src_dir | dirname }}"
+        state: directory
+        owner: solv
+        group: solv
+        mode: "0755"
+
+    - name: Clone pythnet repo (shallow, pinned branch)
+      become_user: solv
+      ansible.builtin.git:
+        repo: "{{ pythnet_repo }}"
+        dest: "{{ src_dir }}"
+        version: "{{ pythnet_ref }}"
+        depth: 1
+        force: yes
+      register: pythnet_git
+
+    # CXXFLAGS workaround: rocksdb's data_block_hash_index.h drops
+    # uint*_t under modern GCC because <cstdint> isn't transitively
+    # included.  -include cstdint fixes the build without patching
+    # upstream sources.  Scoped to C++ only — blake3's build.rs uses cc
+    # to assemble .S files and a C-level -include would corrupt those.
+    - name: Build solana-validator + keygen + gossip
+      become_user: solv
+      ansible.builtin.shell: 'source $HOME/.cargo/env && export CXXFLAGS="-include cstdint" && unset CFLAGS && cargo build --release --bin solana-validator --bin solana-keygen --bin solana-gossip'
+      args:
+        chdir: "{{ src_dir }}"
+        executable: /bin/bash
+      register: build_result
+      changed_when: build_result.rc == 0
+      when: pythnet_git.changed
+
+    - name: Verify binaries exist
+      ansible.builtin.stat:
+        path: "{{ src_dir }}/target/release/{{ item }}"
+      loop:
+        - solana-validator
+        - solana-keygen
+        - solana-gossip
+      register: bin_stat
+
+    - name: Fail if any binary is missing
+      ansible.builtin.assert:
+        that: bin_stat.results | map(attribute='stat.exists') | list | min
+        fail_msg: "build_pythnet: one or more binaries missing under {{ src_dir }}/target/release/"
+
+    - name: Symlink binaries to /usr/local/bin
+      ansible.builtin.file:
+        src: "{{ src_dir }}/target/release/{{ item }}"
+        dest: "/usr/local/bin/{{ item }}"
+        state: link
+        force: yes
+      loop:
+        - solana-validator
+        - solana-keygen
+        - solana-gossip

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/create-start-pythnet-sh.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/create-start-pythnet-sh.yml
@@ -1,0 +1,13 @@
+---
+- name: Render start-pythnet.sh from Jinja template
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - name: Drop start-pythnet.sh
+      ansible.builtin.template:
+        src: "~/.slv/mainnet-pythnet/start-pythnet.sh.j2"
+        dest: /home/solv/start-pythnet.sh
+        owner: solv
+        group: solv
+        mode: "0755"

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/gen_identity.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/gen_identity.yml
@@ -1,0 +1,31 @@
+---
+# Generate the validator identity keypair if not already present.
+#
+# Pythnet RPC nodes run with --no-voting, so this key is only used as a
+# gossip identity — it does not hold stake or sign votes.  Losing it has
+# no monetary consequence; the validator just rejoins gossip under a new
+# pubkey on next start.
+- name: Generate Pythnet validator identity
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - name: Create identity.json (no-bip39-passphrase) if absent
+      become_user: solv
+      ansible.builtin.shell: |
+        /usr/local/bin/solana-keygen new \
+          --no-bip39-passphrase \
+          --outfile /home/solv/pythnet-identity.json \
+          --silent
+      args:
+        creates: /home/solv/pythnet-identity.json
+
+    - name: Read pubkey
+      become_user: solv
+      ansible.builtin.command: /usr/local/bin/solana-keygen pubkey /home/solv/pythnet-identity.json
+      register: pubkey_result
+      changed_when: false
+
+    - name: Show pubkey
+      ansible.builtin.debug:
+        msg: "Pythnet identity pubkey: {{ pubkey_result.stdout }}"

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/init.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/init.yml
@@ -1,0 +1,23 @@
+---
+# Pythnet RPC node initialization.
+#
+# Pythnet is an application-specific Solana fork operated by Pyth's data
+# providers.  Running a Pythnet RPC node lets you serve Pythnet HTTP+WS
+# directly to a self-hosted Hermes (see ../mainnet-hermes/), eliminating
+# the dependency on public Pythnet endpoints.
+#
+# Usage:
+#   ansible-playbook -i ~/.slv/inventory.mainnet.pythnet.yml \
+#     template/2026.5.5.1612/ansible/mainnet-pythnet/init.yml
+
+- import_playbook: ../cmn/fix_permissions.yml
+- import_playbook: ../cmn/create_user.yml
+- import_playbook: ../cmn/update_ubuntu.yml
+- import_playbook: install_package.yml
+- import_playbook: install_rust.yml
+- import_playbook: mount_disks.yml
+- import_playbook: optimize_pythnet.yml
+- import_playbook: build_pythnet.yml
+- import_playbook: gen_identity.yml
+- import_playbook: create-start-pythnet-sh.yml
+- import_playbook: setup-pythnet-service.yml

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/install_package.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/install_package.yml
@@ -1,0 +1,23 @@
+---
+- name: Install build dependencies for Pythnet (Solana 1.14 fork)
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - name: apt install
+      ansible.builtin.apt:
+        name:
+          - build-essential
+          - pkg-config
+          - libssl-dev
+          - libudev-dev
+          - clang
+          - cmake
+          - protobuf-compiler
+          - git
+          - curl
+          - jq
+          - ca-certificates
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/install_rust.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/install_rust.yml
@@ -1,0 +1,19 @@
+---
+# Pythnet's pyth-v1.14.17 branch pins rust-toolchain = "1.60.0".  rustup
+# auto-downloads 1.60 when building inside the repo, so we only need a
+# bootstrap toolchain — 1.78.0 is recent enough to run rustup itself and
+# small enough to install quickly.
+- name: Install Rust toolchain for solv
+  hosts: all
+  become: true
+  gather_facts: no
+  vars:
+    pythnet_rust_toolchain: "{{ pythnet_rust_toolchain | default('1.78.0') }}"
+  tasks:
+    - name: Install rustup via the official installer
+      become_user: solv
+      ansible.builtin.shell: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+          | sh -s -- -y --default-toolchain {{ pythnet_rust_toolchain }} --profile minimal
+      args:
+        creates: /home/solv/.cargo/bin/cargo

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/mount_disks.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/mount_disks.yml
@@ -1,0 +1,82 @@
+---
+# Format and mount the ledger disk for Pythnet.
+#
+# Pythnet ledger is much smaller than Solana mainnet (~10 GB/day vs
+# 200+ GB/day) so a single NVMe (or even a directory on the OS disk) is
+# sufficient.  This playbook is opt-in via `pythnet_format_disk` — leave
+# the default (false) if you'd rather manage the mount yourself or use a
+# directory on the root filesystem.
+#
+# Inventory variables:
+#   pythnet_format_disk    false      Set to true to actually run mkfs+mount
+#   pythnet_ledger_device  /dev/nvme0n1
+#   pythnet_ledger_mount   /mnt/ledger
+
+- name: Provision ledger disk for Pythnet
+  hosts: all
+  become: true
+  gather_facts: yes
+  vars:
+    do_format: "{{ pythnet_format_disk | default(false) | bool }}"
+    device: "{{ pythnet_ledger_device | default('/dev/nvme0n1') }}"
+    mount_point: "{{ pythnet_ledger_mount | default('/mnt/ledger') }}"
+
+  tasks:
+    - name: Ensure mount point exists
+      ansible.builtin.file:
+        path: "{{ mount_point }}"
+        state: directory
+        owner: solv
+        group: solv
+        mode: "0755"
+
+    # Guard: refuse to format an already-mounted or partitioned device unless
+    # the operator explicitly asks for a rebuild.  Without this guard a
+    # re-run of init.yml could wipe an existing ledger.
+    - name: Probe device for existing partition table / FS
+      ansible.builtin.command: "blkid -p {{ device }}"
+      register: dev_probe
+      changed_when: false
+      failed_when: false
+      when: do_format
+
+    - name: Refuse to wipe a non-empty device unless pythnet_force_format=true
+      ansible.builtin.fail:
+        msg: "{{ device }} already has a filesystem/partition table; set pythnet_force_format=true to rebuild"
+      when:
+        - do_format
+        - dev_probe.rc == 0
+        - dev_probe.stdout | length > 0
+        - not (pythnet_force_format | default(false) | bool)
+
+    - name: Wipe device (XFS — single agcount=32 stripe)
+      ansible.builtin.shell: |
+        wipefs -a {{ device }}
+        mkfs.xfs -f -d agcount=32 {{ device }}
+      when:
+        - do_format
+        - (dev_probe.rc != 0) or (pythnet_force_format | default(false) | bool)
+
+    - name: Add to fstab + mount
+      ansible.posix.mount:
+        path: "{{ mount_point }}"
+        src: "{{ device }}"
+        fstype: xfs
+        opts: "noatime,nodiratime,inode64,logbufs=8,logbsize=256k"
+        state: mounted
+      when: do_format
+
+    - name: Ensure ledger sub-dirs exist
+      ansible.builtin.file:
+        path: "{{ mount_point }}/{{ item }}"
+        state: directory
+        owner: solv
+        group: solv
+        mode: "0755"
+      loop:
+        - "pythnet"
+        - "pythnet/ledger"
+        - "pythnet/accounts"
+        - "pythnet/snapshots"
+        - "pythnet/log"
+        - "src"

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/optimize_pythnet.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/optimize_pythnet.yml
@@ -1,0 +1,27 @@
+---
+# sysctl tuning for Pythnet validator.  Same network buffers Solana
+# expects.  The validator's startup self-check fails fast if the four
+# rmem/wmem values aren't all 128 MiB, so we set defaults to match max.
+- name: Apply sysctl tuning for Pythnet validator
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - name: Drop /etc/sysctl.d/99-pythnet.conf
+      ansible.builtin.copy:
+        dest: /etc/sysctl.d/99-pythnet.conf
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          # Pythnet (Solana 1.14 fork) network buffers.  Required to pass
+          # solana_core::system_monitor_service's startup self-check.
+          net.core.rmem_default = 134217728
+          net.core.rmem_max = 134217728
+          net.core.wmem_default = 134217728
+          net.core.wmem_max = 134217728
+          vm.max_map_count = 1000000
+
+    - name: Reload sysctl
+      ansible.builtin.command: sysctl --system
+      changed_when: false

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/restart_node.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/restart_node.yml
@@ -1,0 +1,9 @@
+---
+- name: Restart Pythnet validator
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - ansible.builtin.systemd:
+        name: pythnet.service
+        state: restarted

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/setup-pythnet-service.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/setup-pythnet-service.yml
@@ -1,0 +1,32 @@
+---
+- name: Install + start Pythnet systemd service
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - name: Drop pythnet.service unit
+      ansible.builtin.template:
+        src: "~/.slv/mainnet-pythnet/pythnet.service.j2"
+        dest: /etc/systemd/system/pythnet.service
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: daemon-reload
+      ansible.builtin.command: systemctl daemon-reload
+      changed_when: false
+
+    - name: Enable + start pythnet
+      ansible.builtin.systemd:
+        name: pythnet.service
+        enabled: yes
+        state: started
+
+    # Pythnet ledger is small enough that snapshot fetch + catch-up
+    # typically finishes in 10-20 minutes (vs hours on mainnet).  We
+    # don't block init.yml on getHealth=ok here — the validator boots
+    # asynchronously and `slv pythnet status` (or a direct curl) is the
+    # right place to verify readiness.
+    - name: Note next step
+      ansible.builtin.debug:
+        msg: "pythnet.service started.  Tail /mnt/ledger/pythnet/log/validator.log to watch snapshot fetch + catch-up; expect ~10-20 min before getHealth='ok'."

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/start_node.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/start_node.yml
@@ -1,0 +1,10 @@
+---
+- name: Start Pythnet validator
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - ansible.builtin.systemd:
+        name: pythnet.service
+        state: started
+        enabled: yes

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/stop_node.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/stop_node.yml
@@ -1,0 +1,9 @@
+---
+- name: Stop Pythnet validator
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - ansible.builtin.systemd:
+        name: pythnet.service
+        state: stopped

--- a/template/2026.5.5.1612/ansible/mainnet-pythnet/update_pythnet.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-pythnet/update_pythnet.yml
@@ -1,0 +1,15 @@
+---
+# Pull updates from pythnet_ref, rebuild, restart.  Safe to run between
+# upstream releases — the build is idempotent and only restarts when the
+# binary changes.
+- import_playbook: build_pythnet.yml
+- import_playbook: create-start-pythnet-sh.yml
+
+- name: Restart pythnet
+  hosts: all
+  become: true
+  gather_facts: no
+  tasks:
+    - ansible.builtin.systemd:
+        name: pythnet.service
+        state: restarted

--- a/template/2026.5.5.1612/jinja/cmn/files/cf_ipv4.yml
+++ b/template/2026.5.5.1612/jinja/cmn/files/cf_ipv4.yml
@@ -1,0 +1,31 @@
+# Cloudflare IPv4 ranges — sourced from https://www.cloudflare.com/ips-v4
+#
+# Keep this file in sync with Cloudflare's published list.  CF publishes
+# a changelog at https://www.cloudflare.com/ips/ — refresh on advisory.
+#
+# Loaded automatically by cmn/deploy_nftables.yml via include_vars
+# (skipped silently if the file is absent).  Operators reference the
+# resulting `cf_ipv4` variable from their inventory, e.g.
+#
+#   restricted_ports:
+#     - port: 443
+#       tcp: true
+#       allow_ipv4: "{{ cf_ipv4 | default([]) }}"
+#
+# As of 2026-05 the list contains 15 ranges:
+cf_ipv4:
+  - 173.245.48.0/20
+  - 103.21.244.0/22
+  - 103.22.200.0/22
+  - 103.31.4.0/22
+  - 141.101.64.0/18
+  - 108.162.192.0/18
+  - 190.93.240.0/20
+  - 188.114.96.0/20
+  - 197.234.240.0/22
+  - 198.41.128.0/17
+  - 162.158.0.0/15
+  - 104.16.0.0/13
+  - 104.24.0.0/14
+  - 172.64.0.0/13
+  - 131.0.72.0/22

--- a/template/2026.5.5.1612/jinja/cmn/nftables/00-ban-check.nft.j2
+++ b/template/2026.5.5.1612/jinja/cmn/nftables/00-ban-check.nft.j2
@@ -1,0 +1,4 @@
+# Ban list — must be FIRST priority.  A packet from a banned IP is
+# dropped here before any allow rule has a chance to match.  Counter is
+# bumped so `nft list counter c_ban_drop` shows ban effectiveness.
+ip saddr @banAll_v4 counter name c_ban_drop drop;

--- a/template/2026.5.5.1612/jinja/cmn/nftables/00-sets-common.nft.j2
+++ b/template/2026.5.5.1612/jinja/cmn/nftables/00-sets-common.nft.j2
@@ -1,0 +1,27 @@
+{# Set + counter definitions for slv-nftables.
+
+   `set_slug` derives a stable nft identifier (only [0-9_]) from each
+   restricted_port's `port` value — 8899 → "8899", "8000-8020" → "8000_8020".
+   This lets a single inventory describe both single ports and ranges
+   without the operator having to invent set names by hand.
+#}
+{% macro set_slug(port) -%}
+{{ port | string | regex_replace('[^0-9]+', '_') }}
+{%- endmacro %}
+
+# Ban list — highest priority, evaluated before any allow.
+set banAll_v4   { type ipv4_addr; flags interval; }
+
+# Global allow-all (matches every dport).
+set allowAll_v4 { type ipv4_addr; flags interval; }
+
+{% for rp in (restricted_ports | default([])) %}
+set allow_{{ set_slug(rp.port) }}_v4 { type ipv4_addr; flags interval; }
+{% endfor %}
+
+counter c_allowall { }
+counter c_ban_drop { }
+{% for rp in (restricted_ports | default([])) %}
+counter c_{{ set_slug(rp.port) }}_allow { }
+counter c_{{ set_slug(rp.port) }}_drop  { }
+{% endfor %}

--- a/template/2026.5.5.1612/jinja/cmn/nftables/01-mgmt-allow.nft.j2
+++ b/template/2026.5.5.1612/jinja/cmn/nftables/01-mgmt-allow.nft.j2
@@ -1,0 +1,12 @@
+# Management IPs — full access (all ports, all protocols).
+#
+# `mgmt_ips_v4` / `mgmt_ips_v6` come from inventory; the playbook
+# refuses to deploy if `mgmt_ips_v4` is empty (no SSH lockout).
+{% set v4 = (mgmt_ips_v4 | default([])) | map('trim') | reject('equalto','') | list %}
+{% set v6 = (mgmt_ips_v6 | default([])) | map('trim') | reject('equalto','') | list %}
+{% if v4 | length > 0 %}ip saddr { {{ v4 | join(', ') }} } accept;{% endif %}
+{% if v6 | length > 0 %}ip6 saddr { {{ v6 | join(', ') }} } accept;{% endif %}
+
+# allowAll_v4 set — IPs added at runtime via `nft add element ...`
+# also get unconditional access.
+ip saddr @allowAll_v4 counter name c_allowall accept;

--- a/template/2026.5.5.1612/jinja/cmn/nftables/01-ssh-accept.nft.j2
+++ b/template/2026.5.5.1612/jinja/cmn/nftables/01-ssh-accept.nft.j2
@@ -1,0 +1,9 @@
+# SSH safety net.  `01-mgmt-allow.nft` already grants management IPs
+# unconditional access, but explicitly accepting tcp/{{ ssh_port | default(22) }}
+# from mgmt addresses guarantees we never lose admin access even if the
+# allow-all rule is removed by hand.
+{% set v4 = (mgmt_ips_v4 | default([])) | map('trim') | reject('equalto','') | list %}
+{% set v6 = (mgmt_ips_v6 | default([])) | map('trim') | reject('equalto','') | list %}
+{% set p = ssh_port | default(22) %}
+{% if v4 | length > 0 %}ip saddr { {{ v4 | join(', ') }} } tcp dport {{ p }} accept;{% endif %}
+{% if v6 | length > 0 %}ip6 saddr { {{ v6 | join(', ') }} } tcp dport {{ p }} accept;{% endif %}

--- a/template/2026.5.5.1612/jinja/cmn/nftables/02-public-ports.nft.j2
+++ b/template/2026.5.5.1612/jinja/cmn/nftables/02-public-ports.nft.j2
@@ -1,0 +1,10 @@
+# Public-access ports — accept from any source.
+#
+# `public_tcp_ports` / `public_udp_ports` are inventory lists; entries
+# may be a bare integer (8001) or a range string ("8000-8020").
+{% for p in (public_tcp_ports | default([])) %}
+tcp dport {{ p }} accept;
+{% endfor %}
+{% for p in (public_udp_ports | default([])) %}
+udp dport {{ p }} accept;
+{% endfor %}

--- a/template/2026.5.5.1612/jinja/cmn/nftables/03-restricted-ports.nft.j2
+++ b/template/2026.5.5.1612/jinja/cmn/nftables/03-restricted-ports.nft.j2
@@ -1,0 +1,19 @@
+{# Restricted port rules — accept only from listed IPs, drop otherwise.
+   Set/counter names are derived from each port via set_slug (see
+   00-sets-common.nft.j2 for the same derivation). #}
+{% macro set_slug(port) -%}
+{{ port | string | regex_replace('[^0-9]+', '_') }}
+{%- endmacro %}
+
+{% for rp in (restricted_ports | default([])) %}
+{% set slug = set_slug(rp.port) %}
+{% if rp.tcp | default(true) %}
+tcp dport {{ rp.port }} ip saddr @allow_{{ slug }}_v4 counter name c_{{ slug }}_allow accept;
+tcp dport {{ rp.port }} counter name c_{{ slug }}_drop drop;
+{% endif %}
+{% if rp.udp | default(false) %}
+udp dport {{ rp.port }} ip saddr @allow_{{ slug }}_v4 counter name c_{{ slug }}_allow accept;
+udp dport {{ rp.port }} counter name c_{{ slug }}_drop drop;
+{% endif %}
+
+{% endfor %}

--- a/template/2026.5.5.1612/jinja/cmn/nftables/nftables.conf.j2
+++ b/template/2026.5.5.1612/jinja/cmn/nftables/nftables.conf.j2
@@ -11,6 +11,13 @@
 # `tasks/persist_nftables_ruleset.yml` which exports the live ruleset
 # back into this file on every deploy.
 
+# `flush ruleset` is the only safe way to re-apply: without it, `nft -f`
+# merges the new table into the existing one, accumulating duplicate
+# rules on every deploy.  The flush is atomic with the subsequent table
+# definition (nft -f loads the whole file as a single transaction), so
+# there's no observable window where the chain is empty.
+flush ruleset
+
 table inet filter {
   include "/etc/nftables.sets.d/*.nft";
 

--- a/template/2026.5.5.1612/jinja/cmn/nftables/nftables.conf.j2
+++ b/template/2026.5.5.1612/jinja/cmn/nftables/nftables.conf.j2
@@ -1,0 +1,42 @@
+# Managed by slv — nftables base ruleset
+#
+# Fragment layout:
+#   /etc/nftables.sets.d/*.nft   — set + counter definitions (table-scope)
+#   /etc/nftables.d/*.nft        — chain rules (loaded inside `input`)
+#
+# Re-running the playbook clears these directories before re-rendering, so
+# manual edits to fragment files will not survive a re-deploy.  Use the
+# `slv firewall add-ip` / `slv firewall remove-ip` runtime commands (or
+# raw `nft add/delete element`) for ad-hoc IP changes; they persist via
+# `tasks/persist_nftables_ruleset.yml` which exports the live ruleset
+# back into this file on every deploy.
+
+table inet filter {
+  include "/etc/nftables.sets.d/*.nft";
+
+  chain input {
+    type filter hook input priority 0;
+    policy drop;
+
+    iif "lo" accept;
+    ct state established,related accept;
+
+    # ICMP / ICMPv6 — allow ping + path MTU discovery.  Without this,
+    # connections through routers that need to send Fragmentation Needed
+    # silently stall instead of erroring.
+    ip protocol icmp accept;
+    ip6 nexthdr ipv6-icmp accept;
+
+    include "/etc/nftables.d/*.nft";
+  }
+
+  chain forward {
+    type filter hook forward priority 0;
+    policy drop;
+  }
+
+  chain output {
+    type filter hook output priority 0;
+    policy accept;
+  }
+}

--- a/template/2026.5.5.1612/jinja/mainnet-hermes/beacon.service.j2
+++ b/template/2026.5.5.1612/jinja/mainnet-hermes/beacon.service.j2
@@ -1,0 +1,25 @@
+[Unit]
+Description=Pyth Beacon — Wormhole spy relay (VAAs → NATS)
+After=nats-server.service network-online.target
+Requires=nats-server.service
+
+[Service]
+Type=simple
+User=solv
+Group=solv
+WorkingDirectory=/home/solv
+Environment=WORMHOLE_ENV={{ wormhole_env }}
+Environment=WORMHOLE_LISTEN_PORT={{ beacon_listen_port }}
+Environment=NATS_URL=127.0.0.1:{{ nats_port }}
+Environment=NATS_STREAM={{ wormhole_env }}-vaas
+Environment=SERVER_URL={{ beacon_spy_grpc_addr }}
+Environment=LOG_LEVEL=info
+Environment=WRITER_BATCH_SIZE=1000
+Environment=NODE_KEY_PATH=/home/solv/beacon-node.key
+ExecStart=/home/solv/beacon-bin
+Restart=always
+RestartSec=5
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/template/2026.5.5.1612/jinja/mainnet-hermes/hermes.service.j2
+++ b/template/2026.5.5.1612/jinja/mainnet-hermes/hermes.service.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=Pyth Hermes — REST/WS price feed API
+After=beacon.service network-online.target
+Requires=beacon.service
+
+[Service]
+Type=simple
+User=solv
+Group=solv
+WorkingDirectory=/home/solv
+Environment=PYTHNET_HTTP_ADDR={{ pythnet_http_addr }}
+Environment=PYTHNET_WS_ADDR={{ pythnet_ws_addr }}
+Environment=WORMHOLE_SPY_RPC_ADDR=http://{{ beacon_spy_grpc_addr }}
+Environment=RPC_LISTEN_ADDR={{ rpc_listen_addr }}
+Environment=METRICS_SERVER_LISTEN_ADDR={{ metrics_listen_addr }}
+Environment=RUST_LOG=info
+ExecStart=/home/solv/src/pyth-crosschain/apps/hermes/server/target/release/hermes run
+Restart=always
+RestartSec=5
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/template/2026.5.5.1612/jinja/mainnet-hermes/nats-server.service.j2
+++ b/template/2026.5.5.1612/jinja/mainnet-hermes/nats-server.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=NATS server (JetStream) — VAA dedup/stream for Pyth Beacon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=solv
+Group=solv
+ExecStart=/usr/local/bin/nats-server --jetstream --store_dir=/home/solv/nats-data --port={{ nats_port }}
+Restart=always
+RestartSec=5
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/template/2026.5.5.1612/jinja/mainnet-pythnet/pythnet.service.j2
+++ b/template/2026.5.5.1612/jinja/mainnet-pythnet/pythnet.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=Pythnet RPC validator (no-voting)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=solv
+Group=solv
+WorkingDirectory=/home/solv
+ExecStart=/home/solv/start-pythnet.sh
+Restart=always
+RestartSec=5
+LimitNOFILE=1048576
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/template/2026.5.5.1612/jinja/mainnet-pythnet/start-pythnet.sh.j2
+++ b/template/2026.5.5.1612/jinja/mainnet-pythnet/start-pythnet.sh.j2
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Pythnet RPC validator — no-voting, full RPC API.
+#
+# Genesis hash and expected_shred_version are fixed network parameters
+# discoverable via the public Pythnet RPC:
+#   curl -s https://pythnet.rpcpool.com -X POST -H 'content-type: application/json' \
+#        -d '{"jsonrpc":"2.0","id":1,"method":"getGenesisHash"}'
+#
+# The --account-index program-id flag is *mandatory* on Pythnet — the
+# validator panics on startup if it's missing.
+set -euo pipefail
+exec /usr/local/bin/solana-validator \
+  --identity /home/solv/pythnet-identity.json \
+  --no-voting \
+  --entrypoint {{ pythnet_entrypoint | default('pythnet.rpcpool.com:8001') }} \
+{% for kv in (pythnet_known_validators | default(['DzZov8p2kwXJeYx2hnVyaxNFugYVF4up9AWwRvtYWU4u', '6Rr1vUgRZmqDuzzU6Sf3QAfUTYV3aa4wqxKrL6uBGXdU'])) %}
+  --known-validator {{ kv }} \
+{% endfor %}
+  --expected-genesis-hash {{ pythnet_genesis_hash | default('GLKkBUr6r72nBtGrtBPJLRqtsh8wXZanX4xfnqKnWwKq') }} \
+  --expected-shred-version {{ pythnet_shred_version | default(35891) }} \
+  --rpc-port {{ pythnet_rpc_port | default(8899) }} \
+  --rpc-bind-address {{ pythnet_rpc_bind | default('0.0.0.0') }} \
+  --full-rpc-api \
+  --enable-rpc-transaction-history \
+  --dynamic-port-range {{ pythnet_dynamic_port_range | default('8000-8020') }} \
+  --gossip-port {{ pythnet_gossip_port | default(8001) }} \
+  --account-index program-id \
+  --ledger {{ pythnet_ledger_mount | default('/mnt/ledger') }}/pythnet/ledger \
+  --accounts {{ pythnet_ledger_mount | default('/mnt/ledger') }}/pythnet/accounts \
+  --snapshots {{ pythnet_ledger_mount | default('/mnt/ledger') }}/pythnet/snapshots \
+  --log {{ pythnet_ledger_mount | default('/mnt/ledger') }}/pythnet/log/validator.log \
+  --limit-ledger-size {{ pythnet_limit_ledger_size | default(50000000) }} \
+  --wal-recovery-mode skip_any_corrupted_record


### PR DESCRIPTION
## Summary

Adds two new SLV deployment surfaces that together provide a **fully self-hosted Pyth price feed pipeline**:

- **`slv hermes`** (alias `slv h`) — deploys a Hermes price API stack (`nats-server` + `pyth-network/beacon` + `pyth-network/pyth-crosschain` apps/hermes/server) on a single VPS. Serves the standard Hermes REST/WS API (`/v2/updates/price/latest`, `/v2/price_feeds`, `/ws`) so existing Pyth SDK clients work unchanged.
- **`slv pythnet`** — deploys a Pythnet RPC node (Pyth's application-specific Solana 1.14 fork). Lets you point Hermes at a self-hosted Pythnet HTTP/WS endpoint instead of `pythnet.rpcpool.com`, removing the last external dependency in the pipeline.

Two-component layout:

```
BM (Pythnet RPC)              VPS (Hermes stack)
┌──────────────────┐          ┌──────────────────────────┐
│ solana-validator │ :8899/   │  nats-server  :4222      │
│ (no-voting RPC)  │ :8900    │  beacon       :7072 (lo) │
│ 1.14.180         │ ◄────────┤  hermes       :7575      │◄── clients (REST/WS)
└──────────────────┘          └──────────────────────────┘
                                       ▲
                                       │ Wormhole P2P (UDP/QUIC :8999)
                                       │
                              Wormhole guardian network
```

## Verified end-to-end

Validated against a VPS (4 vCPU / 8 GB) + baremetal (32T Ryzen 9 9950X / 186 GB / 1.7 TB NVMe) pair:

- **Hermes** serves SOL/USD with `publish_time` age ≤ 1 s, 3027 feeds available, full VAA pipeline running (6055 Pyth message states per Wormhole VAA).
- **Pythnet RPC** boots from snapshot fetch + catch-up in **~15 min** (vs hours for Solana mainnet), validator self-publishes 8010 prices per slot via Pyth accumulator.

## What's in this PR

### Ansible
- `template/2026.5.5.1612/ansible/cmn/install_hermes_stack.yml` — one-shot stack installer (apt deps, Rust 1.82, Go 1.22, `nats-server` release pin, Beacon Go build, Hermes Rust build, three systemd units, `/v2/price_feeds` smoke test).
- `template/2026.5.5.1612/ansible/mainnet-hermes/{init,start_node,stop_node,restart_node,update_hermes}.yml`.
- `template/2026.5.5.1612/jinja/mainnet-hermes/{nats-server,beacon,hermes}.service.j2`.
- `template/2026.5.5.1612/ansible/mainnet-pythnet/*` — orchestrator + supporting (install_package, install_rust, mount_disks, optimize_pythnet, build_pythnet, gen_identity, create-start-pythnet-sh, setup-pythnet-service, update_pythnet, lifecycle).
- `template/2026.5.5.1612/jinja/mainnet-pythnet/{start-pythnet.sh,pythnet.service}.j2`.

### OSS skills
- `oss-skills/slv-hermes/SKILL.md` + `examples/inventory.yml`.
- `oss-skills/slv-pythnet/SKILL.md` + `examples/inventory.yml`.

### CLI
- `cli/src/hermes/` and `cli/src/pythnet/` — mirror `slv r` structure with `deploy/start/stop/restart/update`.
- `cmn/types/config.ts`: `InventoryType` extended with `mainnet_hermes` / `mainnet_pythnet`.
- `cli/src/rpc/init.ts`: `copyTemplateDirs` extended to copy the new jinja dirs into `~/.slv/`.
- `cli/src/rpc/{index,listRPCs}.ts`: narrowing at two callsites (`VersionSection`, `Extract<InventoryType, keyof CmnType>`) since allowed_ips and versions.yml remain rpc/validator-only.

## Notable workarounds baked in

1. **`CXXFLAGS=\"-include cstdint\"`** for `build_pythnet.yml`. The bundled RocksDB (v7.4.4 in pyth-v1.14.17) fails to compile under modern GCC because it relies on legacy implicit-include behavior for `<cstdint>`. Scoped to CXX-only — blake3's build.rs uses `cc` to assemble `.S` files and a C-level `-include` would corrupt assembly source.
2. **sysctl pinning of `net.core.{r,w}mem_{default,max}=128 MiB`**. The Pythnet validator's startup self-check fails fast if any of the four values is below 128 MiB.

## VPS / BM sizing

| Role | Recommended | Minimum |
|---|---|---|
| Hermes (VPS) | 4 vCPU / 8 GB / 80 GB | 2 vCPU / 4 GB / 40 GB |
| Pythnet RPC (BM) | 16-32 core / 128 GB / 2 TB NVMe / 1 Gbps | (same; Pythnet is ~1/4-1/8 of Solana mainnet) |

## Test plan

- [x] `ansible-playbook --syntax-check` clean on all 19 new playbooks
- [x] `deno check` clean on all 4 new TypeScript files
- [x] End-to-end deployment validated on a fresh VPS + baremetal pair
- [x] Hermes API responds with SOL/BTC/ETH prices, age ≤ 1 s
- [x] Pythnet `getHealth` = `"ok"`, `getGenesisHash` matches public Pythnet
- [x] Hermes switched from public Pythnet to self-hosted BM, price feed continuity verified
- [x] OSS audit: no production IPs / hostnames / identity keys in committed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)