### PR TITLE
fix(richat): pubsub workers + per-tick drain (slotSubscribe lag)

### DIFF
--- a/template/2026.5.5.1612/jinja/mainnet-rpc/richat-setting.yml.j2
+++ b/template/2026.5.5.1612/jinja/mainnet-rpc/richat-setting.yml.j2
@@ -110,9 +110,19 @@ apps:
     enable_block_subscription: true
     enable_transaction_subscription: true
     clients_requests_channel_size: 8_192
-    subscriptions_workers_count: 2
+    # richat's pubsub uses a single tracker loop that drains messages
+    # per-commitment up to `max_messages_per_commitment_per_tick`, then
+    # fans them out to clients via a rayon pool sized to
+    # `subscriptions_workers_count`.  The upstream defaults (2 workers,
+    # 256 msg/tick) were measured to cause slotSubscribe lag of 5-10
+    # slots when block + transaction subscriptions are also enabled —
+    # tx notifications saturate the per-tick budget and slot
+    # notifications queue up behind them.  These tuned values keep the
+    # slot stream within 0-1 slot of Helius / api.mainnet-beta on a
+    # 64-core mainnet RPC host.
+    subscriptions_workers_count: 8
     subscriptions_max_clients_request_per_tick: 32
-    subscriptions_max_messages_per_commitment_per_tick: 256
+    subscriptions_max_messages_per_commitment_per_tick: 4096
     notifications_messages_max_count: 16_777_216
     notifications_messages_max_bytes: 32GiB
     signatures_cache_max: 1_228_800


### PR DESCRIPTION
## Problem

External client report (May 12 2026, slv-rpc user): \`slotSubscribe\` over WebSocket falls behind by 7+ slots compared to Helius / \`api.mainnet-beta\` / \`solana-rpc.publicnode.com\`, briefly catches back up to 0-1 behind, then drifts again — continuously, from multiple geographies and test tools. gRPC streaming was stable.

\`\`\`
2026-05-12 15:45:17.678
ours:        419284177
helius:      419284184
publicnode:  419284184
api.mainnet: 419284184
\`\`\`

## Root cause

richat's pubsub (`richat/src/pubsub/tracker.rs`) drains messages per commitment level up to `max_messages_per_commitment_per_tick`, then fans out via a rayon pool sized to `subscriptions_workers_count`. **Slot / Account / Transaction / Block notifications all share the same per-tick budget per commitment.**

With `enable_transaction_subscription: true`, a single busy mainnet slot can enqueue hundreds of finalized-tx notifications — saturating the 256-msg budget and head-of-line-blocking Slot notifications behind them. The 2-worker fan-out compounds the problem under concurrent subscriber load.

## Fix

```diff
-    subscriptions_workers_count: 2
+    subscriptions_workers_count: 8
-    subscriptions_max_messages_per_commitment_per_tick: 256
+    subscriptions_max_messages_per_commitment_per_tick: 4096
```

- `workers_count: 2 → 8`: rayon pool size for client fan-out. Safe on the slv mainnet-rpc spec (32-64 vCPU); shrink to 4 on lower-core hosts.
- `max_messages_per_commitment_per_tick: 256 → 4096`: per-tick drain ceiling, so Slot messages aren't head-of-line-blocked by Tx/Account/Block on busy slots.

`enable_block_subscription` and `enable_transaction_subscription` remain `true` so existing clients aren't broken.

## Verification

Applied on a 64-core mainnet-rpc host with the agave validator + a concurrent \`blockSubscribe\` stressor. 2-minute \`slotSubscribe\` walk-through against the same endpoint plus Helius and \`api.mainnet-beta\`:

\`\`\`
time_s | ours_slot   | helius_slot | mainnet_slot | ours_lag
   5.0 |   419326892 |   419326892 |    419326892 |        0
  10.0 |   419326904 |   419326904 |    419326904 |        0
  15.0 |   419326917 |   419326918 |    419326917 |        1
  ...
 115.0 |   419327167 |   419327167 |    419327167 |        0

lag stats: min=0 max=1 avg=0.09  (300 slot notifications)
\`\`\`

## Rollout

Apply to a running richat host:

\`\`\`bash
sudo sed -i 's/^\(\s*subscriptions_workers_count: \).*/\18/' /home/solv/richat-config.yml
sudo sed -i 's/^\(\s*subscriptions_max_messages_per_commitment_per_tick: \).*/\14096/' /home/solv/richat-config.yml
sudo systemctl restart richat
\`\`\`

Or use \`slv r deploy\` (after pulling this fix) to re-render the template and trigger the existing change-detection restart handler.

## Test plan

- [x] \`ansible-playbook --syntax-check\` template still parses
- [x] richat starts cleanly with new config (NRestarts=0)
- [x] All three ports (\`:7111\`, \`:10000\`, \`:10100\`) come back up
- [x] 2-minute slotSubscribe walk-through stays within 1 slot of Helius / api.mainnet-beta
- [x] No regressions on gRPC streaming (gRPC was already stable; pubsub-only knobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)