### PR TITLE
feat(rpc-gateway): add windowStart to gtfa + transfers responses

### DIFF
--- a/api/rpc-gateway/src/handlers/gtfa.ts
+++ b/api/rpc-gateway/src/handlers/gtfa.ts
@@ -173,11 +173,46 @@ export class GtfaHandlers {
   private of1Url: string
   private of1TimeoutMs: number
   private fullConcurrency: number
+  // Cached `min(slot)` from gtfa_tx_mentions.  ~30-epoch retention TTL
+  // means this slowly advances forward as old partitions drop; refresh
+  // every 60 s is way faster than a partition turnover.
+  private windowStartCache: { value: number | null; expiresAt: number } | null = null
 
   constructor(private ch: ClickHouseClient, cfg: GtfaConfig) {
     this.of1Url = cfg.of1Url
     this.of1TimeoutMs = cfg.of1TimeoutMs ?? 60_000
     this.fullConcurrency = Math.max(1, cfg.fullConcurrency ?? 20)
+  }
+
+  /**
+   * Oldest slot currently retained in `gtfa_tx_mentions`.  Returned as
+   * `windowStart` in every response so clients know the retention floor
+   * — anything older than this slot is permanently gone from this
+   * gateway's window (currently ~30 epochs, set by the plugin's TTL).
+   * `null` is returned when the table is empty or CH is unreachable;
+   * in that case clients should treat the window as unknown.
+   */
+  private async getWindowStart(): Promise<number | null> {
+    const now = Date.now()
+    if (this.windowStartCache && this.windowStartCache.expiresAt > now) {
+      return this.windowStartCache.value
+    }
+    let value: number | null = null
+    try {
+      const rows = await this.ch.query<{ min_slot: string | null }>(
+        `SELECT toString(min(slot)) AS min_slot FROM gtfa_tx_mentions`,
+      )
+      const raw = rows[0]?.min_slot
+      if (raw && raw !== '\\N') {
+        const n = parseInt(raw, 10)
+        if (Number.isFinite(n) && n > 0) value = n
+      }
+    } catch {
+      // CH unreachable — leave value as null; cached briefly so we
+      // don't hammer CH on every request.
+    }
+    this.windowStartCache = { value, expiresAt: now + 60_000 }
+    return value
   }
 
   /**
@@ -246,7 +281,8 @@ export class GtfaHandlers {
         ? Math.min(DEFAULT_LIMIT, maxLimit)
         : Math.min(asInt(options.limit, 'limit'), maxLimit)
       if (limit === 0) {
-        return ok(req.id ?? null, { data: [], paginationToken: null })
+        const windowStart = await this.getWindowStart()
+        return ok(req.id ?? null, { data: [], paginationToken: null, windowStart })
       }
 
       const where: string[] = [
@@ -352,7 +388,8 @@ export class GtfaHandlers {
         // Helius wire-compat: rename root → `data`, derive `err` from
         // status (placeholder for failed; full-mode sets it from of1).
         const data = rows.map((r) => sigRowToHeliusEntry(r))
-        return ok(req.id ?? null, { data, paginationToken })
+        const windowStart = await this.getWindowStart()
+        return ok(req.id ?? null, { data, paginationToken, windowStart })
       }
 
       // Full mode: fan out to of1 with a concurrency cap.  We keep CH-sourced
@@ -386,7 +423,8 @@ export class GtfaHandlers {
       )
 
       const data = fullRows.map((r) => fullRowToHeliusEntry(r))
-      return ok(req.id ?? null, { data, paginationToken })
+      const windowStart = await this.getWindowStart()
+      return ok(req.id ?? null, { data, paginationToken, windowStart })
     } catch (e) {
       return err(req.id ?? null, ERROR_CODES.INVALID_PARAMS, (e as Error).message)
     }

--- a/api/rpc-gateway/src/handlers/transfers.ts
+++ b/api/rpc-gateway/src/handlers/transfers.ts
@@ -213,7 +213,39 @@ type RawRow = {
 const ZERO_PUBKEY_B58 = '11111111111111111111111111111111' // 32-zero-bytes base58 encoding
 
 export class TransfersHandlers {
+  // Cached `min(slot)` from token_transfers.  Refresh every 60 s; the
+  // table's TTL drops whole partitions roughly daily so the value
+  // advances slowly relative to the cache window.
+  private windowStartCache: { value: number | null; expiresAt: number } | null = null
+
   constructor(private ch: ClickHouseClient) {}
+
+  /**
+   * Oldest slot currently retained in `token_transfers`.  Returned as
+   * `windowStart` in every response so clients know the retention floor.
+   * `null` when CH is unreachable or the table is empty.
+   */
+  private async getWindowStart(): Promise<number | null> {
+    const now = Date.now()
+    if (this.windowStartCache && this.windowStartCache.expiresAt > now) {
+      return this.windowStartCache.value
+    }
+    let value: number | null = null
+    try {
+      const rows = await this.ch.query<{ min_slot: string | null }>(
+        `SELECT toString(min(slot)) AS min_slot FROM token_transfers`,
+      )
+      const raw = rows[0]?.min_slot
+      if (raw && raw !== '\\N') {
+        const n = parseInt(raw, 10)
+        if (Number.isFinite(n) && n > 0) value = n
+      }
+    } catch {
+      // CH unreachable — leave value as null; cached briefly.
+    }
+    this.windowStartCache = { value, expiresAt: now + 60_000 }
+    return value
+  }
 
   /**
    * Helius-wire-compatible.  Phase 2 of the slv-transfers-plugin work.
@@ -245,7 +277,8 @@ export class TransfersHandlers {
         ? DEFAULT_LIMIT
         : Math.min(asInt(options.limit, 'limit'), MAX_LIMIT)
       if (limit === 0) {
-        return ok(req.id ?? null, { data: [], paginationToken: null })
+        const windowStart = await this.getWindowStart()
+        return ok(req.id ?? null, { data: [], paginationToken: null, windowStart })
       }
 
       const solMode = options.solMode === undefined
@@ -386,8 +419,8 @@ export class TransfersHandlers {
       }
 
       const data = rows.map((r) => rawRowToHeliusEntry(r, solMode))
-
-      return ok(req.id ?? null, { data, paginationToken })
+      const windowStart = await this.getWindowStart()
+      return ok(req.id ?? null, { data, paginationToken, windowStart })
     } catch (e) {
       return err(req.id ?? null, ERROR_CODES.INVALID_PARAMS, (e as Error).message)
     }


### PR DESCRIPTION
## Summary
Companion to [vs2-app PR #4144](https://github.com/elsoul/vs2-app/pull/4144) (30-epoch TTL on `gtfa_tx_mentions` and `token_transfers`). With a rolling retention window in place, clients need to detect the floor of available data so they can show "history before slot N is unavailable" UX instead of treating an empty response as "address has no activity".

## API change
Both `getTransactionsForAddress` and `getTransfersByAddress` responses now include a top-level `windowStart` field:

```jsonc
{
  "result": {
    "data": [ ... ],
    "paginationToken": "...",
    "windowStart": <oldest slot in our table> | null
  }
}
```

`null` = table empty or ClickHouse unreachable (clients should treat as "window unknown").

## Implementation
- Computed via `SELECT min(slot) FROM <table>` and cached per-handler-instance for 60 s.
- Refresh cadence (60 s) is much faster than partition-drop cadence (~daily) so cached values stay accurate.
- Per-table caches (one in `GtfaHandlers`, one in `TransfersHandlers`) tolerate out-of-band drops on either table without staleness.

## Test plan
- [x] `deno check src/main.ts` clean
- [x] `deno fmt --check` clean
- [ ] After post-PR-#4144 migration: `getTransactionsForAddress` response shows `windowStart: <slot ≈ head - 30 epochs>` (post-deploy, post-rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)