### PR TITLE
fix(rpc-gateway): wire getTransfersByAddress dispatch (lost in #367 rename)

### DIFF
--- a/api/rpc-gateway/src/main.ts
+++ b/api/rpc-gateway/src/main.ts
@@ -31,6 +31,7 @@ import { Hono } from '@hono/hono'
 import { ClickHouseClient } from './lib/clickhouse.ts'
 import { JetHandlers } from './handlers/jet.ts'
 import { GtfaHandlers } from './handlers/gtfa.ts'
+import { TransfersHandlers } from './handlers/transfers.ts'
 import { StandardProxy } from './handlers/proxy.ts'
 import { buildWsHandler } from './handlers/ws.ts'
 import {
@@ -67,6 +68,7 @@ const gtfa = new GtfaHandlers(ch, {
   of1TimeoutMs: OF1_TIMEOUT_MS,
   fullConcurrency: GTFA_FULL_CONCURRENCY,
 })
+const transfers = new TransfersHandlers(ch)
 const proxy = new StandardProxy({ upstream: OF1_URL, timeoutMs: OF1_TIMEOUT_MS })
 
 const log = (msg: string, extra?: Record<string, unknown>) => {
@@ -98,6 +100,10 @@ async function dispatch(req: JsonRpcRequest): Promise<JsonRpcResponse> {
     // gtfa_tx_mentions table (NOT proxied to of1).
     case 'getTransactionsForAddress':
       return gtfa.getTransactionsForAddress(req)
+    // Helius-wire-compatible token-transfer index, backed by jetstreamer's
+    // token_transfers + token_transfers_by_to (slv-transfers-plugin).
+    case 'getTransfersByAddress':
+      return transfers.getTransfersByAddress(req)
   }
   if (JET_NAMESPACE_RE.test(req.method)) {
     return err(


### PR DESCRIPTION
## Summary

- PR #366 added `TransfersHandlers` + `case 'getTransfersByAddress'` in `dispatch()`. PR #367 (jet_* → jetX* rename) was authored against an older base; merging it silently dropped the import, the `transfers` instantiation, and the switch case.
- Since #367, every `getTransfersByAddress` request has fallen through `dispatch()` to `proxy.handle()` and been forwarded to of1 (which falls back to Helius). Callers got Helius-shaped responses without our `windowStart` extension and our `token_transfers` table was being populated for nothing.
- This restores the three lines that were dropped — no other behaviour change.

## Test plan

- [x] `deno check api/rpc-gateway/src/main.ts` clean
- [ ] After deploy: `getTransfersByAddress` response includes `windowStart` field
- [ ] Verify `windowStart` numeric value matches `SELECT min(slot) FROM token_transfers` on the host
- [ ] Verify `paginationToken` last segment is the integer `transfer_type`, not `systemTransfer` (Helius shape) — confirms our handler is in path

🤖 Generated with [Claude Code](https://claude.com/claude-code)