### PR TITLE
feat(rpc-gateway): optional dedicated slotSubscribe source (shred-bridge)

### DIFF
--- a/api/rpc-gateway/src/handlers/ws.ts
+++ b/api/rpc-gateway/src/handlers/ws.ts
@@ -28,10 +28,17 @@ import {
   YellowstoneBridge,
 } from '../lib/yellowstone-bridge.ts'
 import { PubsubForward } from '../lib/pubsub-forward.ts'
+import { SlotBridge } from '../lib/slot-bridge.ts'
 
 export type WsConfig = {
   yellowstoneEndpoint: string // host:port — passed straight to gRPC client
   pubsubUrl: string // ws://… upstream Solana pubsub
+  // Optional dedicated source for slotSubscribe.  When set, slotSubscribe
+  // notifications come from this Yellowstone-gRPC endpoint (typically a
+  // shred-bridge that fires first-shred-of-next-slot ~5–8 ms earlier than
+  // validator-replay-complete).  When unset, slotSubscribe falls through
+  // to the standard pubsub forward like every other pubsub method.
+  slotBridgeEndpoint?: string
 }
 
 const HELIUS_ID_BASE = 1_000_000_000
@@ -45,8 +52,8 @@ const STANDARD_PUBSUB_METHODS = new Set([
   'programUnsubscribe',
   'signatureSubscribe',
   'signatureUnsubscribe',
-  'slotSubscribe',
-  'slotUnsubscribe',
+  // slotSubscribe / slotUnsubscribe are intercepted below when a
+  // slotBridge endpoint is configured; otherwise they fall through here.
   'slotsUpdatesSubscribe',
   'slotsUpdatesUnsubscribe',
   'blockSubscribe',
@@ -59,6 +66,13 @@ const STANDARD_PUBSUB_METHODS = new Set([
 
 export function buildWsHandler(cfg: WsConfig) {
   const bridge = new YellowstoneBridge(cfg.yellowstoneEndpoint)
+  // Process-wide single subscription, fanned out to all WS clients that
+  // call slotSubscribe.  Null when no override endpoint is configured —
+  // in that case slotSubscribe falls through to STANDARD_PUBSUB_METHODS
+  // and is forwarded to richat WS untouched.
+  const slotBridge = cfg.slotBridgeEndpoint
+    ? new SlotBridge(cfg.slotBridgeEndpoint)
+    : null
 
   return upgradeWebSocket(() => {
     // Per-connection state.
@@ -187,6 +201,46 @@ export function buildWsHandler(cfg: WsConfig) {
           }
           case 'transactionUnsubscribe': {
             send(handleHeliusTransactionUnsubscribe(req))
+            return
+          }
+          case 'slotSubscribe': {
+            if (slotBridge) {
+              const subId = ++localSubCounter
+              const handle = slotBridge.subscribe((u) => {
+                send({
+                  jsonrpc: '2.0',
+                  method: 'slotNotification',
+                  params: { result: u, subscription: subId },
+                })
+              })
+              localSubs.set(subId, handle)
+              send(ok(req.id ?? null, subId))
+              return
+            }
+            // Fall through to pubsub forward.
+            ensurePubsub().send(text)
+            return
+          }
+          case 'slotUnsubscribe': {
+            if (slotBridge) {
+              const params = (req.params as unknown[]) ?? []
+              const subId = Number(params[0])
+              const handle = Number.isFinite(subId) ? localSubs.get(subId) : undefined
+              if (handle) {
+                handle.cancel()
+                localSubs.delete(subId)
+                send(ok(req.id ?? null, true))
+                return
+              }
+              // Unknown id — could be an upstream pubsub id, forward through.
+              if (subId < HELIUS_ID_BASE) {
+                ensurePubsub().send(text)
+                return
+              }
+              send(ok(req.id ?? null, false))
+              return
+            }
+            ensurePubsub().send(text)
             return
           }
           default: {

--- a/api/rpc-gateway/src/lib/slot-bridge.ts
+++ b/api/rpc-gateway/src/lib/slot-bridge.ts
@@ -1,0 +1,182 @@
+// Slot-only Yellowstone-gRPC subscriber, shared across all WebSocket clients.
+//
+// Opens ONE persistent `Subscribe { slots: { all: {} }, commitment:
+// processed }` stream against `endpoint` and fans the resulting
+// `SubscribeUpdate.slot` events out to N registered listeners.  One
+// subscriber per process keeps the upstream load constant regardless of
+// how many web3.js clients call `slotSubscribe`.
+//
+// Why it exists: routing `slotSubscribe` to the validator-backed pubsub
+// (richat WS → validator geyser → block-replay-complete) costs ~5–8 ms
+// vs Helius, which fires slot notifications from shred receipt
+// (pre-execution).  Pointing this bridge at the yellowstone_shred_bridge
+// (1.5.0+ on 198.13.137.159:10005) gives the same first-shred-of-next-slot
+// semantic and closes that gap.
+//
+// `root` field: the shred bridge cannot derive `root` from shreds alone
+// (root requires vote/finality info).  For now we emit a deterministic
+// approximation (`max(0, slot - 32)`) so web3.js callbacks receive a
+// numeric value.  Clients that actually consume `root` need
+// `commitmentSubscribe` / `rootSubscribe` instead.
+
+import grpcModule from 'npm:@triton-one/yellowstone-grpc@1.3.0'
+
+// deno-lint-ignore no-explicit-any
+const Client = (grpcModule as any).default as new (
+  endpoint: string,
+  xToken?: string,
+  channelOptions?: Record<string, unknown>,
+) => {
+  subscribe(): Promise<{
+    write(req: unknown, cb: (err: Error | null | undefined) => void): void
+    on(event: 'data', cb: (u: SubscribeUpdate) => void): void
+    on(event: 'error', cb: (e: unknown) => void): void
+    cancel(): void
+    end(): void
+  }>
+}
+// deno-lint-ignore no-explicit-any
+const CommitmentLevel = (grpcModule as any).CommitmentLevel as {
+  PROCESSED: number
+  CONFIRMED: number
+  FINALIZED: number
+}
+
+type SubscribeUpdate = {
+  slot?: {
+    slot: number | string | bigint
+    parent?: number | string | bigint | null
+    status?: number
+  }
+}
+
+export type SlotUpdate = {
+  slot: number
+  parent: number | null
+  root: number
+}
+
+type Listener = (u: SlotUpdate) => void
+
+export class SlotBridge {
+  private endpoint: string
+  private listeners = new Set<Listener>()
+  // deno-lint-ignore no-explicit-any
+  private stream: any = null
+  private starting = false
+  private reconnectTimer: number | null = null
+
+  constructor(endpoint: string) {
+    if (/^https?:\/\//.test(endpoint)) {
+      this.endpoint = endpoint
+    } else {
+      this.endpoint = `http://${endpoint.replace(/^grpc:\/\//, '')}`
+    }
+  }
+
+  /** Register a listener; returns a cancel handle. */
+  subscribe(listener: Listener): { cancel: () => void } {
+    this.listeners.add(listener)
+    if (!this.stream && !this.starting) {
+      this.start().catch((e) => {
+        console.error(JSON.stringify({
+          ts: new Date().toISOString(),
+          msg: 'slot_bridge_start_error',
+          error: String(e),
+        }))
+      })
+    }
+    return {
+      cancel: () => {
+        this.listeners.delete(listener)
+        // Stream stays open — likely more subscribers coming and the
+        // process-wide single stream costs ~one tcp socket.
+      },
+    }
+  }
+
+  private async start() {
+    this.starting = true
+    try {
+      const client = new Client(this.endpoint, undefined, {
+        'grpc.max_receive_message_length': 64 * 1024 * 1024,
+      })
+      const stream = await client.subscribe()
+      this.stream = stream
+      const req = {
+        slots: { all: {} },
+        accounts: {},
+        transactions: {},
+        transactionsStatus: {},
+        blocks: {},
+        blocksMeta: {},
+        entry: {},
+        commitment: CommitmentLevel.PROCESSED,
+        accountsDataSlice: [],
+      }
+      await new Promise<void>((resolve, reject) => {
+        stream.write(req, (err: Error | null | undefined) => {
+          if (err) reject(err)
+          else resolve()
+        })
+      })
+      console.log(JSON.stringify({
+        ts: new Date().toISOString(),
+        msg: 'slot_bridge_connected',
+        endpoint: this.endpoint,
+        listeners: this.listeners.size,
+      }))
+      stream.on('data', (u: SubscribeUpdate) => {
+        if (!u.slot) return
+        const slot = Number(u.slot.slot)
+        if (!Number.isFinite(slot) || slot <= 0) return
+        const parent = u.slot.parent != null ? Number(u.slot.parent) : null
+        const root = Math.max(0, slot - 32)
+        const evt: SlotUpdate = { slot, parent, root }
+        for (const l of this.listeners) {
+          try {
+            l(evt)
+          } catch {
+            // Swallow per-listener errors to keep the bridge running.
+          }
+        }
+      })
+      stream.on('error', (e: unknown) => {
+        console.error(JSON.stringify({
+          ts: new Date().toISOString(),
+          msg: 'slot_bridge_stream_error',
+          error: String(e),
+        }))
+        this.stream = null
+        this.scheduleReconnect()
+      })
+    } catch (e) {
+      console.error(JSON.stringify({
+        ts: new Date().toISOString(),
+        msg: 'slot_bridge_connect_failed',
+        error: String(e),
+      }))
+      this.stream = null
+      this.scheduleReconnect()
+    } finally {
+      this.starting = false
+    }
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer != null) return
+    if (this.listeners.size === 0) return
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      if (this.listeners.size > 0 && !this.stream) {
+        this.start().catch((e) =>
+          console.error(JSON.stringify({
+            ts: new Date().toISOString(),
+            msg: 'slot_bridge_reconnect_error',
+            error: String(e),
+          }))
+        )
+      }
+    }, 1000) as unknown as number
+  }
+}

--- a/api/rpc-gateway/src/main.ts
+++ b/api/rpc-gateway/src/main.ts
@@ -53,6 +53,10 @@ const CLICKHOUSE_TIMEOUT_MS = parseInt(Deno.env.get('CLICKHOUSE_TIMEOUT_MS') ?? 
 const OF1_TIMEOUT_MS = parseInt(Deno.env.get('OF1_TIMEOUT_MS') ?? '60000', 10)
 const YELLOWSTONE_GRPC = Deno.env.get('YELLOWSTONE_GRPC') ?? 'localhost:10000'
 const PUBSUB_WS_URL = Deno.env.get('PUBSUB_WS_URL') ?? 'ws://localhost:7111'
+// Optional override: when set, slotSubscribe notifications come from
+// this dedicated Yellowstone-gRPC endpoint (typically a shred-bridge)
+// instead of falling through to richat WS / validator geyser.
+const SLOT_BRIDGE_GRPC = Deno.env.get('SLOT_BRIDGE_GRPC') || undefined
 const GTFA_FULL_CONCURRENCY = parseInt(Deno.env.get('GTFA_FULL_CONCURRENCY') ?? '20', 10)
 
 const ch = new ClickHouseClient({
@@ -132,6 +136,7 @@ app.use('*', async (c, next) => {
 const wsHandler = buildWsHandler({
   yellowstoneEndpoint: YELLOWSTONE_GRPC,
   pubsubUrl: PUBSUB_WS_URL,
+  slotBridgeEndpoint: SLOT_BRIDGE_GRPC,
 })
 app.get('/ws', wsHandler)
 // Alias for clients that hard-code `wss://<host>/?api-key=…` — historical


### PR DESCRIPTION
## Summary

- New `SlotBridge` singleton: opens **one** Yellowstone-gRPC subscribe stream and fans slot events out to every WS client that calls `slotSubscribe`.
- When `SLOT_BRIDGE_GRPC` env is set, `slotSubscribe` / `slotUnsubscribe` are intercepted in the WS handler and answered from this bridge. When unset, behaviour is unchanged (still forwarded to richat WS).
- Motivation: 60s slot race from a FRA host shows Helius beta consistently 5–8 ms ahead on slot notifications (96.7%). The gap matches shred-receipt vs validator-replay-complete latency. Pointing this bridge at `yellowstone_shred_bridge` (which emits SlotProcessed on first-shred-of-next-slot) should close it.

## Rollout plan

1. Merge.
2. Enable on **FRA-1 only** by setting `SLOT_BRIDGE_GRPC=198.13.137.159:10005` in the gateway service drop-in on `185.191.116.182`.
3. Re-run the slot race against Helius beta from the FRA host. Expected: lead drops from +6.4 ms to near-zero (or ERPC ahead).
4. If POC succeeds, decide whether to deploy a shred-bridge per region or share FRA's (= cross-region hop, not free).

The other 5 regions are unaffected — `SLOT_BRIDGE_GRPC` is opt-in.

## Test plan

- [x] `deno check` clean
- [ ] After enabling on FRA-1: run `slot_race_deno.ts` from FRA host for 60s, log avg lead vs Helius
- [ ] Verify reconnect: kill the gRPC stream and confirm new subscribers re-establish within 1s
- [ ] Verify non-FRA regions still serve `slotSubscribe` from richat (no env set)

## Caveats

- The `root` field in emitted notifications is approximated as `max(0, slot - 32)` because shreds carry no finality info. Clients that actually need `root` should use `rootSubscribe` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)