### PR TITLE
feat(rpc-gateway): SLOT_PUBSUB_URL — route slotSubscribe to a faster WS source

### DIFF
--- a/api/rpc-gateway/src/handlers/ws.ts
+++ b/api/rpc-gateway/src/handlers/ws.ts
@@ -32,12 +32,23 @@ import { SlotBridge } from '../lib/slot-bridge.ts'
 
 export type WsConfig = {
   yellowstoneEndpoint: string // host:port — passed straight to gRPC client
-  pubsubUrl: string // ws://… upstream Solana pubsub
-  // Optional dedicated source for slotSubscribe.  When set, slotSubscribe
-  // notifications come from this Yellowstone-gRPC endpoint (typically a
-  // shred-bridge that fires first-shred-of-next-slot ~5–8 ms earlier than
-  // validator-replay-complete).  When unset, slotSubscribe falls through
-  // to the standard pubsub forward like every other pubsub method.
+  pubsubUrl: string // ws://… upstream Solana pubsub (richat)
+  // Optional dedicated source for slotSubscribe.  Two flavours:
+  //
+  // - `slotPubsubUrl` (ws://…): forward `slotSubscribe` / `slotUnsubscribe`
+  //   to this Solana-pubsub-compat WebSocket (typically the validator's
+  //   own pubsub on `:rpc-port + 1`).  Empirically ~3 ms faster than
+  //   richat for slot notifications on this codebase as of 2026-05.
+  //
+  // - `slotBridgeEndpoint` (Yellowstone-gRPC): fan slot events out from
+  //   a shared gRPC stream.  Intended for shred-derived slot sources.
+  //   Note: jito-shredstream-derived sources have been measured ~400 ms
+  //   SLOWER than richat — the bridge code itself is fine but the
+  //   upstream shred feed lags turbine on a co-located validator.
+  //
+  // Priority: `slotPubsubUrl` > `slotBridgeEndpoint` > falls through to
+  // the standard pubsub forward (= same as every other pubsub method).
+  slotPubsubUrl?: string
   slotBridgeEndpoint?: string
 }
 
@@ -79,6 +90,10 @@ export function buildWsHandler(cfg: WsConfig) {
     const localSubs = new Map<number, { cancel: () => void }>()
     let localSubCounter = HELIUS_ID_BASE
     let pubsub: PubsubForward | null = null
+    // Separate forward for slotSubscribe when `slotPubsubUrl` is
+    // configured.  Each WS client gets its own upstream connection so
+    // subscription IDs from upstream stay namespaced per-client.
+    let slotPubsub: PubsubForward | null = null
     let socket: WebSocket | null = null
 
     const send = (msg: unknown) => {
@@ -109,6 +124,28 @@ export function buildWsHandler(cfg: WsConfig) {
         },
       })
       return pubsub
+    }
+
+    const ensureSlotPubsub = (): PubsubForward | null => {
+      if (!cfg.slotPubsubUrl) return null
+      if (slotPubsub) return slotPubsub
+      slotPubsub = new PubsubForward({
+        upstreamUrl: cfg.slotPubsubUrl,
+        onUpstreamMessage: (raw) => {
+          try {
+            socket?.send(raw)
+          } catch { /* closed */ }
+        },
+        onUpstreamClose: () => {},
+        onUpstreamError: (e) => {
+          console.error(JSON.stringify({
+            ts: new Date().toISOString(),
+            msg: 'slot_pubsub_upstream_error',
+            error: String(e),
+          }))
+        },
+      })
+      return slotPubsub
     }
 
     const handleHeliusTransactionSubscribe = async (
@@ -204,6 +241,13 @@ export function buildWsHandler(cfg: WsConfig) {
             return
           }
           case 'slotSubscribe': {
+            // Priority: slotPubsubUrl (WS) > slotBridge (gRPC) > standard
+            // pubsub forward.  See WsConfig docs for the latency rationale.
+            const sp = ensureSlotPubsub()
+            if (sp) {
+              sp.send(text)
+              return
+            }
             if (slotBridge) {
               const subId = ++localSubCounter
               const handle = slotBridge.subscribe((u) => {
@@ -217,11 +261,15 @@ export function buildWsHandler(cfg: WsConfig) {
               send(ok(req.id ?? null, subId))
               return
             }
-            // Fall through to pubsub forward.
             ensurePubsub().send(text)
             return
           }
           case 'slotUnsubscribe': {
+            const sp = ensureSlotPubsub()
+            if (sp) {
+              sp.send(text)
+              return
+            }
             if (slotBridge) {
               const params = (req.params as unknown[]) ?? []
               const subId = Number(params[0])
@@ -232,7 +280,6 @@ export function buildWsHandler(cfg: WsConfig) {
                 send(ok(req.id ?? null, true))
                 return
               }
-              // Unknown id — could be an upstream pubsub id, forward through.
               if (subId < HELIUS_ID_BASE) {
                 ensurePubsub().send(text)
                 return
@@ -257,6 +304,8 @@ export function buildWsHandler(cfg: WsConfig) {
         localSubs.clear()
         pubsub?.close()
         pubsub = null
+        slotPubsub?.close()
+        slotPubsub = null
         socket = null
       },
       onError(_e) {
@@ -264,6 +313,8 @@ export function buildWsHandler(cfg: WsConfig) {
         localSubs.clear()
         pubsub?.close()
         pubsub = null
+        slotPubsub?.close()
+        slotPubsub = null
         socket = null
       },
     }

--- a/api/rpc-gateway/src/main.ts
+++ b/api/rpc-gateway/src/main.ts
@@ -53,9 +53,11 @@ const CLICKHOUSE_TIMEOUT_MS = parseInt(Deno.env.get('CLICKHOUSE_TIMEOUT_MS') ?? 
 const OF1_TIMEOUT_MS = parseInt(Deno.env.get('OF1_TIMEOUT_MS') ?? '60000', 10)
 const YELLOWSTONE_GRPC = Deno.env.get('YELLOWSTONE_GRPC') ?? 'localhost:10000'
 const PUBSUB_WS_URL = Deno.env.get('PUBSUB_WS_URL') ?? 'ws://localhost:7111'
-// Optional override: when set, slotSubscribe notifications come from
-// this dedicated Yellowstone-gRPC endpoint (typically a shred-bridge)
-// instead of falling through to richat WS / validator geyser.
+// Optional overrides for the slotSubscribe upstream.  See WsConfig
+// docstrings in handlers/ws.ts for the latency rationale.
+// Priority: SLOT_PUBSUB_URL > SLOT_BRIDGE_GRPC > falls through to
+// PUBSUB_WS_URL (richat).
+const SLOT_PUBSUB_URL = Deno.env.get('SLOT_PUBSUB_URL') || undefined
 const SLOT_BRIDGE_GRPC = Deno.env.get('SLOT_BRIDGE_GRPC') || undefined
 const GTFA_FULL_CONCURRENCY = parseInt(Deno.env.get('GTFA_FULL_CONCURRENCY') ?? '20', 10)
 
@@ -136,6 +138,7 @@ app.use('*', async (c, next) => {
 const wsHandler = buildWsHandler({
   yellowstoneEndpoint: YELLOWSTONE_GRPC,
   pubsubUrl: PUBSUB_WS_URL,
+  slotPubsubUrl: SLOT_PUBSUB_URL,
   slotBridgeEndpoint: SLOT_BRIDGE_GRPC,
 })
 app.get('/ws', wsHandler)


### PR DESCRIPTION
## Summary

When `SLOT_PUBSUB_URL` env is set, `slotSubscribe` / `slotUnsubscribe` get their own dedicated `PubsubForward` to that WebSocket (typically the validator's own pubsub on `:rpc-port + 1`). All other pubsub methods continue to flow through `PUBSUB_WS_URL` (richat).

## Why

60-second slot race vs Helius beta from a FRA host, three sources:

| source | Helius first | Helius avg lead |
|---|---|---|
| default (richat WS :7111) | 139/149 (93.3 %) | **+8.9 ms** |
| native validator pubsub :7212 | 141/151 (93.4 %) | **+5.7 ms** |
| shred bridge gRPC :10005 (#370) | 150/150 (100 %) | +404 ms (regression — see below) |

Switching to native validator pubsub closes ~3 ms of the Helius gap with no validator restart and no loss of features (blockSubscribe / accountSubscribe etc. stay on richat).

## On the shred bridge (#370)

The Phase 1 `SLOT_BRIDGE_GRPC` option (gRPC subscribe to yellowstone_shred_bridge) is kept as a configuration option but is **a 400 ms regression** when pointed at the current jito-shredstream-derived source. The bridge code emits SlotProcessed at the correct point (first-shred-of-next-slot), but the jito-shredstream upstream feed itself lags a co-located validator's turbine receipt by roughly one slot.

WsConfig now documents the priority order: `slotPubsubUrl` > `slotBridgeEndpoint` > standard pubsub forward.

## Rollout plan

1. Merge.
2. Enable on FRA-1 by adding `Environment=SLOT_PUBSUB_URL=ws://127.0.0.1:7212` to the gateway service drop-in on `185.191.116.182`.
3. Re-measure from a FRA host; expect Helius lead to drop ~3 ms.
4. If stable, roll out to other 5 regions (each validator already exposes pubsub on `:rpc-port + 1`).

## Test plan

- [x] `deno check` clean
- [ ] After FRA-1 deploy: 60s slot race vs Helius, confirm Helius lead drops from ~9 ms to ~5–6 ms
- [ ] Verify other pubsub methods (accountSubscribe, blockSubscribe) still work — they should be untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)