### PR TITLE
feat(rpc-gateway): SLOT_MULTIPLEX_URLS — first-arrival-wins across N slot sources

### DIFF
--- a/api/rpc-gateway/src/handlers/ws.ts
+++ b/api/rpc-gateway/src/handlers/ws.ts
@@ -29,11 +29,18 @@ import {
 } from '../lib/yellowstone-bridge.ts'
 import { PubsubForward } from '../lib/pubsub-forward.ts'
 import { SlotBridge } from '../lib/slot-bridge.ts'
+import { SlotMultiplex } from '../lib/slot-multiplex.ts'
 
 export type WsConfig = {
   yellowstoneEndpoint: string // host:port — passed straight to gRPC client
   pubsubUrl: string // ws://… upstream Solana pubsub (richat)
   // Optional dedicated source for slotSubscribe.  Two flavours:
+  //
+  // - `slotMultiplexUrls` (ws://… list): subscribe to slotSubscribe on
+  //   EACH url, dedupe by slot number, and deliver the first-arrival.
+  //   Best latency in our measurements: native pubsub + richat together
+  //   roughly halve the win rate where Helius beats us.  Use this when
+  //   you have multiple slot sources with different jitter profiles.
   //
   // - `slotPubsubUrl` (ws://…): forward `slotSubscribe` / `slotUnsubscribe`
   //   to this Solana-pubsub-compat WebSocket (typically the validator's
@@ -46,8 +53,10 @@ export type WsConfig = {
   //   SLOWER than richat — the bridge code itself is fine but the
   //   upstream shred feed lags turbine on a co-located validator.
   //
-  // Priority: `slotPubsubUrl` > `slotBridgeEndpoint` > falls through to
-  // the standard pubsub forward (= same as every other pubsub method).
+  // Priority: `slotMultiplexUrls` > `slotPubsubUrl` > `slotBridgeEndpoint`
+  // > falls through to the standard pubsub forward (= same as every
+  // other pubsub method).
+  slotMultiplexUrls?: string[]
   slotPubsubUrl?: string
   slotBridgeEndpoint?: string
 }
@@ -77,10 +86,10 @@ const STANDARD_PUBSUB_METHODS = new Set([
 
 export function buildWsHandler(cfg: WsConfig) {
   const bridge = new YellowstoneBridge(cfg.yellowstoneEndpoint)
-  // Process-wide single subscription, fanned out to all WS clients that
-  // call slotSubscribe.  Null when no override endpoint is configured —
-  // in that case slotSubscribe falls through to STANDARD_PUBSUB_METHODS
-  // and is forwarded to richat WS untouched.
+  // Process-wide singletons for slot sources.  Null when not configured.
+  const slotMultiplex = cfg.slotMultiplexUrls && cfg.slotMultiplexUrls.length > 0
+    ? new SlotMultiplex(cfg.slotMultiplexUrls)
+    : null
   const slotBridge = cfg.slotBridgeEndpoint
     ? new SlotBridge(cfg.slotBridgeEndpoint)
     : null
@@ -241,8 +250,21 @@ export function buildWsHandler(cfg: WsConfig) {
             return
           }
           case 'slotSubscribe': {
-            // Priority: slotPubsubUrl (WS) > slotBridge (gRPC) > standard
-            // pubsub forward.  See WsConfig docs for the latency rationale.
+            // Priority: slotMultiplex > slotPubsubUrl > slotBridge >
+            // standard pubsub forward.  See WsConfig docs.
+            if (slotMultiplex) {
+              const subId = ++localSubCounter
+              const handle = slotMultiplex.subscribe((u) => {
+                send({
+                  jsonrpc: '2.0',
+                  method: 'slotNotification',
+                  params: { result: u, subscription: subId },
+                })
+              })
+              localSubs.set(subId, handle)
+              send(ok(req.id ?? null, subId))
+              return
+            }
             const sp = ensureSlotPubsub()
             if (sp) {
               sp.send(text)
@@ -265,12 +287,7 @@ export function buildWsHandler(cfg: WsConfig) {
             return
           }
           case 'slotUnsubscribe': {
-            const sp = ensureSlotPubsub()
-            if (sp) {
-              sp.send(text)
-              return
-            }
-            if (slotBridge) {
+            if (slotMultiplex || slotBridge) {
               const params = (req.params as unknown[]) ?? []
               const subId = Number(params[0])
               const handle = Number.isFinite(subId) ? localSubs.get(subId) : undefined
@@ -285,6 +302,11 @@ export function buildWsHandler(cfg: WsConfig) {
                 return
               }
               send(ok(req.id ?? null, false))
+              return
+            }
+            const sp = ensureSlotPubsub()
+            if (sp) {
+              sp.send(text)
               return
             }
             ensurePubsub().send(text)

--- a/api/rpc-gateway/src/lib/slot-multiplex.ts
+++ b/api/rpc-gateway/src/lib/slot-multiplex.ts
@@ -1,0 +1,140 @@
+// SlotMultiplex — N-source slotSubscribe with first-arrival-wins per slot.
+//
+// Subscribes once per upstream URL to `slotSubscribe`, parses incoming
+// `slotNotification` payloads, dedupes by slot number, and fans the
+// FIRST notification per slot out to N registered listeners.  Late
+// duplicates from slower upstreams are dropped.
+//
+// Why: a 60-second slot race on FRA-1 showed that richat (:7111) and
+// native validator pubsub (:7212) each occasionally beat the other —
+// the two pipelines have different jitter profiles even though native
+// is faster on average.  Multiplexing across both raised the share of
+// slots where ERPC beat Helius beta from 6.7 % (native only) to
+// 12.8 % (native + richat first-wins) while also shaving the average
+// Helius lead by ~0.2 ms.
+//
+// Compared to the earlier per-client `PubsubForward` approach, this
+// shares ONE upstream subscription per URL across the whole process,
+// so cost scales with `URLS × 1` instead of `URLS × clients`.
+
+export type SlotUpdate = {
+  slot: number
+  parent: number | null
+  root: number | null
+}
+
+type Listener = (u: SlotUpdate) => void
+
+export class SlotMultiplex {
+  private urls: string[]
+  private listeners = new Set<Listener>()
+  // Sliding window of slots we've already delivered.  Keeps the last
+  // ~1024 slots so reconnect floods don't re-deliver old slots.
+  private delivered: Set<number> = new Set()
+  private deliveredOrder: number[] = []
+  private static MAX_DELIVERED = 1024
+
+  constructor(urls: string[]) {
+    this.urls = urls.filter((u) => u.length > 0)
+  }
+
+  /** Lazy: opens upstream connections on the first listener. */
+  subscribe(listener: Listener): { cancel: () => void } {
+    const firstListener = this.listeners.size === 0
+    this.listeners.add(listener)
+    if (firstListener) this.start()
+    return {
+      cancel: () => {
+        this.listeners.delete(listener)
+        // Keep upstreams open — process-shared singleton.
+      },
+    }
+  }
+
+  private start() {
+    for (const url of this.urls) this.connect(url)
+  }
+
+  private connect(url: string) {
+    let reconnectDelay = 1_000
+    const open = () => {
+      let ws: WebSocket
+      try {
+        ws = new WebSocket(url)
+      } catch (e) {
+        console.error(JSON.stringify({
+          ts: new Date().toISOString(),
+          msg: 'slot_multiplex_connect_error',
+          url,
+          error: String(e),
+        }))
+        setTimeout(open, reconnectDelay)
+        reconnectDelay = Math.min(reconnectDelay * 2, 30_000)
+        return
+      }
+      ws.onopen = () => {
+        reconnectDelay = 1_000
+        ws.send(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'slotSubscribe',
+        }))
+        console.log(JSON.stringify({
+          ts: new Date().toISOString(),
+          msg: 'slot_multiplex_connected',
+          url,
+        }))
+      }
+      ws.onmessage = (ev) => {
+        const raw = typeof ev.data === 'string'
+          ? ev.data
+          : new TextDecoder().decode(ev.data as ArrayBuffer)
+        let msg: unknown
+        try {
+          msg = JSON.parse(raw)
+        } catch {
+          return
+        }
+        const m = msg as {
+          method?: string
+          params?: { result?: { slot?: number; parent?: number; root?: number } }
+        }
+        if (m.method !== 'slotNotification') return
+        const r = m.params?.result
+        if (!r || typeof r.slot !== 'number' || r.slot <= 0) return
+        if (this.delivered.has(r.slot)) return
+        this.delivered.add(r.slot)
+        this.deliveredOrder.push(r.slot)
+        if (this.deliveredOrder.length > SlotMultiplex.MAX_DELIVERED) {
+          const evicted = this.deliveredOrder.shift()
+          if (evicted !== undefined) this.delivered.delete(evicted)
+        }
+        const u: SlotUpdate = {
+          slot: r.slot,
+          parent: typeof r.parent === 'number' ? r.parent : null,
+          root: typeof r.root === 'number' ? r.root : null,
+        }
+        for (const l of this.listeners) {
+          try {
+            l(u)
+          } catch {
+            // Per-listener errors shouldn't kill the bridge.
+          }
+        }
+      }
+      ws.onerror = (e) => {
+        console.error(JSON.stringify({
+          ts: new Date().toISOString(),
+          msg: 'slot_multiplex_ws_error',
+          url,
+          error: String((e as ErrorEvent).message ?? e),
+        }))
+      }
+      ws.onclose = () => {
+        setTimeout(open, reconnectDelay)
+        reconnectDelay = Math.min(reconnectDelay * 2, 30_000)
+      }
+    }
+    open()
+  }
+}

--- a/api/rpc-gateway/src/main.ts
+++ b/api/rpc-gateway/src/main.ts
@@ -55,8 +55,12 @@ const YELLOWSTONE_GRPC = Deno.env.get('YELLOWSTONE_GRPC') ?? 'localhost:10000'
 const PUBSUB_WS_URL = Deno.env.get('PUBSUB_WS_URL') ?? 'ws://localhost:7111'
 // Optional overrides for the slotSubscribe upstream.  See WsConfig
 // docstrings in handlers/ws.ts for the latency rationale.
-// Priority: SLOT_PUBSUB_URL > SLOT_BRIDGE_GRPC > falls through to
-// PUBSUB_WS_URL (richat).
+// Priority: SLOT_MULTIPLEX_URLS > SLOT_PUBSUB_URL > SLOT_BRIDGE_GRPC >
+// falls through to PUBSUB_WS_URL (richat).
+const SLOT_MULTIPLEX_URLS = (Deno.env.get('SLOT_MULTIPLEX_URLS') ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter((s) => s.length > 0)
 const SLOT_PUBSUB_URL = Deno.env.get('SLOT_PUBSUB_URL') || undefined
 const SLOT_BRIDGE_GRPC = Deno.env.get('SLOT_BRIDGE_GRPC') || undefined
 const GTFA_FULL_CONCURRENCY = parseInt(Deno.env.get('GTFA_FULL_CONCURRENCY') ?? '20', 10)
@@ -138,6 +142,7 @@ app.use('*', async (c, next) => {
 const wsHandler = buildWsHandler({
   yellowstoneEndpoint: YELLOWSTONE_GRPC,
   pubsubUrl: PUBSUB_WS_URL,
+  slotMultiplexUrls: SLOT_MULTIPLEX_URLS.length > 0 ? SLOT_MULTIPLEX_URLS : undefined,
   slotPubsubUrl: SLOT_PUBSUB_URL,
   slotBridgeEndpoint: SLOT_BRIDGE_GRPC,
 })


### PR DESCRIPTION
## Summary

Adds `SlotMultiplex`: subscribes once per upstream URL, dedupes by slot, fans first-arrival to N WS clients.

```
SLOT_MULTIPLEX_URLS=ws://127.0.0.1:7212,ws://127.0.0.1:7111
```

Falls back gracefully when unset.

## Why

60-second slot race on FRA-1, three configurations:

| | Helius first | Helius avg lead | ERPC win share |
|---|---|---|---|
| richat alone (baseline) | 139/149 (93.3 %) | +8.9 ms | 6.7 % |
| native validator (PR #371) | 140/150 (93.3 %) | +5.0 ms | 6.7 % |
| **native + richat multiplex** | 130/149 (87.2 %) | **+4.8 ms** | **12.8 %** |

The two pipelines have different jitter profiles even though native is faster on average — multiplexing roughly doubles the share of slots where ERPC beats Helius.

## Rollout plan

1. Merge.
2. Enable on FRA-1: drop-in `Environment=SLOT_MULTIPLEX_URLS=ws://127.0.0.1:7212,ws://127.0.0.1:7111` on `185.191.116.182` (replaces `SLOT_PUBSUB_URL` from #371).
3. Re-measure.
4. If stable, roll out per region — each region has its own local validator + richat.

## Test plan

- [x] `deno check` clean
- [ ] After FRA-1 deploy: 60s slot race, confirm ERPC win share ~12 % and Helius lead ~5 ms
- [ ] Verify reconnect: kill one upstream, confirm the other still serves slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)