### PR TITLE
feat(rpc-gateway): SLOT_FIRST_SHRED_URL — match Helius slotNotification timing

### DIFF
--- a/api/rpc-gateway/src/handlers/ws.ts
+++ b/api/rpc-gateway/src/handlers/ws.ts
@@ -30,11 +30,23 @@ import {
 import { PubsubForward } from '../lib/pubsub-forward.ts'
 import { SlotBridge } from '../lib/slot-bridge.ts'
 import { SlotMultiplex } from '../lib/slot-multiplex.ts'
+import { SlotFirstShredBridge } from '../lib/slot-first-shred.ts'
 
 export type WsConfig = {
   yellowstoneEndpoint: string // host:port — passed straight to gRPC client
   pubsubUrl: string // ws://… upstream Solana pubsub (richat)
   // Optional dedicated source for slotSubscribe.  Two flavours:
+  //
+  // - `slotFirstShredUrl` (ws://…): subscribe to `slotsUpdatesSubscribe`
+  //   on this Solana-pubsub-compat endpoint and emit `firstShredReceived`
+  //   events as `slotNotification`.  This matches what Helius beta does
+  //   internally and was the only configuration in our 2026-05-17
+  //   measurements that closed the Helius latency gap meaningfully
+  //   (Helius avg lead +5.6 ms → +2.5 ms; ERPC win share 6.7 % → 23 %).
+  //   Trade-off: clients see slot ticks ~5 ms earlier but the bank for
+  //   that slot does not yet exist — downstream `getAccountInfo` may
+  //   race the validator's own replay.  Off by default; opt in when
+  //   slot freshness > consistency.
   //
   // - `slotMultiplexUrls` (ws://… list): subscribe to slotSubscribe on
   //   EACH url, dedupe by slot number, and deliver the first-arrival.
@@ -53,9 +65,10 @@ export type WsConfig = {
   //   SLOWER than richat — the bridge code itself is fine but the
   //   upstream shred feed lags turbine on a co-located validator.
   //
-  // Priority: `slotMultiplexUrls` > `slotPubsubUrl` > `slotBridgeEndpoint`
-  // > falls through to the standard pubsub forward (= same as every
-  // other pubsub method).
+  // Priority: `slotFirstShredUrl` > `slotMultiplexUrls` > `slotPubsubUrl`
+  // > `slotBridgeEndpoint` > falls through to the standard pubsub
+  // forward (= same as every other pubsub method).
+  slotFirstShredUrl?: string
   slotMultiplexUrls?: string[]
   slotPubsubUrl?: string
   slotBridgeEndpoint?: string
@@ -87,6 +100,9 @@ const STANDARD_PUBSUB_METHODS = new Set([
 export function buildWsHandler(cfg: WsConfig) {
   const bridge = new YellowstoneBridge(cfg.yellowstoneEndpoint)
   // Process-wide singletons for slot sources.  Null when not configured.
+  const slotFirstShred = cfg.slotFirstShredUrl
+    ? new SlotFirstShredBridge(cfg.slotFirstShredUrl)
+    : null
   const slotMultiplex = cfg.slotMultiplexUrls && cfg.slotMultiplexUrls.length > 0
     ? new SlotMultiplex(cfg.slotMultiplexUrls)
     : null
@@ -250,8 +266,21 @@ export function buildWsHandler(cfg: WsConfig) {
             return
           }
           case 'slotSubscribe': {
-            // Priority: slotMultiplex > slotPubsubUrl > slotBridge >
-            // standard pubsub forward.  See WsConfig docs.
+            // Priority: slotFirstShred > slotMultiplex > slotPubsubUrl >
+            // slotBridge > standard pubsub forward.  See WsConfig docs.
+            if (slotFirstShred) {
+              const subId = ++localSubCounter
+              const handle = slotFirstShred.subscribe((u) => {
+                send({
+                  jsonrpc: '2.0',
+                  method: 'slotNotification',
+                  params: { result: u, subscription: subId },
+                })
+              })
+              localSubs.set(subId, handle)
+              send(ok(req.id ?? null, subId))
+              return
+            }
             if (slotMultiplex) {
               const subId = ++localSubCounter
               const handle = slotMultiplex.subscribe((u) => {
@@ -287,7 +316,7 @@ export function buildWsHandler(cfg: WsConfig) {
             return
           }
           case 'slotUnsubscribe': {
-            if (slotMultiplex || slotBridge) {
+            if (slotFirstShred || slotMultiplex || slotBridge) {
               const params = (req.params as unknown[]) ?? []
               const subId = Number(params[0])
               const handle = Number.isFinite(subId) ? localSubs.get(subId) : undefined

--- a/api/rpc-gateway/src/lib/slot-first-shred.ts
+++ b/api/rpc-gateway/src/lib/slot-first-shred.ts
@@ -1,0 +1,157 @@
+// SlotFirstShredBridge — emit slotNotification at `firstShredReceived`
+// instead of the standard `processed` (= bank-frozen) semantic.
+//
+// Why: a standard `slotSubscribe` fires when the validator finishes
+// replaying a slot's last shred and freezes the bank.  Helius beta
+// fires noticeably earlier — measurement on FRA-1 (2026-05-17) showed
+// Helius beat ERPC by avg +5.6 ms on `slotSubscribe`, but only +2.5 ms
+// when ERPC subscribed to `slotsUpdatesSubscribe` and re-emitted the
+// `firstShredReceived` events as `slotNotification`.  The gap closed
+// because `firstShredReceived` fires the instant the validator sees
+// the first shred for a slot — same physics as Helius's signal.
+//
+// Trade-off: clients still see `slotNotification` with `{slot, parent,
+// root}`, but the slot has only just *started* — the bank for that
+// slot does not yet exist, so a follow-up `getAccountInfo` /
+// `getBalance` at that slot may race the validator's own replay.
+// Use this when the customer wants early slot ticks (e.g. for trading
+// loops or progress UIs), NOT when they want guaranteed bank state.
+//
+// Implementation: opens ONE upstream WebSocket to a Solana-pubsub-compat
+// endpoint, sends `slotsUpdatesSubscribe`, and fans the filtered events
+// out to N registered listeners.  Cost: one upstream subscription per
+// process regardless of client count.
+
+export type SlotUpdate = {
+  slot: number
+  parent: number | null
+  root: number | null
+}
+
+type Listener = (u: SlotUpdate) => void
+
+export class SlotFirstShredBridge {
+  private url: string
+  private listeners = new Set<Listener>()
+  private ws: WebSocket | null = null
+  private reconnectDelay = 1_000
+  private starting = false
+  // Sliding-window dedupe so a reconnect surge doesn't re-deliver old slots.
+  private delivered = new Set<number>()
+  private deliveredOrder: number[] = []
+  private static MAX_DELIVERED = 1024
+
+  constructor(url: string) {
+    this.url = url
+  }
+
+  subscribe(listener: Listener): { cancel: () => void } {
+    const firstListener = this.listeners.size === 0
+    this.listeners.add(listener)
+    if (firstListener) this.connect()
+    return {
+      cancel: () => {
+        this.listeners.delete(listener)
+      },
+    }
+  }
+
+  private connect() {
+    if (this.starting || this.ws) return
+    this.starting = true
+    let ws: WebSocket
+    try {
+      ws = new WebSocket(this.url)
+    } catch (e) {
+      this.starting = false
+      console.error(JSON.stringify({
+        ts: new Date().toISOString(),
+        msg: 'slot_first_shred_connect_error',
+        url: this.url,
+        error: String(e),
+      }))
+      this.scheduleReconnect()
+      return
+    }
+    this.ws = ws
+    ws.onopen = () => {
+      this.starting = false
+      this.reconnectDelay = 1_000
+      ws.send(JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'slotsUpdatesSubscribe',
+      }))
+      console.log(JSON.stringify({
+        ts: new Date().toISOString(),
+        msg: 'slot_first_shred_connected',
+        url: this.url,
+      }))
+    }
+    ws.onmessage = (ev) => {
+      const raw = typeof ev.data === 'string'
+        ? ev.data
+        : new TextDecoder().decode(ev.data as ArrayBuffer)
+      let msg: unknown
+      try {
+        msg = JSON.parse(raw)
+      } catch {
+        return
+      }
+      const m = msg as {
+        method?: string
+        params?: {
+          result?: {
+            slot?: number
+            parent?: number
+            type?: string
+          }
+        }
+      }
+      if (m.method !== 'slotsUpdatesNotification') return
+      const r = m.params?.result
+      if (!r || r.type !== 'firstShredReceived' || typeof r.slot !== 'number') return
+      if (r.slot <= 0 || this.delivered.has(r.slot)) return
+      this.delivered.add(r.slot)
+      this.deliveredOrder.push(r.slot)
+      if (this.deliveredOrder.length > SlotFirstShredBridge.MAX_DELIVERED) {
+        const evicted = this.deliveredOrder.shift()
+        if (evicted !== undefined) this.delivered.delete(evicted)
+      }
+      const update: SlotUpdate = {
+        slot: r.slot,
+        parent: typeof r.parent === 'number' ? r.parent : r.slot - 1,
+        // `root` is unknown at first-shred-received time — slotsUpdates
+        // doesn't carry it.  Approximate with `slot - 32`; clients that
+        // need real root should call `rootSubscribe` separately.
+        root: Math.max(0, r.slot - 32),
+      }
+      for (const l of this.listeners) {
+        try {
+          l(update)
+        } catch {
+          // Per-listener errors shouldn't kill the bridge.
+        }
+      }
+    }
+    ws.onerror = (e) => {
+      console.error(JSON.stringify({
+        ts: new Date().toISOString(),
+        msg: 'slot_first_shred_ws_error',
+        url: this.url,
+        error: String((e as ErrorEvent).message ?? e),
+      }))
+    }
+    ws.onclose = () => {
+      this.ws = null
+      this.starting = false
+      if (this.listeners.size > 0) this.scheduleReconnect()
+    }
+  }
+
+  private scheduleReconnect() {
+    const delay = this.reconnectDelay
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30_000)
+    setTimeout(() => this.connect(), delay)
+  }
+}

--- a/api/rpc-gateway/src/main.ts
+++ b/api/rpc-gateway/src/main.ts
@@ -55,8 +55,9 @@ const YELLOWSTONE_GRPC = Deno.env.get('YELLOWSTONE_GRPC') ?? 'localhost:10000'
 const PUBSUB_WS_URL = Deno.env.get('PUBSUB_WS_URL') ?? 'ws://localhost:7111'
 // Optional overrides for the slotSubscribe upstream.  See WsConfig
 // docstrings in handlers/ws.ts for the latency rationale.
-// Priority: SLOT_MULTIPLEX_URLS > SLOT_PUBSUB_URL > SLOT_BRIDGE_GRPC >
-// falls through to PUBSUB_WS_URL (richat).
+// Priority: SLOT_FIRST_SHRED_URL > SLOT_MULTIPLEX_URLS > SLOT_PUBSUB_URL
+// > SLOT_BRIDGE_GRPC > falls through to PUBSUB_WS_URL (richat).
+const SLOT_FIRST_SHRED_URL = Deno.env.get('SLOT_FIRST_SHRED_URL') || undefined
 const SLOT_MULTIPLEX_URLS = (Deno.env.get('SLOT_MULTIPLEX_URLS') ?? '')
   .split(',')
   .map((s) => s.trim())
@@ -142,6 +143,7 @@ app.use('*', async (c, next) => {
 const wsHandler = buildWsHandler({
   yellowstoneEndpoint: YELLOWSTONE_GRPC,
   pubsubUrl: PUBSUB_WS_URL,
+  slotFirstShredUrl: SLOT_FIRST_SHRED_URL,
   slotMultiplexUrls: SLOT_MULTIPLEX_URLS.length > 0 ? SLOT_MULTIPLEX_URLS : undefined,
   slotPubsubUrl: SLOT_PUBSUB_URL,
   slotBridgeEndpoint: SLOT_BRIDGE_GRPC,


### PR DESCRIPTION
## Summary

Add `SlotFirstShredBridge`: subscribe to `slotsUpdatesSubscribe` on a Solana-pubsub-compat WebSocket, filter `firstShredReceived` events, re-emit as standard `slotNotification`. Singleton per process; fans out to N WS clients.

Enable per-gateway by env: `SLOT_FIRST_SHRED_URL=ws://127.0.0.1:7212`.

## Why

`slotsUpdatesSubscribe` race vs Helius beta on FRA-1 (with the user's high-stake validator already shred-forwarding via `--shred-receiver-address 185.191.116.182:8001`):

| source | Helius first | Helius avg lead | ERPC win share |
|---|---|---|---|
| default `slotSubscribe` (= bank frozen) | 146/156 (93.6 %) | +5.6 ms | 6.4 % |
| **firstShredReceived re-emit (this PR)** | **116/151 (76.8 %)** | **+2.5 ms** | **23.2 %** |

Standard `slotSubscribe` fires after the validator replays the slot. Helius beta fires when the first shred for the slot lands, which is ~5 ms earlier. With the user's shred forward delivering shreds before our turbine receipt, `firstShredReceived` is the realistic ceiling — we now match it.

## Trade-off

Clients see slot ticks ~5 ms earlier, but the bank for that slot does NOT yet exist. A follow-up `getAccountInfo` may race the validator's replay. Off by default; opt-in when slot freshness > consistency.

## Rollout plan

1. Merge.
2. Enable on FRA-1: drop-in `Environment=SLOT_FIRST_SHRED_URL=ws://127.0.0.1:7212` on `185.191.116.182`.
3. Re-measure vs Helius; expected Helius lead ~+2.5 ms.
4. If stable + customer-acceptable, roll out per region (each validator's native pubsub on `:rpc-port + 1`).

## Test plan

- [x] `deno check` clean
- [ ] After FRA-1 deploy: 60 s race vs Helius beta, confirm Helius avg lead ~+2.5 ms and ERPC win share ~20 %+
- [ ] Verify reconnect: kill validator pubsub temporarily, confirm SlotFirstShredBridge reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)