### PR TITLE
feat(rpc-gateway): SLOT_FIRST_SHRED_MULTIPLEX_URLS — N-URL firstShredReceived

### DIFF
--- a/api/rpc-gateway/deno.json
+++ b/api/rpc-gateway/deno.json
@@ -6,12 +6,14 @@
     "start": "deno run --allow-net --allow-env src/main.ts",
     "compile": "deno compile --allow-net --allow-env --output dist/rpc-gateway src/main.ts",
     "check": "deno check src/main.ts",
+    "test": "deno test --allow-net src/",
     "fmt": "deno fmt src/",
     "lint": "deno lint src/"
   },
   "imports": {
     "@hono/hono": "jsr:@hono/hono@4.7.6",
-    "@hono/hono/deno": "jsr:@hono/hono@4.7.6/deno"
+    "@hono/hono/deno": "jsr:@hono/hono@4.7.6/deno",
+    "@std/assert": "jsr:@std/assert@1"
   },
   "fmt": {
     "lineWidth": 100,

--- a/api/rpc-gateway/src/handlers/ws.ts
+++ b/api/rpc-gateway/src/handlers/ws.ts
@@ -31,11 +31,19 @@ import { PubsubForward } from '../lib/pubsub-forward.ts'
 import { SlotBridge } from '../lib/slot-bridge.ts'
 import { SlotMultiplex } from '../lib/slot-multiplex.ts'
 import { SlotFirstShredBridge } from '../lib/slot-first-shred.ts'
+import { SlotFirstShredMultiplex } from '../lib/slot-first-shred-multiplex.ts'
 
 export type WsConfig = {
   yellowstoneEndpoint: string // host:port — passed straight to gRPC client
   pubsubUrl: string // ws://… upstream Solana pubsub (richat)
   // Optional dedicated source for slotSubscribe.  Two flavours:
+  //
+  // - `slotFirstShredMultiplexUrls` (ws://… list): combines the
+  //   `firstShredReceived` semantic with N-URL first-arrival-wins
+  //   multiplexing.  Best single knob for slot latency: stack the
+  //   early-signal of `slotFirstShredUrl` on top of the jitter-
+  //   smoothing of `slotMultiplexUrls`.  Same trade-off as
+  //   `slotFirstShredUrl` (= bank not yet frozen at notify time).
   //
   // - `slotFirstShredUrl` (ws://…): subscribe to `slotsUpdatesSubscribe`
   //   on this Solana-pubsub-compat endpoint and emit `firstShredReceived`
@@ -65,9 +73,11 @@ export type WsConfig = {
   //   SLOWER than richat — the bridge code itself is fine but the
   //   upstream shred feed lags turbine on a co-located validator.
   //
-  // Priority: `slotFirstShredUrl` > `slotMultiplexUrls` > `slotPubsubUrl`
-  // > `slotBridgeEndpoint` > falls through to the standard pubsub
-  // forward (= same as every other pubsub method).
+  // Priority: `slotFirstShredMultiplexUrls` > `slotFirstShredUrl` >
+  // `slotMultiplexUrls` > `slotPubsubUrl` > `slotBridgeEndpoint` >
+  // falls through to the standard pubsub forward (= same as every
+  // other pubsub method).
+  slotFirstShredMultiplexUrls?: string[]
   slotFirstShredUrl?: string
   slotMultiplexUrls?: string[]
   slotPubsubUrl?: string
@@ -100,15 +110,17 @@ const STANDARD_PUBSUB_METHODS = new Set([
 export function buildWsHandler(cfg: WsConfig) {
   const bridge = new YellowstoneBridge(cfg.yellowstoneEndpoint)
   // Process-wide singletons for slot sources.  Null when not configured.
+  const slotFirstShredMultiplex =
+    cfg.slotFirstShredMultiplexUrls && cfg.slotFirstShredMultiplexUrls.length > 0
+      ? new SlotFirstShredMultiplex(cfg.slotFirstShredMultiplexUrls)
+      : null
   const slotFirstShred = cfg.slotFirstShredUrl
     ? new SlotFirstShredBridge(cfg.slotFirstShredUrl)
     : null
   const slotMultiplex = cfg.slotMultiplexUrls && cfg.slotMultiplexUrls.length > 0
     ? new SlotMultiplex(cfg.slotMultiplexUrls)
     : null
-  const slotBridge = cfg.slotBridgeEndpoint
-    ? new SlotBridge(cfg.slotBridgeEndpoint)
-    : null
+  const slotBridge = cfg.slotBridgeEndpoint ? new SlotBridge(cfg.slotBridgeEndpoint) : null
 
   return upgradeWebSocket(() => {
     // Per-connection state.
@@ -266,8 +278,22 @@ export function buildWsHandler(cfg: WsConfig) {
             return
           }
           case 'slotSubscribe': {
-            // Priority: slotFirstShred > slotMultiplex > slotPubsubUrl >
-            // slotBridge > standard pubsub forward.  See WsConfig docs.
+            // Priority: slotFirstShredMultiplex > slotFirstShred >
+            // slotMultiplex > slotPubsubUrl > slotBridge > standard
+            // pubsub forward.  See WsConfig docs.
+            if (slotFirstShredMultiplex) {
+              const subId = ++localSubCounter
+              const handle = slotFirstShredMultiplex.subscribe((u) => {
+                send({
+                  jsonrpc: '2.0',
+                  method: 'slotNotification',
+                  params: { result: u, subscription: subId },
+                })
+              })
+              localSubs.set(subId, handle)
+              send(ok(req.id ?? null, subId))
+              return
+            }
             if (slotFirstShred) {
               const subId = ++localSubCounter
               const handle = slotFirstShred.subscribe((u) => {
@@ -316,7 +342,7 @@ export function buildWsHandler(cfg: WsConfig) {
             return
           }
           case 'slotUnsubscribe': {
-            if (slotFirstShred || slotMultiplex || slotBridge) {
+            if (slotFirstShredMultiplex || slotFirstShred || slotMultiplex || slotBridge) {
               const params = (req.params as unknown[]) ?? []
               const subId = Number(params[0])
               const handle = Number.isFinite(subId) ? localSubs.get(subId) : undefined
@@ -346,7 +372,13 @@ export function buildWsHandler(cfg: WsConfig) {
               ensurePubsub().send(text)
               return
             }
-            send(err(req.id ?? null, ERROR_CODES.METHOD_NOT_FOUND, `unsupported WS method: ${req.method}`))
+            send(
+              err(
+                req.id ?? null,
+                ERROR_CODES.METHOD_NOT_FOUND,
+                `unsupported WS method: ${req.method}`,
+              ),
+            )
           }
         }
       },

--- a/api/rpc-gateway/src/lib/slot-first-shred-multiplex.ts
+++ b/api/rpc-gateway/src/lib/slot-first-shred-multiplex.ts
@@ -1,0 +1,198 @@
+// SlotFirstShredMultiplex — N-URL fan-in of `slotsUpdatesSubscribe` →
+// `firstShredReceived` events, first-arrival-wins per slot.
+//
+// Combines the design of `SlotFirstShredBridge` (Helius-parity early
+// signal at first-shred receipt) with `SlotMultiplex` (process-wide
+// dedup across multiple upstream sources).  One outbound WS per URL,
+// one shared listener set per process, first arrival wins per slot.
+//
+// Why both axes matter:
+//
+//   - `firstShredReceived` semantics close the bulk of the Helius gap
+//     by emitting on shred receipt instead of bank-frozen
+//     (`SlotFirstShredBridge` got Helius avg lead +5.6 ms → +2.5 ms
+//     on FRA-1, 2026-05-17).
+//
+//   - Multiplexing across N upstream pubsub sources catches the slots
+//     where any individual source happened to win the jitter race
+//     (`SlotMultiplex` measured ERPC win share 6.7 % → 12.8 % with
+//     native + richat, 2026-05-17).
+//
+// Pointing this class at the same N URLs as `SlotMultiplex` but
+// filtered through the `firstShredReceived` event type combines both
+// improvements in a single subscription stream.  Wire-format on the
+// output side is still a regular `slotNotification` so client SDKs
+// (web3.js etc.) need no changes.
+//
+// Trade-off: same as `SlotFirstShredBridge` — clients see the slot
+// tick before the bank for that slot is frozen, so a follow-up
+// `getAccountInfo` at the new slot can race the validator's replay.
+
+export type SlotUpdate = {
+  slot: number
+  parent: number | null
+  root: number | null
+}
+
+type Listener = (u: SlotUpdate) => void
+
+export class SlotFirstShredMultiplex {
+  private urls: string[]
+  private listeners = new Set<Listener>()
+  // Sliding-window dedupe so a reconnect surge doesn't re-deliver
+  // old slots and so two simultaneous sources never deliver twice.
+  private delivered = new Set<number>()
+  private deliveredOrder: number[] = []
+  private static MAX_DELIVERED = 1024
+  // Tracked so close() can stop them and tests don't trip Deno's
+  // op-leak detector on pending reconnects.
+  private reconnectTimers = new Set<number>()
+  private openSockets = new Set<WebSocket>()
+  private shutdownRequested = false
+
+  constructor(urls: string[]) {
+    this.urls = urls.filter((u) => u.length > 0)
+  }
+
+  /** Lazy: opens upstream connections on the first listener. */
+  subscribe(listener: Listener): { cancel: () => void } {
+    const firstListener = this.listeners.size === 0
+    this.listeners.add(listener)
+    if (firstListener) this.start()
+    return {
+      cancel: () => {
+        this.listeners.delete(listener)
+        // Upstreams stay open — process-shared singleton pattern.
+      },
+    }
+  }
+
+  /** Stop reconnecting and close every open upstream socket. */
+  close() {
+    this.shutdownRequested = true
+    for (const t of this.reconnectTimers) clearTimeout(t)
+    this.reconnectTimers.clear()
+    for (const ws of this.openSockets) {
+      try {
+        ws.close()
+      } catch { /* ignore */ }
+    }
+    this.openSockets.clear()
+  }
+
+  private start() {
+    if (this.shutdownRequested) return
+    for (const url of this.urls) this.connect(url)
+  }
+
+  private scheduleReconnect(open: () => void, delay: number) {
+    if (this.shutdownRequested) return
+    const id = setTimeout(() => {
+      this.reconnectTimers.delete(id)
+      if (!this.shutdownRequested) open()
+    }, delay) as unknown as number
+    this.reconnectTimers.add(id)
+  }
+
+  private connect(url: string) {
+    let reconnectDelay = 1_000
+    const open = () => {
+      if (this.shutdownRequested) return
+      let ws: WebSocket
+      try {
+        ws = new WebSocket(url)
+      } catch (e) {
+        console.error(JSON.stringify({
+          ts: new Date().toISOString(),
+          msg: 'slot_first_shred_multiplex_connect_error',
+          url,
+          error: String(e),
+        }))
+        this.scheduleReconnect(open, reconnectDelay)
+        reconnectDelay = Math.min(reconnectDelay * 2, 30_000)
+        return
+      }
+      this.openSockets.add(ws)
+      ws.onopen = () => {
+        if (this.shutdownRequested) {
+          try {
+            ws.close()
+          } catch { /* ignore */ }
+          return
+        }
+        reconnectDelay = 1_000
+        ws.send(JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'slotsUpdatesSubscribe',
+        }))
+        console.log(JSON.stringify({
+          ts: new Date().toISOString(),
+          msg: 'slot_first_shred_multiplex_connected',
+          url,
+        }))
+      }
+      ws.onmessage = (ev) => {
+        const raw = typeof ev.data === 'string'
+          ? ev.data
+          : new TextDecoder().decode(ev.data as ArrayBuffer)
+        let msg: unknown
+        try {
+          msg = JSON.parse(raw)
+        } catch {
+          return
+        }
+        const m = msg as {
+          method?: string
+          params?: {
+            result?: {
+              slot?: number
+              parent?: number
+              type?: string
+            }
+          }
+        }
+        if (m.method !== 'slotsUpdatesNotification') return
+        const r = m.params?.result
+        if (!r || r.type !== 'firstShredReceived') return
+        if (typeof r.slot !== 'number' || r.slot <= 0) return
+        if (this.delivered.has(r.slot)) return
+        this.delivered.add(r.slot)
+        this.deliveredOrder.push(r.slot)
+        if (this.deliveredOrder.length > SlotFirstShredMultiplex.MAX_DELIVERED) {
+          const evicted = this.deliveredOrder.shift()
+          if (evicted !== undefined) this.delivered.delete(evicted)
+        }
+        const update: SlotUpdate = {
+          slot: r.slot,
+          parent: typeof r.parent === 'number' ? r.parent : r.slot - 1,
+          // `root` is unknown at first-shred-received time — clients
+          // that need real root should call `rootSubscribe` instead.
+          root: Math.max(0, r.slot - 32),
+        }
+        for (const l of this.listeners) {
+          try {
+            l(update)
+          } catch {
+            // Per-listener errors shouldn't kill the bridge.
+          }
+        }
+      }
+      ws.onerror = (e) => {
+        console.error(JSON.stringify({
+          ts: new Date().toISOString(),
+          msg: 'slot_first_shred_multiplex_ws_error',
+          url,
+          error: String((e as ErrorEvent).message ?? e),
+        }))
+      }
+      ws.onclose = () => {
+        this.openSockets.delete(ws)
+        if (this.shutdownRequested) return
+        this.scheduleReconnect(open, reconnectDelay)
+        reconnectDelay = Math.min(reconnectDelay * 2, 30_000)
+      }
+    }
+    open()
+  }
+}

--- a/api/rpc-gateway/src/lib/slot-first-shred-multiplex_test.ts
+++ b/api/rpc-gateway/src/lib/slot-first-shred-multiplex_test.ts
@@ -1,0 +1,158 @@
+// Unit test for SlotFirstShredMultiplex: two upstream WS sources,
+// overlapping `firstShredReceived` events, verify first-arrival
+// dedup so each slot is delivered to the listener exactly once.
+
+import { assertEquals } from '@std/assert'
+import { SlotFirstShredMultiplex, type SlotUpdate } from './slot-first-shred-multiplex.ts'
+
+type Mock = {
+  port: number
+  url: string
+  shutdown: () => Promise<void>
+  send: (slot: number, type?: string) => void
+}
+
+function spawnMockPubsub(label: string): Promise<Mock> {
+  return new Promise((resolve) => {
+    const sockets = new Set<WebSocket>()
+    const ac = new AbortController()
+    const server = Deno.serve({
+      port: 0,
+      signal: ac.signal,
+      onListen: ({ port }) => {
+        resolve({
+          port,
+          url: `ws://127.0.0.1:${port}/`,
+          async shutdown() {
+            for (const s of sockets) {
+              try {
+                s.close()
+              } catch { /* ignore */ }
+            }
+            ac.abort()
+            await server.finished
+          },
+          send(slot, type = 'firstShredReceived') {
+            const payload = JSON.stringify({
+              jsonrpc: '2.0',
+              method: 'slotsUpdatesNotification',
+              params: {
+                result: { slot, parent: slot - 1, type },
+                subscription: 1,
+              },
+            })
+            for (const s of sockets) {
+              try {
+                s.send(payload)
+              } catch { /* ignore closed */ }
+            }
+          },
+        })
+      },
+    }, (req) => {
+      if (req.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
+        return new Response(`mock ${label}`, { status: 426 })
+      }
+      const { socket, response } = Deno.upgradeWebSocket(req)
+      socket.onopen = () => {
+        sockets.add(socket)
+      }
+      socket.onclose = () => {
+        sockets.delete(socket)
+      }
+      socket.onmessage = () => {/* swallow client subscribe; we drive sends manually */}
+      return response
+    })
+  })
+}
+
+function waitUntil(cond: () => boolean, timeoutMs = 1_000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now()
+    const tick = () => {
+      if (cond()) return resolve()
+      if (Date.now() - start > timeoutMs) return reject(new Error('waitUntil timeout'))
+      setTimeout(tick, 10)
+    }
+    tick()
+  })
+}
+
+Deno.test('SlotFirstShredMultiplex: first-arrival dedup across two sources', async () => {
+  const a = await spawnMockPubsub('a')
+  const b = await spawnMockPubsub('b')
+  try {
+    const mux = new SlotFirstShredMultiplex([a.url, b.url])
+    const received: SlotUpdate[] = []
+    const handle = mux.subscribe((u) => {
+      received.push(u)
+    })
+
+    // Give the multiplex a tick to connect to both upstreams.
+    await waitUntil(() => true, 200) // unconditional small wait
+    await new Promise((r) => setTimeout(r, 250))
+
+    // slot 100: a first, then b (= dup, should be dropped)
+    a.send(100)
+    await new Promise((r) => setTimeout(r, 30))
+    b.send(100)
+
+    // slot 101: only b (= unique)
+    await new Promise((r) => setTimeout(r, 30))
+    b.send(101)
+
+    // slot 102: only a (= unique)
+    await new Promise((r) => setTimeout(r, 30))
+    a.send(102)
+
+    // slot 103: both send roughly simultaneously (= one wins)
+    await new Promise((r) => setTimeout(r, 30))
+    a.send(103)
+    b.send(103)
+
+    await waitUntil(() => received.length >= 4, 1_000)
+    handle.cancel()
+    mux.close()
+
+    const slots = received.map((u) => u.slot).sort((x, y) => x - y)
+    assertEquals(slots, [100, 101, 102, 103], 'each slot delivered exactly once across sources')
+
+    // parent / root sanity (root is approximated as slot-32, parent given by upstream).
+    for (const u of received) {
+      assertEquals(u.parent, u.slot - 1, `parent for slot ${u.slot}`)
+      assertEquals(u.root, Math.max(0, u.slot - 32), `root for slot ${u.slot}`)
+    }
+  } finally {
+    await a.shutdown()
+    await b.shutdown()
+  }
+})
+
+Deno.test('SlotFirstShredMultiplex: ignores non-firstShredReceived event types', async () => {
+  const a = await spawnMockPubsub('a')
+  try {
+    const mux = new SlotFirstShredMultiplex([a.url])
+    const received: SlotUpdate[] = []
+    const handle = mux.subscribe((u) => {
+      received.push(u)
+    })
+
+    await new Promise((r) => setTimeout(r, 250))
+
+    a.send(200, 'completed')
+    a.send(201, 'frozen')
+    a.send(202, 'optimisticConfirmation')
+    a.send(203, 'firstShredReceived') // only this should reach the listener
+
+    await waitUntil(() => received.length >= 1, 1_000)
+    // Give a small buffer to ensure no late deliveries.
+    await new Promise((r) => setTimeout(r, 100))
+    handle.cancel()
+    mux.close()
+
+    assertEquals(received.length, 1, 'only firstShredReceived events are forwarded')
+    assertEquals(received[0].slot, 203)
+  } finally {
+    await a.shutdown()
+  }
+})

--- a/api/rpc-gateway/src/main.ts
+++ b/api/rpc-gateway/src/main.ts
@@ -55,8 +55,13 @@ const YELLOWSTONE_GRPC = Deno.env.get('YELLOWSTONE_GRPC') ?? 'localhost:10000'
 const PUBSUB_WS_URL = Deno.env.get('PUBSUB_WS_URL') ?? 'ws://localhost:7111'
 // Optional overrides for the slotSubscribe upstream.  See WsConfig
 // docstrings in handlers/ws.ts for the latency rationale.
-// Priority: SLOT_FIRST_SHRED_URL > SLOT_MULTIPLEX_URLS > SLOT_PUBSUB_URL
-// > SLOT_BRIDGE_GRPC > falls through to PUBSUB_WS_URL (richat).
+// Priority: SLOT_FIRST_SHRED_MULTIPLEX_URLS > SLOT_FIRST_SHRED_URL >
+// SLOT_MULTIPLEX_URLS > SLOT_PUBSUB_URL > SLOT_BRIDGE_GRPC >
+// falls through to PUBSUB_WS_URL (richat).
+const SLOT_FIRST_SHRED_MULTIPLEX_URLS = (Deno.env.get('SLOT_FIRST_SHRED_MULTIPLEX_URLS') ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter((s) => s.length > 0)
 const SLOT_FIRST_SHRED_URL = Deno.env.get('SLOT_FIRST_SHRED_URL') || undefined
 const SLOT_MULTIPLEX_URLS = (Deno.env.get('SLOT_MULTIPLEX_URLS') ?? '')
   .split(',')
@@ -143,6 +148,9 @@ app.use('*', async (c, next) => {
 const wsHandler = buildWsHandler({
   yellowstoneEndpoint: YELLOWSTONE_GRPC,
   pubsubUrl: PUBSUB_WS_URL,
+  slotFirstShredMultiplexUrls: SLOT_FIRST_SHRED_MULTIPLEX_URLS.length > 0
+    ? SLOT_FIRST_SHRED_MULTIPLEX_URLS
+    : undefined,
   slotFirstShredUrl: SLOT_FIRST_SHRED_URL,
   slotMultiplexUrls: SLOT_MULTIPLEX_URLS.length > 0 ? SLOT_MULTIPLEX_URLS : undefined,
   slotPubsubUrl: SLOT_PUBSUB_URL,


### PR DESCRIPTION
## Summary

Add `SlotFirstShredMultiplex`, the missing two-axis combination of existing slot sources:

- `SlotFirstShredBridge` (PR #373) — 1 URL × `firstShredReceived` (Helius-parity early signal: avg Helius lead +5.6 ms → +2.5 ms on FRA-1, 2026-05-17).
- `SlotMultiplex` (PR #372) — N URLs × standard `slotSubscribe` (jitter smoothing: ERPC win share 6.7 % → 12.8 % with native + richat on FRA-1, 2026-05-17).

Stack both knobs in a single fan-in (subscribe to N upstreams via `slotsUpdatesSubscribe`, filter `firstShredReceived`, first-arrival wins per slot) to accumulate the latency wins of multiple geyser sources at the early-signal cutpoint.

## Configuration

```
SLOT_FIRST_SHRED_MULTIPLEX_URLS=ws://127.0.0.1:7212,ws://127.0.0.1:7111
```

Priority order:

`SLOT_FIRST_SHRED_MULTIPLEX_URLS` > `SLOT_FIRST_SHRED_URL` > `SLOT_MULTIPLEX_URLS` > `SLOT_PUBSUB_URL` > `SLOT_BRIDGE_GRPC` > `PUBSUB_WS_URL` (richat fallback)

## Test plan

- [x] `deno check src/main.ts` — clean
- [x] `deno test --allow-net src/` — 2 tests, both green:
  - `first-arrival dedup across two sources` — overlapping slot events from 2 mock pubsubs, each slot delivered exactly once
  - `ignores non-firstShredReceived event types` — `completed` / `frozen` / `optimisticConfirmation` dropped
- [x] `deno fmt --check` — clean on touched files
- [x] `deno lint` — no new warnings (pre-existing `require-await` on `main.ts:164` and `npm:` import in `slot-bridge.ts`/`yellowstone-bridge.ts` left alone, out of scope)

## Rollout plan

1. Merge.
2. Enable per region via `Environment=SLOT_FIRST_SHRED_MULTIPLEX_URLS=ws://127.0.0.1:7212,ws://127.0.0.1:7111` in the gateway service drop-in.  Each region has both a validator native pubsub on `:7212` and a richat WS on `:7111`.
3. Re-run the 60 s slot race vs Helius beta on FRA-1; expected lead < +2.5 ms and ERPC win share ≥ 25 %.
4. If stable, roll out to other 5 regions.

## Trade-off

Same as `SlotFirstShredBridge`: clients see the slot tick before the bank for that slot is frozen, so a follow-up `getAccountInfo` at the new slot may race the validator's replay.  Opt-in only; safe to leave unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)