### PR TITLE
feat(slv-plugins/rpc-gateway): Phase 0 scaffold (axum + JSON-RPC dispatch shell)

### DIFF
--- a/slv-plugins/Cargo.lock
+++ b/slv-plugins/Cargo.lock
@@ -873,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -881,7 +881,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding 2.3.2",
@@ -892,6 +892,40 @@ dependencies = [
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "base64 0.22.1",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding 2.3.2",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "sha1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -909,6 +943,25 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3134,6 +3187,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -4158,6 +4212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4168,6 +4231,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -4408,6 +4477,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num"
@@ -6023,6 +6101,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6159,6 +6248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6261,6 +6359,23 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slv-rpc-gateway"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.9",
+ "hyper 1.9.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "slv_gtfa_plugin"
@@ -8167,8 +8282,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
- "tungstenite",
+ "tokio-tungstenite 0.28.0",
+ "tungstenite 0.28.0",
  "url 2.5.8",
 ]
 
@@ -10199,6 +10314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if 1.0.4",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10371,8 +10495,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
- "tungstenite",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -10451,7 +10587,7 @@ checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "futures-core",
@@ -10542,6 +10678,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url 2.5.8",
 ]
 
@@ -10587,6 +10724,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -10619,6 +10799,22 @@ dependencies = [
  "thiserror 2.0.18",
  "utf-8",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10777,6 +10973,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/slv-plugins/Cargo.toml
+++ b/slv-plugins/Cargo.toml
@@ -19,6 +19,7 @@
 [workspace]
 resolver = "2"
 members = [
+  "rpc-gateway",
   "slv_gtfa_plugin",
   "slv_transfers_plugin",
 ]
@@ -60,3 +61,14 @@ solana-signature = { version = "3", default-features = false }
 solana-transaction-status = "3"
 
 env_logger = "0.11"
+
+# rpc-gateway extras
+axum = { version = "0.8", default-features = false, features = ["http1", "http2", "json", "ws", "tokio", "tracing"] }
+hyper = { version = "1", features = ["http1", "http2"] }
+serde_json = "1"
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+anyhow = "1"
+regex = "1"

--- a/slv-plugins/README.md
+++ b/slv-plugins/README.md
@@ -5,8 +5,8 @@ Rust workspace for slv-flavoured plugins on top of
 
 Each member crate is a thin extension that emits rows into a
 ClickHouse schema served by [`../api/rpc-gateway`](../api/rpc-gateway).
-Pair them with the gateway's Helius-wire-compatible JSON-RPC methods
-to serve queries that vanilla Solana RPC can't answer.
+Pair them with the gateway's extended JSON-RPC methods to serve queries
+that vanilla Solana RPC can't answer.
 
 ## Crates
 

--- a/slv-plugins/rpc-gateway/Cargo.toml
+++ b/slv-plugins/rpc-gateway/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "slv-rpc-gateway"
+description = "JSON-RPC 2.0 gateway for slv-extended Solana RPC methods + analytics, served from the same workspace as the jetstreamer plugins that emit the backing ClickHouse rows"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "slv-rpc-gateway"
+path = "src/main.rs"
+
+[lib]
+name = "slv_rpc_gateway"
+path = "src/lib.rs"
+
+[dependencies]
+axum.workspace = true
+hyper.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tower-http.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+anyhow.workspace = true
+regex.workspace = true

--- a/slv-plugins/rpc-gateway/README.md
+++ b/slv-plugins/rpc-gateway/README.md
@@ -1,0 +1,76 @@
+# slv-rpc-gateway (Rust)
+
+JSON-RPC 2.0 gateway in Rust.  Successor to the Deno gateway at
+[`../../api/rpc-gateway`](../../api/rpc-gateway).  Lives in the same
+workspace as the jetstreamer plugins (`slv_gtfa_plugin`,
+`slv_transfers_plugin`) so the schemas they emit and the handlers
+that read them ship as one binary set.
+
+## Phase 0 — scaffold (this directory today)
+
+- `tokio` + `axum` HTTP server
+- JSON-RPC 2.0 envelope parsing (`src/jsonrpc.rs`)
+- Dispatcher shell (`src/dispatch.rs`) — recognises the slv-extended
+  method names and returns `METHOD_NOT_FOUND` for everything
+- `/health` endpoint returning `{ok: true}`
+- Listens on `PORT` (default 8889 — matches the Deno gateway, so the
+  load balancer pool can swap binaries without reconfiguration)
+- Structured logging via `tracing-subscriber` with JSON output
+
+## Method roadmap
+
+| Phase | Methods | Backing |
+|---|---|---|
+| 0 (this PR) | dispatch shell + `/health` | — |
+| 1 | `jetTopPrograms`, `jetSlotStats`, `jetTpsTimeseries`, `jetEpochSummary`, `jetProgramStats` | ClickHouse: `program_invocations`, `jetstreamer_slot_status` |
+| 2 | `getTransactionsForAddress` | ClickHouse: `gtfa_tx_mentions` (= `slv_gtfa_plugin`) |
+| 2 | `getTransfersByAddress` | ClickHouse: `token_transfers`, `token_transfers_by_to` (= `slv_transfers_plugin`) |
+| 3 | Pass-through proxy for every other Solana JSON-RPC method | Upstream RPC node |
+| 4 | WebSocket: `transactionSubscribe`/`Unsubscribe`, `slotSubscribe` with the multi-source fan-in, all standard pubsub methods | Yellowstone gRPC + Solana pubsub WS |
+
+## Build
+
+```bash
+cd slv-plugins
+cargo build --release -p slv-rpc-gateway
+./target/release/slv-rpc-gateway
+```
+
+## Run
+
+```bash
+PORT=8889 RUST_LOG=info ./target/release/slv-rpc-gateway
+```
+
+```bash
+curl -fsS http://127.0.0.1:8889/health
+# → {"ok":true}
+
+curl -sS http://127.0.0.1:8889/ \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"jetTopPrograms"}'
+# → {"jsonrpc":"2.0","error":{"code":-32601,"message":"jetTopPrograms: handler not yet ported to Rust gateway"},"id":1}
+```
+
+## Why a Rust rewrite
+
+The Deno gateway is the right shape for business logic but adds
+~0.1–0.5 ms of per-message overhead on the WebSocket fast paths
+where the multiplexed slot stream wins or loses by single-digit
+milliseconds.  Porting the gateway to native gives us:
+
+- per-message overhead in the microseconds range (no V8 GC pause
+  contributing to tail latency)
+- a tighter Cargo workspace with the jetstreamer plugins so a
+  schema change touches one workspace and one `cargo build`
+- shared `clickhouse-rs` Row derive types between the plugins that
+  *write* the rows and the handlers that *read* them
+- predictable resource use (no V8 heap growth) for long-lived
+  WebSocket connections
+
+The Deno gateway stays in production until each method is ported
+and individually cut over via load-balancer routing.
+
+## License
+
+Apache-2.0. See workspace `Cargo.toml`.

--- a/slv-plugins/rpc-gateway/src/dispatch.rs
+++ b/slv-plugins/rpc-gateway/src/dispatch.rs
@@ -1,0 +1,53 @@
+//! JSON-RPC method dispatcher — the spine of the gateway.
+//!
+//! Scaffold scope: switch shell that recognises the slv-extended
+//! method namespaces but returns `METHOD_NOT_FOUND` for everything
+//! until handlers land in follow-up PRs.  See the module-level doc
+//! in `lib.rs` for the full method roadmap.
+
+use crate::jsonrpc::{error_codes, Id, Request, Response};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Methods in the `jet*` namespace (camelCase, prefix `jet` + uppercase
+/// 4th char): `jetTopPrograms`, `jetSlotStats`, `jetTpsTimeseries`,
+/// `jetEpochSummary`, `jetProgramStats`.  Catches typos in this
+/// namespace early instead of forwarding them to the standard-RPC
+/// upstream where they'd surface as a confusing "method not found"
+/// from a different service.
+static JET_NAMESPACE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^jet[A-Z]").expect("static regex compiles"));
+
+pub async fn dispatch(req: Request) -> Response {
+    let id = Id::or_null(req.id.clone());
+    match req.method.as_str() {
+        // Analytics namespace (= ClickHouse-backed, handled locally).
+        "jetTopPrograms" | "jetSlotStats" | "jetTpsTimeseries"
+        | "jetEpochSummary" | "jetProgramStats" => {
+            Response::err(id, error_codes::METHOD_NOT_FOUND, format!(
+                "{}: handler not yet ported to Rust gateway", req.method,
+            ))
+        }
+        // Address-indexed methods (= ClickHouse-backed, handled locally).
+        "getTransactionsForAddress" | "getTransfersByAddress" => {
+            Response::err(id, error_codes::METHOD_NOT_FOUND, format!(
+                "{}: handler not yet ported to Rust gateway", req.method,
+            ))
+        }
+        _ => {
+            // Unknown `jet*` namespace member — short-circuit so it
+            // doesn't get forwarded to the standard-RPC upstream.
+            if JET_NAMESPACE_RE.is_match(&req.method) {
+                return Response::err(id, error_codes::METHOD_NOT_FOUND, format!(
+                    "unknown jet* method: {}", req.method,
+                ));
+            }
+            // Everything else → would be forwarded to the standard
+            // Solana RPC upstream once the proxy lands; until then
+            // return method-not-found to keep behaviour explicit.
+            Response::err(id, error_codes::METHOD_NOT_FOUND, format!(
+                "{}: upstream proxy not yet ported to Rust gateway", req.method,
+            ))
+        }
+    }
+}

--- a/slv-plugins/rpc-gateway/src/dispatch_test.rs
+++ b/slv-plugins/rpc-gateway/src/dispatch_test.rs
@@ -1,0 +1,99 @@
+//! Dispatcher unit tests — verify the scaffold returns the expected
+//! placeholder error shape for every namespace bucket.
+
+#[cfg(test)]
+mod tests {
+    use crate::dispatch::dispatch;
+    use crate::jsonrpc::{error_codes, Id, Request};
+    use serde_json::json;
+
+    fn req(method: &str) -> Request {
+        Request::validate(json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "id": 1,
+        }))
+        .expect("test request envelope is well-formed")
+    }
+
+    #[tokio::test]
+    async fn known_jet_method_returns_handler_pending() {
+        for m in [
+            "jetTopPrograms",
+            "jetSlotStats",
+            "jetTpsTimeseries",
+            "jetEpochSummary",
+            "jetProgramStats",
+        ] {
+            let r = dispatch(req(m)).await;
+            assert!(r.error.is_some(), "{m} should error in scaffold");
+            let e = r.error.unwrap();
+            assert_eq!(e.code, error_codes::METHOD_NOT_FOUND);
+            assert!(e.message.contains("not yet ported"), "got {:?}", e.message);
+        }
+    }
+
+    #[tokio::test]
+    async fn address_indexed_methods_return_handler_pending() {
+        for m in ["getTransactionsForAddress", "getTransfersByAddress"] {
+            let r = dispatch(req(m)).await;
+            let e = r.error.expect("should error");
+            assert_eq!(e.code, error_codes::METHOD_NOT_FOUND);
+            assert!(e.message.contains("not yet ported"));
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_jet_namespace_member_is_caught_early() {
+        let r = dispatch(req("jetCompletelyMadeUp")).await;
+        let e = r.error.expect("should error");
+        assert_eq!(e.code, error_codes::METHOD_NOT_FOUND);
+        assert!(
+            e.message.starts_with("unknown jet* method:"),
+            "expected jet-namespace catch, got {:?}",
+            e.message
+        );
+    }
+
+    #[tokio::test]
+    async fn standard_rpc_method_reports_proxy_pending() {
+        let r = dispatch(req("getBalance")).await;
+        let e = r.error.expect("should error");
+        assert_eq!(e.code, error_codes::METHOD_NOT_FOUND);
+        assert!(e.message.contains("upstream proxy not yet ported"));
+    }
+
+    #[test]
+    fn request_validates_jsonrpc_version_and_method() {
+        // Good envelope.
+        assert!(Request::validate(json!({
+            "jsonrpc": "2.0", "method": "jetTopPrograms", "id": 1,
+        })).is_some());
+        // Missing jsonrpc version.
+        assert!(Request::validate(json!({
+            "method": "jetTopPrograms", "id": 1,
+        })).is_none());
+        // Wrong jsonrpc version.
+        assert!(Request::validate(json!({
+            "jsonrpc": "1.0", "method": "jetTopPrograms", "id": 1,
+        })).is_none());
+        // Empty method.
+        assert!(Request::validate(json!({
+            "jsonrpc": "2.0", "method": "", "id": 1,
+        })).is_none());
+    }
+
+    #[test]
+    fn id_or_null_uses_null_when_missing() {
+        assert!(matches!(Id::or_null(None), Id::Null));
+    }
+
+    #[test]
+    fn notification_detected_when_id_absent() {
+        let req = Request::validate(json!({
+            "jsonrpc": "2.0", "method": "jetTopPrograms",
+        }))
+        .unwrap();
+        assert!(req.is_notification());
+    }
+}

--- a/slv-plugins/rpc-gateway/src/jsonrpc.rs
+++ b/slv-plugins/rpc-gateway/src/jsonrpc.rs
@@ -1,0 +1,108 @@
+//! JSON-RPC 2.0 request / response types used by the dispatcher.
+//!
+//! Scope kept intentionally minimal for the scaffold PR:
+//!   - `Request` parses both `id` (number / string / null) and `params`
+//!     (positional array, by-name object, or absent) without committing
+//!     to per-method param schemas — handlers do their own parsing.
+//!   - `Response` is a serialise-only convenience around `success` /
+//!     `error` shapes; the dispatcher returns `serde_json::Value` so
+//!     each handler can construct the most natural body shape and we
+//!     don't pay for a custom enum until we need one.
+//!
+//! Mirrors the wire shape of `api/rpc-gateway/src/jsonrpc.ts` in the
+//! Deno gateway so a method ported to Rust returns byte-for-byte the
+//! same response the Deno version would have.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// JSON-RPC 2.0 request `id` field.  Spec says it may be a string,
+/// number, or `null`.  We also accept absent (= notification) — the
+/// dispatcher decides whether to reply based on `is_notification`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Id {
+    Num(i64),
+    Str(String),
+    Null,
+}
+
+impl Id {
+    pub fn or_null(opt: Option<Self>) -> Self {
+        opt.unwrap_or(Self::Null)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Request {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<Value>,
+    #[serde(default)]
+    pub id: Option<Id>,
+}
+
+impl Request {
+    /// Per JSON-RPC 2.0: a request without `id` is a *notification*;
+    /// the server MUST process it but MUST NOT respond.
+    pub fn is_notification(&self) -> bool {
+        self.id.is_none()
+    }
+
+    /// Cheap validator — returns Some only when the envelope itself is
+    /// well-formed.  Per-method param validation happens inside each
+    /// handler, where the error message can be specific.
+    pub fn validate(value: Value) -> Option<Self> {
+        let req: Self = serde_json::from_value(value).ok()?;
+        if req.jsonrpc != "2.0" || req.method.is_empty() {
+            return None;
+        }
+        Some(req)
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ErrorObject {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Response {
+    pub jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorObject>,
+    pub id: Id,
+}
+
+impl Response {
+    pub fn ok(id: Id, result: Value) -> Self {
+        Self { jsonrpc: "2.0", result: Some(result), error: None, id }
+    }
+    pub fn err(id: Id, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            result: None,
+            error: Some(ErrorObject { code, message: message.into(), data: None }),
+            id,
+        }
+    }
+}
+
+/// JSON-RPC 2.0 standard error codes plus a couple of project-local
+/// extensions used by the Deno gateway that the Rust port preserves
+/// (`UPSTREAM_ERROR` for failed forward to `of1`, `INTERNAL_ERROR`
+/// for unexpected dispatcher panics).
+pub mod error_codes {
+    pub const PARSE_ERROR: i32 = -32700;
+    pub const INVALID_REQUEST: i32 = -32600;
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    pub const INTERNAL_ERROR: i32 = -32603;
+    pub const UPSTREAM_ERROR: i32 = -32099;
+}

--- a/slv-plugins/rpc-gateway/src/lib.rs
+++ b/slv-plugins/rpc-gateway/src/lib.rs
@@ -1,0 +1,32 @@
+//! `slv-rpc-gateway` — JSON-RPC 2.0 gateway in Rust.
+//!
+//! This crate is the Rust successor to the Deno gateway at
+//! `api/rpc-gateway/`.  It is delivered in phases so each port can
+//! be reviewed in isolation and the Deno version can remain in
+//! production until the Rust version reaches feature parity per
+//! method.
+//!
+//! ## Method roadmap
+//!
+//! | Phase | Methods | Notes |
+//! |---|---|---|
+//! | 0 (this PR) | dispatch shell + `/health` | All RPC methods return `METHOD_NOT_FOUND` |
+//! | 1 | `jetTopPrograms`, `jetSlotStats`, `jetTpsTimeseries`, `jetEpochSummary`, `jetProgramStats` | ClickHouse client + the 5 jet* analytics handlers |
+//! | 2 | `getTransactionsForAddress`, `getTransfersByAddress` | Address-indexed methods backed by jetstreamer plugin tables (`gtfa_tx_mentions`, `token_transfers`, `token_transfers_by_to`) |
+//! | 3 | Pass-through proxy | Forwards every other Solana JSON-RPC method to the upstream RPC node |
+//! | 4 | WebSocket | `transactionSubscribe` / `transactionUnsubscribe` (extended), `slotSubscribe` with the multi-source fan-in fast-path, all standard pubsub methods |
+//!
+//! ## Co-location with the jetstreamer plugins
+//!
+//! The gateway lives in the same Cargo workspace as
+//! `slv_gtfa_plugin` and `slv_transfers_plugin` so the schemas they
+//! emit and the handlers that read them are always built against
+//! the same versions of `clickhouse`, `solana-*`, and the row-
+//! derive types.  Each layer can be changed without re-pinning the
+//! other.
+
+pub mod dispatch;
+pub mod jsonrpc;
+
+#[cfg(test)]
+mod dispatch_test;

--- a/slv-plugins/rpc-gateway/src/main.rs
+++ b/slv-plugins/rpc-gateway/src/main.rs
@@ -1,0 +1,115 @@
+//! `slv-rpc-gateway` binary entry point.
+//!
+//! Scaffold scope: bind an HTTP server, serve `/health`, and accept
+//! JSON-RPC 2.0 requests on `/` (single or batch).  The dispatcher
+//! returns `METHOD_NOT_FOUND` for every method until handlers land
+//! in follow-up PRs — see `lib.rs` for the per-phase roadmap.
+//!
+//! Configured via env:
+//!   PORT                  listen port (default 8889 — matches the
+//!                         Deno gateway so a host can swap binaries
+//!                         without changing the load balancer pool)
+//!   RUST_LOG              tracing-subscriber filter (default `info`)
+
+use std::net::SocketAddr;
+
+use axum::extract::Json;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::Router;
+use serde_json::{json, Value};
+use slv_rpc_gateway::dispatch::dispatch;
+use slv_rpc_gateway::jsonrpc::{error_codes, Id, Request, Response};
+use tower_http::cors::{Any, CorsLayer};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .json()
+        .init();
+
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8889);
+    let addr: SocketAddr = SocketAddr::from(([0, 0, 0, 0], port));
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/", post(rpc_entry))
+        .layer(cors);
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!(addr = %addr, "slv-rpc-gateway listening");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn health() -> impl IntoResponse {
+    (StatusCode::OK, Json(json!({ "ok": true })))
+}
+
+/// JSON-RPC entry point.  Accepts a single request or a batch.
+///
+/// - A request without `id` is a notification — process but do not
+///   respond.  A batch consisting only of notifications returns no
+///   body (HTTP 204).
+/// - An empty batch (`[]`) is answered with a single
+///   `INVALID_REQUEST` error per spec.
+async fn rpc_entry(Json(body): Json<Value>) -> impl IntoResponse {
+    if let Value::Array(items) = body {
+        if items.is_empty() {
+            return Json(serde_json::to_value(Response::err(
+                Id::Null,
+                error_codes::INVALID_REQUEST,
+                "invalid JSON-RPC request",
+            )).expect("error response always serialises")).into_response();
+        }
+        let mut out = Vec::with_capacity(items.len());
+        for item in items {
+            if let Some(resp) = handle_one(item).await {
+                out.push(resp);
+            }
+        }
+        if out.is_empty() {
+            return StatusCode::NO_CONTENT.into_response();
+        }
+        Json(Value::Array(out)).into_response()
+    } else {
+        if let Some(resp) = handle_one(body).await {
+            Json(resp).into_response()
+        } else {
+            StatusCode::NO_CONTENT.into_response()
+        }
+    }
+}
+
+async fn handle_one(raw: Value) -> Option<Value> {
+    let Some(req) = Request::validate(raw) else {
+        return Some(
+            serde_json::to_value(Response::err(
+                Id::Null,
+                error_codes::INVALID_REQUEST,
+                "invalid JSON-RPC request",
+            ))
+            .expect("error response always serialises"),
+        );
+    };
+    let notification = req.is_notification();
+    let resp = dispatch(req).await;
+    if notification {
+        None
+    } else {
+        Some(serde_json::to_value(resp).expect("response always serialises"))
+    }
+}

--- a/slv-plugins/slv_gtfa_plugin/Cargo.toml
+++ b/slv-plugins/slv_gtfa_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slv_gtfa_plugin"
-description = "Jetstreamer plugin that emits per-(tx, mentioned-pubkey) rows for Helius-style getTransactionsForAddress queries"
+description = "Jetstreamer plugin that emits per-(tx, mentioned-pubkey) rows backing the getTransactionsForAddress RPC method"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/slv-plugins/slv_gtfa_plugin/src/lib.rs
+++ b/slv-plugins/slv_gtfa_plugin/src/lib.rs
@@ -1,5 +1,5 @@
 //! `slv-gtfa-plugin` — jetstreamer plugin emitting per-(tx, pubkey) rows
-//! for Helius-style `getTransactionsForAddress` queries.
+//! that back the `getTransactionsForAddress` RPC method.
 //!
 //! anza's three built-in plugins (program-tracking, instruction-tracking,
 //! pubkey-stats) are all aggregations: they collapse counts and lose the
@@ -142,18 +142,16 @@ impl Plugin for SlvGtfaPlugin {
         async move {
             // Skip votes — gTFA users never ask for them and they would
             // dominate row counts on busy slots (>50% of mainnet txs are
-            // vote txs).  Helius gTFA already excludes votes when the
-            // client requests them and the SDK doesn't expose a way to
-            // filter on chain-side for vote-only.
+            // vote txs).
             if tx.is_vote {
                 return Ok(());
             }
 
             // Combine static account_keys + ALT-loaded (writable, readonly)
-            // so cards subscriptions that only show in V0 loaded_addresses
-            // still match the address-scan.  Helius returns transactions
-            // even when the user's account is only referenced via an
-            // address lookup table, so we mirror that.
+            // so addresses that only show in V0 `loaded_addresses` still
+            // match the address-scan — clients expect a transaction to be
+            // returned even when the queried account is only referenced
+            // via an address lookup table.
             let static_keys: &[Address] = match &tx.transaction.message {
                 VersionedMessage::Legacy(msg) => &msg.account_keys,
                 VersionedMessage::V0(msg) => &msg.account_keys,
@@ -175,7 +173,8 @@ impl Plugin for SlvGtfaPlugin {
 
             // Deduplicate by pubkey within this transaction — if the same
             // account appears as both static and ALT-loaded (legal in V0),
-            // emit one row, not two.  Helius treats it as one mention.
+            // emit one row, not two.  Each distinct account counts as one
+            // mention.
             let mut seen = ahash::AHashSet::with_capacity(total_keys);
             let mut batch = Vec::with_capacity(total_keys);
             for pk in static_keys

--- a/slv-plugins/slv_transfers_plugin/Cargo.toml
+++ b/slv-plugins/slv_transfers_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slv_transfers_plugin"
-description = "Jetstreamer plugin that emits per-transfer rows for Helius-style getTransfersByAddress queries"
+description = "Jetstreamer plugin that emits per-transfer rows backing the getTransfersByAddress RPC method"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/slv-plugins/slv_transfers_plugin/src/lib.rs
+++ b/slv-plugins/slv_transfers_plugin/src/lib.rs
@@ -1,5 +1,5 @@
 //! `slv-transfers-plugin` — jetstreamer plugin emitting per-transfer rows
-//! for Helius-style `getTransfersByAddress` queries.
+//! that back the `getTransfersByAddress` RPC method.
 //!
 //! Phase 1 scope (this file): SPL Token v1 `Transfer` (3) and
 //! `TransferChecked` (12) **top-level instructions only**.  Phase 3 will
@@ -243,9 +243,9 @@ impl Plugin for SlvTransfersPlugin {
             // Walk top-level instructions AND inner instructions (CPIs).
             // Inner-ix coverage is the dominant Phase 3 gap-closer: most
             // DEX/router transfers are emitted as CPIs from a top-level
-            // router/aggregator ix, not as top-level Token.Transfer.  In
-            // the 2026-05-14 Helius-diff probe, top-level-only coverage
-            // was 15.5%; adding inner-ix is expected to push it >80%.
+            // router/aggregator ix, not as top-level Token.Transfer.  A
+            // 2026-05-14 coverage probe found top-level-only coverage was
+            // 15.5%; adding inner-ix is expected to push it >80%.
             let instructions = match &tx.transaction.message {
                 VersionedMessage::Legacy(msg) => &msg.instructions,
                 VersionedMessage::V0(msg) => &msg.instructions,
@@ -292,8 +292,8 @@ impl Plugin for SlvTransfersPlugin {
             // 2. Inner instructions per top-level ix.  `group.index` is
             //    the parent top-level ix index; `pos` within
             //    `group.instructions` is what we store as `inner_index`.
-            //    `stack_height` exists but isn't part of Helius's wire
-            //    format, so we ignore it (Helius reports a flat
+            //    `stack_height` exists but isn't part of the wire format
+            //    we expose, so we ignore it (the API reports a flat
             //    `innerInstructionIdx`).
             for group in inner_groups {
                 let parent_idx = group.index as u16;


### PR DESCRIPTION
## Summary

First Rust crate of the gateway rewrite. Lives in `slv-plugins/rpc-gateway/`, alongside the two jetstreamer plugins already in this workspace, so the schemas they emit and the handlers that read them are always built against the same `clickhouse`, `solana-*`, and Row-derive versions.

## What this PR ships

- `slv-rpc-gateway` binary that binds an HTTP server (default port `8889`, matching the existing Deno gateway so a host can swap binaries without load-balancer reconfiguration)
- `/health` returning `{ok: true}`
- JSON-RPC 2.0 envelope parser (`src/jsonrpc.rs`)
- Dispatcher shell (`src/dispatch.rs`) returning `METHOD_NOT_FOUND` with explicit "handler not yet ported" until follow-up PRs
- `jet*` namespace catch (unknown member → useful error instead of forwarding upstream)
- Structured JSON logging via `tracing-subscriber`
- Batch + notification + empty-batch + invalid-envelope handling per JSON-RPC 2.0 spec
- 7 unit tests, all green under `cargo test`

## Roadmap (= follow-up PRs)

| Phase | Methods | Scope |
|---|---|---|
| 0 (this) | dispatch shell + /health | — |
| 1 | the 5 `jet*` analytics handlers | ClickHouse client + per-method SQL |
| 2 | `getTransactionsForAddress`, `getTransfersByAddress` | address-indexed tables |
| 3 | pass-through proxy | upstream RPC node |
| 4 | WebSocket | Yellowstone gRPC + Solana pubsub WS |

The Deno gateway at `api/rpc-gateway/` stays in production until each method is ported and individually cut over via load-balancer routing.

## Also in this PR

Neutralised vendor name in the docstrings of `slv_gtfa_plugin` and `slv_transfers_plugin` (and the workspace `README.md`) so the public-visible text describes the RPC methods they back without naming a specific commercial RPC provider.

## Verified

- `cargo check -p slv-rpc-gateway` clean
- `cargo test -p slv-rpc-gateway` — 7 passed, 0 failed
- Local smoke test against the built binary:
  - `/health` → `{"ok":true}` (HTTP 200)
  - `getBalance` → `upstream proxy not yet ported` (-32601)
  - `jetUnknownFoo` → `unknown jet* method: jetUnknownFoo` (-32601)
  - `jetTopPrograms` → `handler not yet ported` (-32601)
  - batch of two known methods → array of two errors
  - empty batch `[]` → single `INVALID_REQUEST` (-32600)
  - notification (no `id`) → HTTP 204 (no body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)