### PR TITLE
feat(slv-plugins/rpc-gateway): Phase 4a — WebSocket scaffold + standard pubsub passthrough

### DIFF
--- a/slv-plugins/Cargo.lock
+++ b/slv-plugins/Cargo.lock
@@ -6379,6 +6379,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.27.0",
  "tower 0.5.3",
  "tower-http",
  "tracing",
@@ -10494,6 +10495,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.27.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -10789,6 +10806,25 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "tungstenite"

--- a/slv-plugins/Cargo.toml
+++ b/slv-plugins/Cargo.toml
@@ -79,3 +79,4 @@ base64 = "0.22"
 url = "2"
 futures = "0.3"
 parking_lot = "0.12"
+tokio-tungstenite = { version = "0.27", default-features = false, features = ["rustls-tls-webpki-roots", "connect"] }

--- a/slv-plugins/rpc-gateway/Cargo.toml
+++ b/slv-plugins/rpc-gateway/Cargo.toml
@@ -34,3 +34,4 @@ base64.workspace = true
 url.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
+tokio-tungstenite.workspace = true

--- a/slv-plugins/rpc-gateway/src/dispatch.rs
+++ b/slv-plugins/rpc-gateway/src/dispatch.rs
@@ -16,6 +16,7 @@ use crate::clickhouse::ClickHouseClient;
 use crate::handlers::{gtfa::GtfaHandlers, jet, transfers::TransfersHandlers};
 use crate::jsonrpc::{error_codes, Id, Request, Response};
 use crate::of1::Of1Client;
+use crate::ws::WsConfig;
 
 /// Methods in the `jet*` namespace (camelCase, prefix `jet` + uppercase
 /// 4th char): `jetTopPrograms`, `jetSlotStats`, `jetTpsTimeseries`,
@@ -29,17 +30,26 @@ static JET_NAMESPACE_RE: LazyLock<Regex> =
 pub struct Gateway {
     pub ch: Arc<ClickHouseClient>,
     pub of1: Arc<Of1Client>,
+    /// WebSocket-side configuration consumed by `crate::ws`.  Owned
+    /// here so the WebSocket handler can borrow it through the same
+    /// `Arc<Gateway>` Axum injects via `State`.
+    pub ws: WsConfig,
     gtfa: GtfaHandlers,
     transfers: TransfersHandlers,
 }
 
 impl Gateway {
-    pub fn new(ch: ClickHouseClient, of1: Of1Client, full_concurrency: usize) -> Self {
+    pub fn new(
+        ch: ClickHouseClient,
+        of1: Of1Client,
+        full_concurrency: usize,
+        ws: WsConfig,
+    ) -> Self {
         let ch = Arc::new(ch);
         let of1 = Arc::new(of1);
         let gtfa = GtfaHandlers::new(ch.clone(), of1.clone(), full_concurrency);
         let transfers = TransfersHandlers::new(ch.clone());
-        Self { ch, of1, gtfa, transfers }
+        Self { ch, of1, ws, gtfa, transfers }
     }
 
     pub async fn dispatch(&self, req: Request) -> Response {

--- a/slv-plugins/rpc-gateway/src/dispatch_test.rs
+++ b/slv-plugins/rpc-gateway/src/dispatch_test.rs
@@ -10,7 +10,12 @@ mod tests {
     use crate::dispatch::Gateway;
     use crate::jsonrpc::{error_codes, Request};
     use crate::of1::{Of1Client, Of1Config};
+    use crate::ws::WsConfig;
     use serde_json::json;
+
+    fn default_ws_cfg() -> WsConfig {
+        WsConfig { pubsub_url: "ws://127.0.0.1:1".into() }
+    }
 
     fn req(method: &str) -> Request {
         Request::validate(json!({
@@ -28,7 +33,7 @@ mod tests {
             .expect("default ch config builds");
         let of1 = Of1Client::new(Of1Config::default())
             .expect("default of1 config builds");
-        Gateway::new(ch, of1, 20)
+        Gateway::new(ch, of1, 20, default_ws_cfg())
     }
 
     #[tokio::test]
@@ -88,7 +93,7 @@ mod tests {
         let (url, server) = spawn_mock_upstream(canned.clone()).await;
         let ch = ClickHouseClient::new(ClickHouseConfig::default()).unwrap();
         let of1 = Of1Client::new(Of1Config { url, ..Of1Config::default() }).unwrap();
-        let gw = Gateway::new(ch, of1, 20);
+        let gw = Gateway::new(ch, of1, 20, default_ws_cfg());
         let req = Request::validate(json!({
             "jsonrpc": "2.0", "method": "getBalance", "id": 7,
             "params": ["SomeAddress"],

--- a/slv-plugins/rpc-gateway/src/lib.rs
+++ b/slv-plugins/rpc-gateway/src/lib.rs
@@ -13,8 +13,10 @@
 //! | 1 | `jetTopPrograms`, `jetSlotStats`, `jetTpsTimeseries`, `jetEpochSummary`, `jetProgramStats` | merged |
 //! | 2a | `getTransactionsForAddress` | merged |
 //! | 2b | `getTransfersByAddress` | merged |
-//! | 3 | Pass-through proxy for every other Solana JSON-RPC method | this PR |
-//! | 4 | WebSocket: `transactionSubscribe`/`Unsubscribe`, `slotSubscribe` multiplex, standard pubsub | next |
+//! | 3 | Pass-through proxy for every other Solana JSON-RPC method | merged |
+//! | 4a | WebSocket scaffold + standard pubsub passthrough | this PR |
+//! | 4b | `slotSubscribe` multi-source fan-in fast paths | next |
+//! | 4c | `transactionSubscribe` / `transactionUnsubscribe` via Yellowstone gRPC | next |
 //!
 //! ## Workspace co-location
 //!
@@ -29,6 +31,7 @@ pub mod dispatch;
 pub mod handlers;
 pub mod jsonrpc;
 pub mod of1;
+pub mod ws;
 
 #[cfg(test)]
 mod dispatch_test;

--- a/slv-plugins/rpc-gateway/src/main.rs
+++ b/slv-plugins/rpc-gateway/src/main.rs
@@ -16,6 +16,9 @@
 //!   GTFA_FULL_CONCURRENCY max parallel of1 `getTransaction` calls when
 //!                         `transactionDetails: "full"` is requested
 //!                         (default 20)
+//!   PUBSUB_WS_URL         upstream Solana pubsub WebSocket for
+//!                         standard pubsub methods (default
+//!                         `ws://localhost:7111`)
 //!   RUST_LOG              tracing-subscriber filter (default `info`)
 
 use std::net::SocketAddr;
@@ -25,13 +28,15 @@ use std::time::Duration;
 use axum::extract::{Json, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::{get, post};
+use axum::routing::get;
 use axum::Router;
 use serde_json::{json, Value};
+use axum::http::HeaderMap;
 use slv_rpc_gateway::clickhouse::{ClickHouseClient, ClickHouseConfig};
 use slv_rpc_gateway::dispatch::Gateway;
 use slv_rpc_gateway::jsonrpc::{error_codes, Id, Request, Response};
 use slv_rpc_gateway::of1::{Of1Client, Of1Config};
+use slv_rpc_gateway::ws::{ws_route, WsConfig};
 use tower_http::cors::{Any, CorsLayer};
 
 #[tokio::main]
@@ -78,7 +83,11 @@ async fn main() -> anyhow::Result<()> {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(20);
-    let gateway = Arc::new(Gateway::new(ch, of1, full_concurrency));
+
+    let ws_cfg = WsConfig {
+        pubsub_url: env_or("PUBSUB_WS_URL", "ws://localhost:7111"),
+    };
+    let gateway = Arc::new(Gateway::new(ch, of1, full_concurrency, ws_cfg));
 
     let cors = CorsLayer::new()
         .allow_origin(Any)
@@ -87,7 +96,12 @@ async fn main() -> anyhow::Result<()> {
 
     let app = Router::new()
         .route("/health", get(health))
-        .route("/", post(rpc_entry))
+        .route("/ws", get(ws_route))
+        // Many SDKs hard-code `wss://<host>/` (no path) for pubsub.
+        // Route GET / through the WebSocket upgrade only when the
+        // client actually requests one; otherwise the JSON-RPC POST
+        // handler takes over via the entry below.
+        .route("/", get(root_get).post(rpc_entry))
         .with_state(gateway)
         .layer(cors);
 
@@ -103,6 +117,25 @@ fn env_or(key: &str, fallback: &str) -> String {
 
 async fn health() -> impl IntoResponse {
     (StatusCode::OK, Json(json!({ "ok": true })))
+}
+
+/// GET / — dispatch to the WebSocket upgrade when a real WS handshake
+/// is requested, otherwise 404 so health probes and accidental
+/// browser loads aren't surprised by a hijacked GET.
+async fn root_get(
+    headers: HeaderMap,
+    ws: axum::extract::WebSocketUpgrade,
+    state: State<Arc<Gateway>>,
+) -> axum::response::Response {
+    if headers
+        .get("upgrade")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.eq_ignore_ascii_case("websocket"))
+        .unwrap_or(false)
+    {
+        return ws_route(ws, state).await.into_response();
+    }
+    StatusCode::NOT_FOUND.into_response()
 }
 
 async fn rpc_entry(

--- a/slv-plugins/rpc-gateway/src/ws/mod.rs
+++ b/slv-plugins/rpc-gateway/src/ws/mod.rs
@@ -1,0 +1,211 @@
+//! WebSocket entry point for the gateway.  Phase 4a — minimal viable
+//! WebSocket surface so clients that hard-code `wss://<gateway>/`
+//! get the standard Solana pubsub methods working.
+//!
+//! Routed methods (Phase 4a):
+//!
+//!   - standard Solana JSON-RPC pubsub methods (`accountSubscribe`,
+//!     `logsSubscribe`, `programSubscribe`, `signatureSubscribe`,
+//!     `slotSubscribe`, `slotsUpdatesSubscribe`, `blockSubscribe`,
+//!     `voteSubscribe`, `rootSubscribe`, etc.) — forwarded verbatim
+//!     to an upstream Solana-pubsub-compatible WebSocket
+//!
+//!   - `transactionSubscribe` / `transactionUnsubscribe`
+//!     (extended-API) — return `METHOD_NOT_FOUND` until Phase 4c
+//!     ports the gRPC bridge
+//!
+//!   - multi-source `slotSubscribe` (= the latency-tuned variant
+//!     from `api/rpc-gateway`) — also Phase 4b
+//!
+//! Per-connection state stays small: one upstream WebSocket is
+//! lazily opened on the first standard-pubsub method and shared by
+//! every subscription that client makes; closing the inbound
+//! WebSocket tears everything down.
+
+pub mod pubsub_forward;
+
+#[cfg(test)]
+mod ws_test;
+
+use std::sync::Arc;
+
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::response::IntoResponse;
+use futures::stream::{SplitSink, SplitStream, StreamExt};
+use futures::SinkExt;
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::dispatch::Gateway;
+use crate::jsonrpc::{error_codes, Id, Request, Response};
+use crate::ws::pubsub_forward::PubsubForward;
+
+/// Methods Solana clients call against the validator's native
+/// pubsub endpoint.  Forwarded verbatim to the upstream WebSocket
+/// configured by `PUBSUB_WS_URL`.  Order matches the Deno gateway
+/// for grep-ability.
+const STANDARD_PUBSUB_METHODS: &[&str] = &[
+    "accountSubscribe",
+    "accountUnsubscribe",
+    "logsSubscribe",
+    "logsUnsubscribe",
+    "programSubscribe",
+    "programUnsubscribe",
+    "signatureSubscribe",
+    "signatureUnsubscribe",
+    "slotSubscribe",
+    "slotUnsubscribe",
+    "slotsUpdatesSubscribe",
+    "slotsUpdatesUnsubscribe",
+    "blockSubscribe",
+    "blockUnsubscribe",
+    "voteSubscribe",
+    "voteUnsubscribe",
+    "rootSubscribe",
+    "rootUnsubscribe",
+];
+
+#[derive(Clone)]
+pub struct WsConfig {
+    /// `ws://…` upstream Solana pubsub endpoint (typically richat
+    /// on the same host).  Used as the destination for every
+    /// standard pubsub method until Phase 4b adds the multi-source
+    /// slot fast-path.
+    pub pubsub_url: String,
+}
+
+/// Axum handler for `GET /ws` (and the `/` alias when a real
+/// WebSocket upgrade is requested).  Hands the upgraded socket off
+/// to `handle_socket` which owns the per-connection state.
+pub async fn ws_route(
+    ws: WebSocketUpgrade,
+    State(gateway): State<Arc<Gateway>>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, gateway))
+}
+
+async fn handle_socket(socket: WebSocket, gateway: Arc<Gateway>) {
+    let (sink, stream) = socket.split();
+    // mpsc gives both the inbound-message loop and the upstream
+    // forwarder a way to enqueue outgoing frames without contending
+    // for the sink directly.
+    let (tx, rx) = mpsc::unbounded_channel::<Message>();
+    let sender_task = tokio::spawn(client_sender(sink, rx));
+    receive_loop(stream, tx, gateway).await;
+    sender_task.abort();
+}
+
+async fn client_sender(
+    mut sink: SplitSink<WebSocket, Message>,
+    mut rx: mpsc::UnboundedReceiver<Message>,
+) {
+    while let Some(msg) = rx.recv().await {
+        if sink.send(msg).await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn receive_loop(
+    mut stream: SplitStream<WebSocket>,
+    tx: mpsc::UnboundedSender<Message>,
+    gateway: Arc<Gateway>,
+) {
+    let mut pubsub: Option<PubsubForward> = None;
+    while let Some(msg) = stream.next().await {
+        let Ok(msg) = msg else { break };
+        let text = match msg {
+            Message::Text(t) => t.to_string(),
+            Message::Binary(b) => match std::str::from_utf8(&b) {
+                Ok(s) => s.to_owned(),
+                Err(_) => continue,
+            },
+            Message::Ping(p) => {
+                let _ = tx.send(Message::Pong(p));
+                continue;
+            }
+            Message::Pong(_) => continue,
+            Message::Close(_) => break,
+        };
+        handle_text(&text, &tx, &mut pubsub, &gateway).await;
+    }
+}
+
+async fn handle_text(
+    text: &str,
+    tx: &mpsc::UnboundedSender<Message>,
+    pubsub: &mut Option<PubsubForward>,
+    gateway: &Arc<Gateway>,
+) {
+    let body: Value = match serde_json::from_str(text) {
+        Ok(v) => v,
+        Err(_) => {
+            send_response(
+                tx,
+                Response::err(Id::Null, error_codes::PARSE_ERROR, "invalid JSON"),
+            );
+            return;
+        }
+    };
+    let Some(req) = Request::validate(body) else {
+        send_response(
+            tx,
+            Response::err(
+                Id::Null,
+                error_codes::INVALID_REQUEST,
+                "invalid JSON-RPC request",
+            ),
+        );
+        return;
+    };
+    let id = Id::or_null(req.id.clone());
+
+    match req.method.as_str() {
+        // Phase 4c will land the gRPC bridge that backs this; for now
+        // tell the client it's unsupported so they can fall back.
+        "transactionSubscribe" | "transactionUnsubscribe" => {
+            send_response(
+                tx,
+                Response::err(
+                    id,
+                    error_codes::METHOD_NOT_FOUND,
+                    format!("{}: handler not yet ported to Rust gateway", req.method),
+                ),
+            );
+        }
+        other if STANDARD_PUBSUB_METHODS.contains(&other) => {
+            let forward = ensure_pubsub(pubsub, gateway, tx.clone());
+            forward.send(text.to_owned());
+        }
+        _ => {
+            send_response(
+                tx,
+                Response::err(
+                    id,
+                    error_codes::METHOD_NOT_FOUND,
+                    format!("unsupported WS method: {}", req.method),
+                ),
+            );
+        }
+    }
+}
+
+fn ensure_pubsub<'a>(
+    slot: &'a mut Option<PubsubForward>,
+    gateway: &Arc<Gateway>,
+    tx: mpsc::UnboundedSender<Message>,
+) -> &'a PubsubForward {
+    if slot.is_none() {
+        *slot = Some(PubsubForward::new(gateway.ws.pubsub_url.clone(), tx));
+    }
+    slot.as_ref().expect("populated above")
+}
+
+fn send_response(tx: &mpsc::UnboundedSender<Message>, resp: Response) {
+    let raw = match serde_json::to_string(&resp) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let _ = tx.send(Message::Text(raw.into()));
+}

--- a/slv-plugins/rpc-gateway/src/ws/pubsub_forward.rs
+++ b/slv-plugins/rpc-gateway/src/ws/pubsub_forward.rs
@@ -1,0 +1,123 @@
+//! Per-client WebSocket bridge to an upstream Solana JSON-RPC
+//! pubsub endpoint.  One outbound connection per client; lazily
+//! opened on the first standard pubsub method the client sends.
+//!
+//! Inbound (`PubsubForward::send`) → upstream; upstream → inbound
+//! mpsc channel that feeds the client sender task.  Buffered until
+//! the upstream handshake completes.
+
+use std::sync::Arc;
+
+use axum::extract::ws::Message;
+use futures::stream::StreamExt;
+use futures::SinkExt;
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
+
+pub struct PubsubForward {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    state: Mutex<State>,
+}
+
+enum State {
+    Connecting { buffered: Vec<String> },
+    Open { tx: mpsc::UnboundedSender<String> },
+    Closed,
+}
+
+impl PubsubForward {
+    pub fn new(upstream_url: String, client_tx: mpsc::UnboundedSender<Message>) -> Self {
+        let inner = Arc::new(Inner {
+            state: Mutex::new(State::Connecting { buffered: Vec::new() }),
+        });
+        tokio::spawn(connect_loop(upstream_url, inner.clone(), client_tx));
+        Self { inner }
+    }
+
+    /// Forward one frame to the upstream.  Buffers if upstream isn't
+    /// open yet.  Silently drops once the upstream is closed.
+    pub fn send(&self, raw: String) {
+        let mut guard = self.inner.state.lock();
+        match &mut *guard {
+            State::Connecting { buffered } => buffered.push(raw),
+            State::Open { tx } => {
+                if tx.send(raw).is_err() {
+                    *guard = State::Closed;
+                }
+            }
+            State::Closed => {}
+        }
+    }
+}
+
+async fn connect_loop(
+    upstream_url: String,
+    inner: Arc<Inner>,
+    client_tx: mpsc::UnboundedSender<Message>,
+) {
+    let connect_result = tokio_tungstenite::connect_async(&upstream_url).await;
+    let (mut sink, mut stream) = match connect_result {
+        Ok((ws, _resp)) => ws.split(),
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                url = %upstream_url,
+                "pubsub_upstream_connect_failed",
+            );
+            *inner.state.lock() = State::Closed;
+            return;
+        }
+    };
+
+    // Drain anything the client queued while we were handshaking, then
+    // transition to Open so subsequent `send`s go straight through.
+    let (up_tx, mut up_rx) = mpsc::unbounded_channel::<String>();
+    {
+        let mut guard = inner.state.lock();
+        if let State::Connecting { buffered } = std::mem::replace(
+            &mut *guard,
+            State::Open { tx: up_tx.clone() },
+        ) {
+            for raw in buffered {
+                if up_tx.send(raw).is_err() {
+                    *guard = State::Closed;
+                    return;
+                }
+            }
+        }
+    }
+
+    let writer = async move {
+        while let Some(raw) = up_rx.recv().await {
+            if sink.send(TungsteniteMessage::Text(raw.into())).await.is_err() {
+                break;
+            }
+        }
+    };
+    let reader = async move {
+        while let Some(msg) = stream.next().await {
+            let Ok(msg) = msg else { break };
+            let frame = match msg {
+                TungsteniteMessage::Text(t) => Message::Text(t.to_string().into()),
+                TungsteniteMessage::Binary(b) => Message::Binary(b.to_vec().into()),
+                TungsteniteMessage::Ping(p) => Message::Ping(p.to_vec().into()),
+                TungsteniteMessage::Pong(p) => Message::Pong(p.to_vec().into()),
+                TungsteniteMessage::Close(_) => break,
+                TungsteniteMessage::Frame(_) => continue,
+            };
+            if client_tx.send(frame).is_err() {
+                break;
+            }
+        }
+    };
+
+    tokio::select! {
+        _ = writer => {},
+        _ = reader => {},
+    }
+    *inner.state.lock() = State::Closed;
+}

--- a/slv-plugins/rpc-gateway/src/ws/ws_test.rs
+++ b/slv-plugins/rpc-gateway/src/ws/ws_test.rs
@@ -1,0 +1,125 @@
+//! WS handler integration test.  Spins a mock pubsub upstream
+//! (tokio-tungstenite) and a real gateway server (axum on
+//! 127.0.0.1:0), connects a real WebSocket client, sends
+//! `slotSubscribe`, and asserts the canned upstream response
+//! makes it back to the client.
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
+    use axum::routing::get;
+    use axum::Router;
+    use futures::SinkExt;
+    use futures::StreamExt;
+    use serde_json::{json, Value};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::Message as TM;
+
+    use crate::clickhouse::{ClickHouseClient, ClickHouseConfig};
+    use crate::dispatch::Gateway;
+    use crate::of1::{Of1Client, Of1Config};
+    use crate::ws::{ws_route, WsConfig};
+
+    /// Trivial Solana-pubsub-compatible mock: accepts the WS upgrade,
+    /// waits for one `slotSubscribe`, replies with the canned
+    /// envelope verbatim.
+    async fn spawn_mock_pubsub(canned_subscribe_reply: Value) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (sock, _) = listener.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(sock).await.unwrap();
+            let (mut sink, mut stream) = ws.split();
+            if let Some(Ok(_first)) = stream.next().await {
+                let raw = serde_json::to_string(&canned_subscribe_reply).unwrap();
+                let _ = sink.send(TM::Text(raw.into())).await;
+            }
+        });
+        format!("ws://{addr}/")
+    }
+
+    async fn spawn_gateway(pubsub_url: String) -> String {
+        let ch = ClickHouseClient::new(ClickHouseConfig::default()).unwrap();
+        let of1 = Of1Client::new(Of1Config::default()).unwrap();
+        let gw = Arc::new(Gateway::new(
+            ch,
+            of1,
+            20,
+            WsConfig { pubsub_url },
+        ));
+        let app = Router::new().route("/ws", get(ws_route)).with_state(gw);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("ws://{addr}/ws")
+    }
+
+    #[tokio::test]
+    async fn ws_forwards_standard_pubsub_to_upstream() {
+        let canned = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": 12345,
+        });
+        let pubsub_url = spawn_mock_pubsub(canned.clone()).await;
+        let gateway_url = spawn_gateway(pubsub_url).await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(&gateway_url).await.unwrap();
+        ws.send(TM::Text(
+            json!({"jsonrpc": "2.0", "id": 1, "method": "slotSubscribe"})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(2), ws.next())
+            .await
+            .expect("upstream reply within timeout")
+            .expect("got a frame")
+            .expect("frame was ok");
+        let body = match frame {
+            TM::Text(t) => serde_json::from_str::<Value>(&t).unwrap(),
+            other => panic!("unexpected frame: {other:?}"),
+        };
+        assert_eq!(body, canned, "client should receive the canned upstream reply verbatim");
+    }
+
+    #[tokio::test]
+    async fn ws_rejects_transaction_subscribe_until_phase4c() {
+        // Phase 4c lands the gRPC bridge; until then the gateway
+        // tells the client transactionSubscribe is not yet ported.
+        let pubsub_url = spawn_mock_pubsub(json!({})).await;
+        let gateway_url = spawn_gateway(pubsub_url).await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(&gateway_url).await.unwrap();
+        ws.send(TM::Text(
+            json!({
+                "jsonrpc": "2.0", "id": 5, "method": "transactionSubscribe",
+                "params": [{ "vote": false }],
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(2), ws.next())
+            .await
+            .expect("server reply within timeout")
+            .unwrap()
+            .unwrap();
+        let body = match frame {
+            TM::Text(t) => serde_json::from_str::<Value>(&t).unwrap(),
+            other => panic!("unexpected frame: {other:?}"),
+        };
+        let err = body.get("error").expect("expected error envelope");
+        assert_eq!(err.get("code").unwrap().as_i64().unwrap(), -32601);
+        assert!(
+            err.get("message").unwrap().as_str().unwrap().contains("not yet ported"),
+            "got {body:?}",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

First piece of the WebSocket port. Lands the WS upgrade + the standard Solana pubsub forwarder so a client connecting to `wss://<gateway>/ws` or `wss://<gateway>/` gets every `*Subscribe` / `*Unsubscribe` method the validator's native pubsub serves (accountSubscribe, programSubscribe, logsSubscribe, slotSubscribe, etc.).

## What this PR ships

### `ws/mod.rs`

`ws_route` axum handler performs the WS upgrade. Per-connection state: mpsc to the client sender task + lazy `PubsubForward` + receive loop that routes on `method`:
- standard pubsub set → `PubsubForward::send`
- `transactionSubscribe` / `transactionUnsubscribe` → METHOD_NOT_FOUND with "not yet ported" (Phase 4c lands the gRPC bridge)
- anything else → method-not-found

Ping/Pong/Close handled inline.

### `ws/pubsub_forward.rs`

Per-client outbound WebSocket via `tokio-tungstenite` to `PUBSUB_WS_URL`. Buffers frames during the handshake; drains and transitions to Open. Bi-directional pump (writer task client→upstream, reader task upstream→client mpsc). Either side closing transitions to Closed and silently drops further frames.

### `dispatch.rs` + `main.rs`

`Gateway::new` takes a fourth `WsConfig` argument so the WS handler borrows config through the same `Arc<Gateway>` Axum injects via `State`.

New env: `PUBSUB_WS_URL` (default `ws://localhost:7111`).

New routes:
- `GET /ws` → WebSocket upgrade
- `GET /` → WebSocket upgrade only when `Upgrade: websocket` header present (otherwise 404, matching the Deno gateway)

## Verified

- `cargo check -p slv-rpc-gateway` clean
- `cargo test -p slv-rpc-gateway` — **33 passed, 0 failed**
  - Earlier phases' tests (31)
  - `ws_test::ws_forwards_standard_pubsub_to_upstream` — full end-to-end: mock pubsub upstream + real gateway server + real client; `slotSubscribe` sent, canned upstream response delivered verbatim
  - `ws_test::ws_rejects_transaction_subscribe_until_phase4c` — placeholder METHOD_NOT_FOUND surface

## Out of scope

- Phase 4b: `slotSubscribe` multi-source fan-in fast paths (`SLOT_FIRST_SHRED_MULTIPLEX_URLS` & friends)
- Phase 4c: `transactionSubscribe` / `transactionUnsubscribe` via Yellowstone gRPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)