### PR TITLE
feat(slv-plugins/rpc-gateway): Phase 4b — multi-source slotSubscribe fast paths

### DIFF
--- a/slv-plugins/rpc-gateway/src/dispatch.rs
+++ b/slv-plugins/rpc-gateway/src/dispatch.rs
@@ -16,6 +16,7 @@ use crate::clickhouse::ClickHouseClient;
 use crate::handlers::{gtfa::GtfaHandlers, jet, transfers::TransfersHandlers};
 use crate::jsonrpc::{error_codes, Id, Request, Response};
 use crate::of1::Of1Client;
+use crate::ws::slot_source::SlotPubsubMultiplex;
 use crate::ws::WsConfig;
 
 /// Methods in the `jet*` namespace (camelCase, prefix `jet` + uppercase
@@ -30,12 +31,25 @@ static JET_NAMESPACE_RE: LazyLock<Regex> =
 pub struct Gateway {
     pub ch: Arc<ClickHouseClient>,
     pub of1: Arc<Of1Client>,
-    /// WebSocket-side configuration consumed by `crate::ws`.  Owned
-    /// here so the WebSocket handler can borrow it through the same
-    /// `Arc<Gateway>` Axum injects via `State`.
     pub ws: WsConfig,
+    /// Optional `slotSubscribe` upstream singletons, owned per-
+    /// process so multiple WS clients share one set of outbound
+    /// connections.  Cascade priority (highest first) is enforced
+    /// in `ws::receive_loop`.
+    pub slot_first_shred_multi: Option<Arc<SlotPubsubMultiplex>>,
+    pub slot_first_shred: Option<Arc<SlotPubsubMultiplex>>,
+    pub slot_multiplex: Option<Arc<SlotPubsubMultiplex>>,
     gtfa: GtfaHandlers,
     transfers: TransfersHandlers,
+}
+
+#[derive(Default)]
+pub struct GatewayBuilder {
+    pub full_concurrency: usize,
+    pub ws: Option<WsConfig>,
+    pub slot_first_shred_multiplex_urls: Vec<String>,
+    pub slot_first_shred_url: Option<String>,
+    pub slot_multiplex_urls: Vec<String>,
 }
 
 impl Gateway {
@@ -45,11 +59,44 @@ impl Gateway {
         full_concurrency: usize,
         ws: WsConfig,
     ) -> Self {
+        Self::with_slot_sources(ch, of1, ws, GatewayBuilder {
+            full_concurrency,
+            ws: None,
+            ..GatewayBuilder::default()
+        })
+    }
+
+    pub fn with_slot_sources(
+        ch: ClickHouseClient,
+        of1: Of1Client,
+        ws: WsConfig,
+        builder: GatewayBuilder,
+    ) -> Self {
         let ch = Arc::new(ch);
         let of1 = Arc::new(of1);
-        let gtfa = GtfaHandlers::new(ch.clone(), of1.clone(), full_concurrency);
+        let gtfa = GtfaHandlers::new(ch.clone(), of1.clone(), builder.full_concurrency.max(1));
         let transfers = TransfersHandlers::new(ch.clone());
-        Self { ch, of1, ws, gtfa, transfers }
+        let slot_first_shred_multi = (!builder.slot_first_shred_multiplex_urls.is_empty()).then(
+            || Arc::new(SlotPubsubMultiplex::first_shred_multiplex(
+                builder.slot_first_shred_multiplex_urls,
+            )),
+        );
+        let slot_first_shred = builder
+            .slot_first_shred_url
+            .map(|url| Arc::new(SlotPubsubMultiplex::first_shred(url)));
+        let slot_multiplex = (!builder.slot_multiplex_urls.is_empty()).then(
+            || Arc::new(SlotPubsubMultiplex::slot_subscribe(builder.slot_multiplex_urls)),
+        );
+        Self {
+            ch,
+            of1,
+            ws,
+            slot_first_shred_multi,
+            slot_first_shred,
+            slot_multiplex,
+            gtfa,
+            transfers,
+        }
     }
 
     pub async fn dispatch(&self, req: Request) -> Response {

--- a/slv-plugins/rpc-gateway/src/dispatch_test.rs
+++ b/slv-plugins/rpc-gateway/src/dispatch_test.rs
@@ -14,7 +14,10 @@ mod tests {
     use serde_json::json;
 
     fn default_ws_cfg() -> WsConfig {
-        WsConfig { pubsub_url: "ws://127.0.0.1:1".into() }
+        WsConfig {
+            pubsub_url: "ws://127.0.0.1:1".into(),
+            slot_pubsub_url: None,
+        }
     }
 
     fn req(method: &str) -> Request {

--- a/slv-plugins/rpc-gateway/src/lib.rs
+++ b/slv-plugins/rpc-gateway/src/lib.rs
@@ -14,8 +14,8 @@
 //! | 2a | `getTransactionsForAddress` | merged |
 //! | 2b | `getTransfersByAddress` | merged |
 //! | 3 | Pass-through proxy for every other Solana JSON-RPC method | merged |
-//! | 4a | WebSocket scaffold + standard pubsub passthrough | this PR |
-//! | 4b | `slotSubscribe` multi-source fan-in fast paths | next |
+//! | 4a | WebSocket scaffold + standard pubsub passthrough | merged |
+//! | 4b | `slotSubscribe` multi-source fan-in fast paths | this PR |
 //! | 4c | `transactionSubscribe` / `transactionUnsubscribe` via Yellowstone gRPC | next |
 //!
 //! ## Workspace co-location

--- a/slv-plugins/rpc-gateway/src/main.rs
+++ b/slv-plugins/rpc-gateway/src/main.rs
@@ -19,6 +19,22 @@
 //!   PUBSUB_WS_URL         upstream Solana pubsub WebSocket for
 //!                         standard pubsub methods (default
 //!                         `ws://localhost:7111`)
+//!   SLOT_FIRST_SHRED_MULTIPLEX_URLS
+//!                         comma-separated list of pubsub WebSocket
+//!                         URLs.  When non-empty, `slotSubscribe`
+//!                         opens `slotsUpdatesSubscribe` against
+//!                         each one, dedups `firstShredReceived`
+//!                         events by slot number, and re-emits
+//!                         them as `slotNotification` to the client.
+//!   SLOT_FIRST_SHRED_URL  single URL variant of the above
+//!   SLOT_MULTIPLEX_URLS   comma-separated pubsub URLs that dedup
+//!                         standard `slotSubscribe` notifications
+//!                         from multiple sources (no
+//!                         `firstShredReceived` filter)
+//!   SLOT_PUBSUB_URL       per-client `PubsubForward` URL used for
+//!                         `slotSubscribe` only (the validator's
+//!                         native pubsub on `rpc-port + 1` is
+//!                         empirically ~3 ms faster than richat)
 //!   RUST_LOG              tracing-subscriber filter (default `info`)
 
 use std::net::SocketAddr;
@@ -33,7 +49,7 @@ use axum::Router;
 use serde_json::{json, Value};
 use axum::http::HeaderMap;
 use slv_rpc_gateway::clickhouse::{ClickHouseClient, ClickHouseConfig};
-use slv_rpc_gateway::dispatch::Gateway;
+use slv_rpc_gateway::dispatch::{Gateway, GatewayBuilder};
 use slv_rpc_gateway::jsonrpc::{error_codes, Id, Request, Response};
 use slv_rpc_gateway::of1::{Of1Client, Of1Config};
 use slv_rpc_gateway::ws::{ws_route, WsConfig};
@@ -86,8 +102,20 @@ async fn main() -> anyhow::Result<()> {
 
     let ws_cfg = WsConfig {
         pubsub_url: env_or("PUBSUB_WS_URL", "ws://localhost:7111"),
+        slot_pubsub_url: std::env::var("SLOT_PUBSUB_URL")
+            .ok()
+            .filter(|s| !s.is_empty()),
     };
-    let gateway = Arc::new(Gateway::new(ch, of1, full_concurrency, ws_cfg));
+    let builder = GatewayBuilder {
+        full_concurrency,
+        ws: None,
+        slot_first_shred_multiplex_urls: comma_list("SLOT_FIRST_SHRED_MULTIPLEX_URLS"),
+        slot_first_shred_url: std::env::var("SLOT_FIRST_SHRED_URL")
+            .ok()
+            .filter(|s| !s.is_empty()),
+        slot_multiplex_urls: comma_list("SLOT_MULTIPLEX_URLS"),
+    };
+    let gateway = Arc::new(Gateway::with_slot_sources(ch, of1, ws_cfg, builder));
 
     let cors = CorsLayer::new()
         .allow_origin(Any)
@@ -113,6 +141,15 @@ async fn main() -> anyhow::Result<()> {
 
 fn env_or(key: &str, fallback: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| fallback.into())
+}
+
+fn comma_list(key: &str) -> Vec<String> {
+    std::env::var(key)
+        .unwrap_or_default()
+        .split(',')
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 async fn health() -> impl IntoResponse {

--- a/slv-plugins/rpc-gateway/src/ws/mod.rs
+++ b/slv-plugins/rpc-gateway/src/ws/mod.rs
@@ -23,10 +23,12 @@
 //! WebSocket tears everything down.
 
 pub mod pubsub_forward;
+pub mod slot_source;
 
 #[cfg(test)]
 mod ws_test;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
@@ -34,12 +36,14 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use futures::stream::{SplitSink, SplitStream, StreamExt};
 use futures::SinkExt;
-use serde_json::Value;
+use serde_json::{json, Value};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
 use crate::dispatch::Gateway;
 use crate::jsonrpc::{error_codes, Id, Request, Response};
 use crate::ws::pubsub_forward::PubsubForward;
+use crate::ws::slot_source::SlotPubsubMultiplex;
 
 /// Methods Solana clients call against the validator's native
 /// pubsub endpoint.  Forwarded verbatim to the upstream WebSocket
@@ -66,13 +70,25 @@ const STANDARD_PUBSUB_METHODS: &[&str] = &[
     "rootUnsubscribe",
 ];
 
+/// Local-subscription ID floor.  Subscription IDs we mint for
+/// gateway-side multiplex handlers always start at this number so
+/// they can never collide with the upstream-pubsub IDs (which are
+/// small positive ints assigned by the validator).  Matches the
+/// Deno gateway's `LOCAL_SUB_ID_BASE`.
+pub const LOCAL_SUB_ID_BASE: u64 = 1_000_000_000;
+
 #[derive(Clone)]
 pub struct WsConfig {
     /// `ws://…` upstream Solana pubsub endpoint (typically richat
-    /// on the same host).  Used as the destination for every
-    /// standard pubsub method until Phase 4b adds the multi-source
-    /// slot fast-path.
+    /// on the same host).  Default destination for every standard
+    /// pubsub method; `slotSubscribe` may take a faster path below.
     pub pubsub_url: String,
+    /// `ws://…` per-client upstream specifically for `slotSubscribe`.
+    /// When set, slot subscriptions use a separate `PubsubForward`
+    /// to this endpoint (typically the validator's own pubsub on
+    /// `rpc-port + 1`, which is ~3 ms faster than richat).  When
+    /// unset, slot subscriptions fall through to `pubsub_url`.
+    pub slot_pubsub_url: Option<String>,
 }
 
 /// Axum handler for `GET /ws` (and the `/` alias when a real
@@ -112,7 +128,7 @@ async fn receive_loop(
     tx: mpsc::UnboundedSender<Message>,
     gateway: Arc<Gateway>,
 ) {
-    let mut pubsub: Option<PubsubForward> = None;
+    let mut state = ConnectionState::new(tx);
     while let Some(msg) = stream.next().await {
         let Ok(msg) = msg else { break };
         let text = match msg {
@@ -122,27 +138,67 @@ async fn receive_loop(
                 Err(_) => continue,
             },
             Message::Ping(p) => {
-                let _ = tx.send(Message::Pong(p));
+                let _ = state.tx.send(Message::Pong(p));
                 continue;
             }
             Message::Pong(_) => continue,
             Message::Close(_) => break,
         };
-        handle_text(&text, &tx, &mut pubsub, &gateway).await;
+        handle_text(&text, &mut state, &gateway).await;
+    }
+    state.shutdown();
+}
+
+/// Per-connection mutable bookkeeping that the receive loop and
+/// every spawned helper share.  Owns the outgoing mpsc, the lazily-
+/// opened upstream `PubsubForward`s, and the gateway-local
+/// subscription map keyed by the locally-assigned sub_id.
+struct ConnectionState {
+    tx: mpsc::UnboundedSender<Message>,
+    pubsub: Option<PubsubForward>,
+    /// Optional second `PubsubForward` for `slotSubscribe` when
+    /// `WsConfig::slot_pubsub_url` is set.
+    slot_pubsub: Option<PubsubForward>,
+    /// `JoinHandle`s for tasks we spawned for gateway-local
+    /// subscriptions (slot multiplex listeners).  Aborted on
+    /// matching `*Unsubscribe` or connection close.
+    local_subs: HashMap<u64, JoinHandle<()>>,
+    next_local_sub_id: u64,
+}
+
+impl ConnectionState {
+    fn new(tx: mpsc::UnboundedSender<Message>) -> Self {
+        Self {
+            tx,
+            pubsub: None,
+            slot_pubsub: None,
+            local_subs: HashMap::new(),
+            next_local_sub_id: LOCAL_SUB_ID_BASE,
+        }
+    }
+
+    fn next_sub_id(&mut self) -> u64 {
+        self.next_local_sub_id += 1;
+        self.next_local_sub_id
+    }
+
+    fn shutdown(&mut self) {
+        for (_, handle) in self.local_subs.drain() {
+            handle.abort();
+        }
     }
 }
 
 async fn handle_text(
     text: &str,
-    tx: &mpsc::UnboundedSender<Message>,
-    pubsub: &mut Option<PubsubForward>,
+    state: &mut ConnectionState,
     gateway: &Arc<Gateway>,
 ) {
     let body: Value = match serde_json::from_str(text) {
         Ok(v) => v,
         Err(_) => {
             send_response(
-                tx,
+                &state.tx,
                 Response::err(Id::Null, error_codes::PARSE_ERROR, "invalid JSON"),
             );
             return;
@@ -150,7 +206,7 @@ async fn handle_text(
     };
     let Some(req) = Request::validate(body) else {
         send_response(
-            tx,
+            &state.tx,
             Response::err(
                 Id::Null,
                 error_codes::INVALID_REQUEST,
@@ -162,11 +218,9 @@ async fn handle_text(
     let id = Id::or_null(req.id.clone());
 
     match req.method.as_str() {
-        // Phase 4c will land the gRPC bridge that backs this; for now
-        // tell the client it's unsupported so they can fall back.
         "transactionSubscribe" | "transactionUnsubscribe" => {
             send_response(
-                tx,
+                &state.tx,
                 Response::err(
                     id,
                     error_codes::METHOD_NOT_FOUND,
@@ -174,13 +228,15 @@ async fn handle_text(
                 ),
             );
         }
+        "slotSubscribe" => handle_slot_subscribe(req, id, text, state, gateway),
+        "slotUnsubscribe" => handle_slot_unsubscribe(req, id, text, state, gateway),
         other if STANDARD_PUBSUB_METHODS.contains(&other) => {
-            let forward = ensure_pubsub(pubsub, gateway, tx.clone());
+            let forward = ensure_pubsub(&mut state.pubsub, gateway, state.tx.clone());
             forward.send(text.to_owned());
         }
         _ => {
             send_response(
-                tx,
+                &state.tx,
                 Response::err(
                     id,
                     error_codes::METHOD_NOT_FOUND,
@@ -189,6 +245,131 @@ async fn handle_text(
             );
         }
     }
+}
+
+/// Priority cascade for `slotSubscribe`:
+///
+///   slot_first_shred_multi   →   N-URL × firstShredReceived
+///     ↓ when None
+///   slot_first_shred         →   single URL × firstShredReceived
+///     ↓ when None
+///   slot_multiplex           →   N-URL × slotSubscribe (dedup)
+///     ↓ when None
+///   slot_pubsub_url          →   per-client PubsubForward (= different
+///                                 URL than `pubsub_url`, e.g. the
+///                                 validator's native pubsub)
+///     ↓ when None
+///   pubsub_url               →   reuse the shared standard pubsub
+fn handle_slot_subscribe(
+    _req: Request,
+    id: Id,
+    raw_text: &str,
+    state: &mut ConnectionState,
+    gateway: &Arc<Gateway>,
+) {
+    if let Some(multi) = gateway.slot_first_shred_multi.clone() {
+        spawn_slot_forwarder(state, id, multi);
+        return;
+    }
+    if let Some(multi) = gateway.slot_first_shred.clone() {
+        spawn_slot_forwarder(state, id, multi);
+        return;
+    }
+    if let Some(multi) = gateway.slot_multiplex.clone() {
+        spawn_slot_forwarder(state, id, multi);
+        return;
+    }
+    if gateway.ws.slot_pubsub_url.is_some() {
+        let forward = ensure_slot_pubsub(state, gateway);
+        forward.send(raw_text.to_owned());
+        return;
+    }
+    let forward = ensure_pubsub(&mut state.pubsub, gateway, state.tx.clone());
+    forward.send(raw_text.to_owned());
+}
+
+fn handle_slot_unsubscribe(
+    req: Request,
+    id: Id,
+    raw_text: &str,
+    state: &mut ConnectionState,
+    gateway: &Arc<Gateway>,
+) {
+    // Local subscription? -> abort the forwarder task.
+    let params = req.params.as_ref().and_then(|v| v.as_array()).cloned();
+    let local_sub_id = params
+        .as_ref()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_u64());
+    if let Some(sub_id) = local_sub_id {
+        if sub_id >= LOCAL_SUB_ID_BASE {
+            if let Some(handle) = state.local_subs.remove(&sub_id) {
+                handle.abort();
+                send_response(&state.tx, Response::ok(id, Value::Bool(true)));
+                return;
+            }
+            send_response(&state.tx, Response::ok(id, Value::Bool(false)));
+            return;
+        }
+    }
+    // Otherwise forward to the same upstream as slotSubscribe took.
+    if gateway.ws.slot_pubsub_url.is_some() {
+        let forward = ensure_slot_pubsub(state, gateway);
+        forward.send(raw_text.to_owned());
+        return;
+    }
+    let forward = ensure_pubsub(&mut state.pubsub, gateway, state.tx.clone());
+    forward.send(raw_text.to_owned());
+}
+
+fn spawn_slot_forwarder(
+    state: &mut ConnectionState,
+    id: Id,
+    multi: Arc<SlotPubsubMultiplex>,
+) {
+    let sub_id = state.next_sub_id();
+    let mut subscription = multi.subscribe();
+    let tx = state.tx.clone();
+    let handle = tokio::spawn(async move {
+        while let Some(update) = subscription.rx.recv().await {
+            let frame = json!({
+                "jsonrpc": "2.0",
+                "method": "slotNotification",
+                "params": {
+                    "result": {
+                        "slot": update.slot,
+                        "parent": update.parent,
+                        "root": update.root,
+                    },
+                    "subscription": sub_id,
+                },
+            });
+            let raw = match serde_json::to_string(&frame) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            if tx.send(Message::Text(raw.into())).is_err() {
+                break;
+            }
+        }
+    });
+    state.local_subs.insert(sub_id, handle);
+    send_response(&state.tx, Response::ok(id, Value::from(sub_id)));
+}
+
+fn ensure_slot_pubsub<'a>(
+    state: &'a mut ConnectionState,
+    gateway: &Arc<Gateway>,
+) -> &'a PubsubForward {
+    if state.slot_pubsub.is_none() {
+        let url = gateway
+            .ws
+            .slot_pubsub_url
+            .clone()
+            .expect("caller checks slot_pubsub_url is set");
+        state.slot_pubsub = Some(PubsubForward::new(url, state.tx.clone()));
+    }
+    state.slot_pubsub.as_ref().expect("populated above")
 }
 
 fn ensure_pubsub<'a>(

--- a/slv-plugins/rpc-gateway/src/ws/slot_source.rs
+++ b/slv-plugins/rpc-gateway/src/ws/slot_source.rs
@@ -1,0 +1,315 @@
+//! Multi-source slot fan-in for `slotSubscribe`.
+//!
+//! One singleton per `Gateway` for each of the three latency-tuned
+//! variants the Deno gateway supports:
+//!
+//! | Constructor | Subscribe method | Filter | Use |
+//! |---|---|---|---|
+//! | `slot_subscribe(urls)` | `slotSubscribe` | none | dedup `slotNotification` across N upstream pubsubs (jitter smoothing) |
+//! | `first_shred(url)` | `slotsUpdatesSubscribe` | `firstShredReceived` | early-signal slot ticks from one source |
+//! | `first_shred_multiplex(urls)` | `slotsUpdatesSubscribe` | `firstShredReceived` | both axes combined |
+//!
+//! Each variant opens N persistent WebSocket connections (one per
+//! URL) when the first client subscribes, dedupes incoming slot
+//! numbers in a 1024-slot sliding window, and fans the resulting
+//! `SlotUpdate` events out to all currently-registered listeners.
+//!
+//! Listeners are removed automatically when the returned
+//! `SlotSubscription` is dropped — the WS handler abort()s the
+//! forwarder task on `slotUnsubscribe` which lets the
+//! `SlotSubscription` drop and unregister.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::SinkExt;
+use futures::StreamExt;
+use parking_lot::Mutex;
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message as TM;
+
+const MAX_DELIVERED: usize = 1024;
+const RECONNECT_MIN: Duration = Duration::from_secs(1);
+const RECONNECT_MAX: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Debug)]
+pub struct SlotUpdate {
+    pub slot: u64,
+    /// Parent slot when carried in the upstream notification, `None`
+    /// otherwise (`firstShredReceived` does not always carry it).
+    pub parent: Option<u64>,
+    /// Approximated `root` (= `slot.saturating_sub(32)`) so the
+    /// emitted `slotNotification` carries a numeric field even when
+    /// the upstream notification doesn't include one.  Clients that
+    /// need an accurate root should use `rootSubscribe`.
+    pub root: u64,
+}
+
+pub struct SlotPubsubMultiplex {
+    /// Used in log lines so operators can tell which singleton emitted what.
+    label: &'static str,
+    urls: Vec<String>,
+    subscribe_method: &'static str,
+    notification_method: &'static str,
+    filter_type: Option<&'static str>,
+    listeners: Mutex<HashMap<u64, mpsc::UnboundedSender<SlotUpdate>>>,
+    delivered: Mutex<DeliveredWindow>,
+    next_listener_id: AtomicU64,
+    started: AtomicBool,
+}
+
+struct DeliveredWindow {
+    queue: VecDeque<u64>,
+    set: HashSet<u64>,
+}
+
+impl DeliveredWindow {
+    fn new() -> Self {
+        Self { queue: VecDeque::new(), set: HashSet::new() }
+    }
+    /// `true` when the slot was newly inserted (= caller should
+    /// deliver), `false` when it was already in the window.
+    fn observe(&mut self, slot: u64) -> bool {
+        if !self.set.insert(slot) {
+            return false;
+        }
+        self.queue.push_back(slot);
+        if self.queue.len() > MAX_DELIVERED {
+            if let Some(evict) = self.queue.pop_front() {
+                self.set.remove(&evict);
+            }
+        }
+        true
+    }
+}
+
+impl SlotPubsubMultiplex {
+    /// Dedup'd `slotSubscribe` fan-in (= jitter smoothing across
+    /// multiple upstream pubsubs).
+    pub fn slot_subscribe(urls: Vec<String>) -> Self {
+        Self::new("slot_multiplex", urls, "slotSubscribe", "slotNotification", None)
+    }
+
+    /// Single upstream re-emitting `firstShredReceived` events from
+    /// `slotsUpdatesSubscribe` as `slotNotification`.
+    pub fn first_shred(url: String) -> Self {
+        Self::new(
+            "slot_first_shred",
+            vec![url],
+            "slotsUpdatesSubscribe",
+            "slotsUpdatesNotification",
+            Some("firstShredReceived"),
+        )
+    }
+
+    /// Dedup'd `firstShredReceived` fan-in across N upstreams.
+    pub fn first_shred_multiplex(urls: Vec<String>) -> Self {
+        Self::new(
+            "slot_first_shred_multiplex",
+            urls,
+            "slotsUpdatesSubscribe",
+            "slotsUpdatesNotification",
+            Some("firstShredReceived"),
+        )
+    }
+
+    fn new(
+        label: &'static str,
+        urls: Vec<String>,
+        subscribe_method: &'static str,
+        notification_method: &'static str,
+        filter_type: Option<&'static str>,
+    ) -> Self {
+        Self {
+            label,
+            urls,
+            subscribe_method,
+            notification_method,
+            filter_type,
+            listeners: Mutex::new(HashMap::new()),
+            delivered: Mutex::new(DeliveredWindow::new()),
+            next_listener_id: AtomicU64::new(1),
+            started: AtomicBool::new(false),
+        }
+    }
+
+    /// Register a listener; returns a subscription handle.  Dropping
+    /// the handle unregisters the listener and (if it was the last
+    /// one) leaves the upstream connections running — connections
+    /// are cheap to keep open and reattaching to a still-running
+    /// singleton avoids per-subscriber reconnect storms.
+    pub fn subscribe(self: &Arc<Self>) -> SlotSubscription {
+        let id = self.next_listener_id.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.listeners.lock().insert(id, tx);
+        self.ensure_started();
+        SlotSubscription { multi: Arc::clone(self), id, rx }
+    }
+
+    fn ensure_started(self: &Arc<Self>) {
+        if self.started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        for url in self.urls.clone() {
+            let me = Arc::clone(self);
+            tokio::spawn(connect_loop(me, url));
+        }
+    }
+
+    fn deliver(&self, update: SlotUpdate) {
+        if !self.delivered.lock().observe(update.slot) {
+            return;
+        }
+        // Snapshot the listener set so per-listener `send` doesn't
+        // hold the lock across an iteration that might want to
+        // remove dropped peers.
+        let snapshot: Vec<(u64, mpsc::UnboundedSender<SlotUpdate>)> = self
+            .listeners
+            .lock()
+            .iter()
+            .map(|(id, tx)| (*id, tx.clone()))
+            .collect();
+        let mut dead = Vec::new();
+        for (id, tx) in snapshot {
+            if tx.send(update.clone()).is_err() {
+                dead.push(id);
+            }
+        }
+        if !dead.is_empty() {
+            let mut listeners = self.listeners.lock();
+            for id in dead {
+                listeners.remove(&id);
+            }
+        }
+    }
+}
+
+pub struct SlotSubscription {
+    multi: Arc<SlotPubsubMultiplex>,
+    id: u64,
+    pub rx: mpsc::UnboundedReceiver<SlotUpdate>,
+}
+
+impl Drop for SlotSubscription {
+    fn drop(&mut self) {
+        self.multi.listeners.lock().remove(&self.id);
+    }
+}
+
+async fn connect_loop(me: Arc<SlotPubsubMultiplex>, url: String) {
+    let mut delay = RECONNECT_MIN;
+    loop {
+        match tokio_tungstenite::connect_async(&url).await {
+            Ok((ws, _)) => {
+                tracing::info!(
+                    label = %me.label,
+                    url = %url,
+                    "slot_pubsub_connected",
+                );
+                delay = RECONNECT_MIN;
+                let _ = run_one(&me, ws).await;
+                tracing::warn!(label = %me.label, url = %url, "slot_pubsub_disconnected");
+            }
+            Err(e) => {
+                tracing::error!(
+                    label = %me.label,
+                    url = %url,
+                    error = %e,
+                    "slot_pubsub_connect_failed",
+                );
+            }
+        }
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(RECONNECT_MAX);
+    }
+}
+
+async fn run_one(
+    me: &Arc<SlotPubsubMultiplex>,
+    ws: tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> Result<(), tokio_tungstenite::tungstenite::Error> {
+    let (mut sink, mut stream) = ws.split();
+    let sub = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": me.subscribe_method,
+    });
+    sink.send(TM::Text(sub.to_string().into())).await?;
+
+    while let Some(msg) = stream.next().await {
+        let msg = msg?;
+        let text = match msg {
+            TM::Text(t) => t.to_string(),
+            TM::Binary(b) => match std::str::from_utf8(&b) {
+                Ok(s) => s.to_owned(),
+                Err(_) => continue,
+            },
+            TM::Ping(p) => {
+                sink.send(TM::Pong(p)).await?;
+                continue;
+            }
+            TM::Pong(_) | TM::Frame(_) => continue,
+            TM::Close(_) => break,
+        };
+        let parsed: Value = match serde_json::from_str(&text) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if parsed.get("method").and_then(Value::as_str) != Some(me.notification_method) {
+            continue;
+        }
+        let Some(result) = parsed.get("params").and_then(|p| p.get("result")) else {
+            continue;
+        };
+        if let Some(filter) = me.filter_type {
+            let ty = result.get("type").and_then(Value::as_str);
+            if ty != Some(filter) {
+                continue;
+            }
+        }
+        let Some(slot) = result.get("slot").and_then(Value::as_u64) else {
+            continue;
+        };
+        if slot == 0 {
+            continue;
+        }
+        let parent = result.get("parent").and_then(Value::as_u64);
+        let update = SlotUpdate {
+            slot,
+            parent,
+            root: slot.saturating_sub(32),
+        };
+        me.deliver(update);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delivered_window_dedupes() {
+        let mut w = DeliveredWindow::new();
+        assert!(w.observe(1));
+        assert!(!w.observe(1));
+        assert!(w.observe(2));
+    }
+
+    #[test]
+    fn delivered_window_evicts_oldest_when_full() {
+        let mut w = DeliveredWindow::new();
+        for slot in 0..(MAX_DELIVERED as u64 + 50) {
+            assert!(w.observe(slot));
+        }
+        // The first 50 slots should have been evicted and be re-observable.
+        for slot in 0..50 {
+            assert!(w.observe(slot), "slot {slot} should re-enter after eviction");
+        }
+    }
+}

--- a/slv-plugins/rpc-gateway/src/ws/ws_test.rs
+++ b/slv-plugins/rpc-gateway/src/ws/ws_test.rs
@@ -18,7 +18,7 @@ mod tests {
     use tokio_tungstenite::tungstenite::Message as TM;
 
     use crate::clickhouse::{ClickHouseClient, ClickHouseConfig};
-    use crate::dispatch::Gateway;
+    use crate::dispatch::{Gateway, GatewayBuilder};
     use crate::of1::{Of1Client, Of1Config};
     use crate::ws::{ws_route, WsConfig};
 
@@ -47,7 +47,7 @@ mod tests {
             ch,
             of1,
             20,
-            WsConfig { pubsub_url },
+            WsConfig { pubsub_url, slot_pubsub_url: None },
         ));
         let app = Router::new().route("/ws", get(ws_route)).with_state(gw);
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -86,6 +86,131 @@ mod tests {
             other => panic!("unexpected frame: {other:?}"),
         };
         assert_eq!(body, canned, "client should receive the canned upstream reply verbatim");
+    }
+
+    /// Mock pubsub that streams `firstShredReceived` notifications
+    /// at a fixed interval until the client disconnects.  Used to
+    /// drive the slot-first-shred-multiplex variant of the
+    /// `slotSubscribe` cascade end-to-end.
+    async fn spawn_mock_first_shred_stream(slots: Vec<u64>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((sock, _)) = listener.accept().await {
+                let slots = slots.clone();
+                tokio::spawn(async move {
+                    let ws = match tokio_tungstenite::accept_async(sock).await {
+                        Ok(w) => w,
+                        Err(_) => return,
+                    };
+                    let (mut sink, mut stream) = ws.split();
+                    // Drain client subscribe; we don't care about its contents.
+                    let _ = stream.next().await;
+                    let sub_ack = serde_json::json!({
+                        "jsonrpc": "2.0", "id": 1, "result": 1,
+                    });
+                    let _ = sink.send(TM::Text(sub_ack.to_string().into())).await;
+                    for slot in slots {
+                        let frame = serde_json::json!({
+                            "jsonrpc": "2.0",
+                            "method": "slotsUpdatesNotification",
+                            "params": {
+                                "subscription": 1,
+                                "result": {
+                                    "slot": slot,
+                                    "parent": slot.saturating_sub(1),
+                                    "type": "firstShredReceived",
+                                },
+                            },
+                        });
+                        if sink.send(TM::Text(frame.to_string().into())).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+            }
+        });
+        format!("ws://{addr}/")
+    }
+
+    async fn spawn_gateway_with_slot_first_shred(urls: Vec<String>) -> String {
+        let ch = ClickHouseClient::new(ClickHouseConfig::default()).unwrap();
+        let of1 = Of1Client::new(Of1Config::default()).unwrap();
+        let ws_cfg = WsConfig {
+            pubsub_url: "ws://127.0.0.1:1".into(),
+            slot_pubsub_url: None,
+        };
+        let builder = GatewayBuilder {
+            full_concurrency: 20,
+            ws: None,
+            slot_first_shred_multiplex_urls: urls,
+            slot_first_shred_url: None,
+            slot_multiplex_urls: Vec::new(),
+        };
+        let gw = Arc::new(Gateway::with_slot_sources(ch, of1, ws_cfg, builder));
+        let app = Router::new().route("/ws", get(ws_route)).with_state(gw);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("ws://{addr}/ws")
+    }
+
+    #[tokio::test]
+    async fn slot_first_shred_multiplex_dedupes_and_remits_as_slot_notification() {
+        // Two upstreams emit overlapping slot ranges; the multiplex
+        // should deliver each slot exactly once as `slotNotification`.
+        let a = spawn_mock_first_shred_stream(vec![100, 101, 102, 103]).await;
+        let b = spawn_mock_first_shred_stream(vec![101, 102, 103, 104]).await;
+        let gateway_url = spawn_gateway_with_slot_first_shred(vec![a, b]).await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(&gateway_url).await.unwrap();
+        ws.send(TM::Text(
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "slotSubscribe"})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+        // Expect the ack envelope first.
+        let ack_frame = tokio::time::timeout(std::time::Duration::from_secs(2), ws.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let ack: Value = match ack_frame {
+            TM::Text(t) => serde_json::from_str(&t).unwrap(),
+            other => panic!("unexpected ack frame: {other:?}"),
+        };
+        let sub_id = ack.get("result").and_then(Value::as_u64).unwrap();
+        assert!(sub_id >= crate::ws::LOCAL_SUB_ID_BASE, "sub_id should be local-base, got {sub_id}");
+
+        // Collect up to 5 distinct slot notifications within a couple seconds.
+        let mut seen: std::collections::HashSet<u64> = Default::default();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while seen.len() < 5 && tokio::time::Instant::now() < deadline {
+            let next = tokio::time::timeout(std::time::Duration::from_millis(500), ws.next()).await;
+            match next {
+                Ok(Some(Ok(TM::Text(t)))) => {
+                    let body: Value = serde_json::from_str(&t).unwrap();
+                    if body.get("method").and_then(Value::as_str) == Some("slotNotification") {
+                        let slot = body
+                            .pointer("/params/result/slot")
+                            .and_then(Value::as_u64)
+                            .unwrap();
+                        seen.insert(slot);
+                    }
+                }
+                _ => break,
+            }
+        }
+        // Both upstreams sent {101, 102, 103} which would total 8 if
+        // not dedup'd; we expect exactly 5 distinct slots {100..104}.
+        assert!(
+            seen.is_superset(&[100, 101, 102, 103, 104].iter().copied().collect()),
+            "expected dedup'd union, got {seen:?}",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Ports the latency-tuned slot variants from the Deno gateway. One unified `SlotPubsubMultiplex` struct covers all three flavours via configuration (subscribe method + notification method + optional event-type filter); the priority cascade in the WS handler picks the right one based on which env vars are populated.

## Variants

| Env | Effect |
|---|---|
| `SLOT_FIRST_SHRED_MULTIPLEX_URLS` (comma list) | N upstreams × `slotsUpdatesSubscribe` × filter `firstShredReceived` |
| `SLOT_FIRST_SHRED_URL` (single) | single upstream × `firstShredReceived` re-emit |
| `SLOT_MULTIPLEX_URLS` (comma list) | N upstreams × standard `slotSubscribe` (dedup-only) |
| `SLOT_PUBSUB_URL` (single) | per-client second `PubsubForward` for `slotSubscribe` only |

Cascade order (highest priority first):

```
SLOT_FIRST_SHRED_MULTIPLEX_URLS
  → SLOT_FIRST_SHRED_URL
  → SLOT_MULTIPLEX_URLS
  → SLOT_PUBSUB_URL
  → PUBSUB_WS_URL (= same upstream as every other standard pubsub)
```

## What this PR ships

### `ws/slot_source.rs` — `SlotPubsubMultiplex`

- Lazy startup, one outbound WS per URL on first subscription
- Auto-reconnect with exponential backoff (1 s → 30 s)
- 1024-slot sliding-window dedupe across the N upstreams
- Fan-out via per-listener `mpsc::UnboundedSender<SlotUpdate>`
- `SlotSubscription` drop removes the listener; upstream connections stay open

### `ws/mod.rs`

- New per-connection `ConnectionState` (outbound mpsc + both `PubsubForward`s + `local_subs` map + sub-id counter)
- `LOCAL_SUB_ID_BASE = 1_000_000_000` floor for gateway-minted sub IDs
- `slotSubscribe` priority cascade
- `slotUnsubscribe` aborts the matching forwarder task

### `dispatch.rs`

`Gateway` now owns `Option<Arc<SlotPubsubMultiplex>>` for each flavour. `GatewayBuilder` carries env-parsed URL lists.

## Verified

- `cargo check -p slv-rpc-gateway` clean
- `cargo test -p slv-rpc-gateway` — **36 passed, 0 failed**
  - `delivered_window_*` (2) — sliding-window dedupe arithmetic
  - `slot_first_shred_multiplex_dedupes_and_remits_as_slot_notification` — end-to-end: two mock pubsub streams emit overlapping `firstShredReceived` events `{100..103}` and `{101..104}`; client receives the dedup'd union `{100..104}` re-emitted as `slotNotification` with a local `subscription` ID

## Out of scope

- Phase 4c: `transactionSubscribe` / `transactionUnsubscribe` via Yellowstone gRPC. Will also revive `SLOT_BRIDGE_GRPC` (gRPC slot source) once the Yellowstone client lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)