### PR TITLE
fix(slv-plugins/rpc-gateway): close 3 byte-for-byte parity gaps with the Deno gateway

### DIFF
--- a/slv-plugins/rpc-gateway/src/handlers/jet.rs
+++ b/slv-plugins/rpc-gateway/src/handlers/jet.rs
@@ -65,12 +65,18 @@ pub async fn top_programs(ch: &ClickHouseClient, params: &Option<Value>) -> Resu
         LIMIT {limit}
         "#
     );
+    // ClickHouse JSONEachRow emits UInt64 sums as numbers (not
+    // quoted strings) when `output_format_json_quote_64bit_integers`
+    // is at its server default of `false`.  The slv-jetstreamer host
+    // runs with that default, so deserialise as `u64`.  Matches the
+    // Deno gateway's actual output where JS coerces the number back
+    // to a JSON number in `JSON.stringify`.
     #[derive(Deserialize, Serialize)]
     struct Row {
         program: String,
-        invocations: String,
-        errors: String,
-        total_cus: String,
+        invocations: u64,
+        errors: u64,
+        total_cus: u64,
     }
     let rows: Vec<Row> = ch.query(&sql).await.map_err(|e| e.to_string())?;
     Ok(json!(rows))
@@ -183,17 +189,16 @@ pub async fn epoch_summary(ch: &ClickHouseClient, params: &Option<Value>) -> Res
     );
     #[derive(Deserialize, Serialize)]
     struct SummaryRow {
-        slots: String,
-        non_vote_txs: Option<String>,
-        vote_txs: Option<String>,
-        total_txs: Option<String>,
+        slots: u64,
+        non_vote_txs: Option<u64>,
+        vote_txs: Option<u64>,
+        total_txs: Option<u64>,
         first_block_time: Option<u64>,
         last_block_time: Option<u64>,
     }
     let row: Option<SummaryRow> = ch.query_one(&summary_sql).await.map_err(|e| e.to_string())?;
     let Some(row) = row else { return Ok(Value::Null); };
-    let slots_count: i64 = row.slots.parse().unwrap_or(0);
-    if slots_count == 0 {
+    if row.slots == 0 {
         return Ok(Value::Null);
     }
 
@@ -208,26 +213,26 @@ pub async fn epoch_summary(ch: &ClickHouseClient, params: &Option<Value>) -> Res
     );
     #[derive(Deserialize)]
     struct ProgRow {
-        programs: Option<String>,
-        invocations: Option<String>,
+        programs: Option<u64>,
+        invocations: Option<u64>,
     }
     let prog: Option<ProgRow> = ch.query_one(&programs_sql).await.map_err(|e| e.to_string())?;
 
     Ok(json!({
         "epoch": epoch,
         "slots": row.slots,
-        "non_vote_txs": row.non_vote_txs.unwrap_or_else(|| "0".into()),
-        "vote_txs": row.vote_txs.unwrap_or_else(|| "0".into()),
-        "total_txs": row.total_txs.unwrap_or_else(|| "0".into()),
+        "non_vote_txs": row.non_vote_txs.unwrap_or(0),
+        "vote_txs": row.vote_txs.unwrap_or(0),
+        "total_txs": row.total_txs.unwrap_or(0),
         "first_block_time": row.first_block_time,
         "last_block_time": row.last_block_time,
         "distinct_programs": prog
             .as_ref()
-            .and_then(|p| p.programs.clone())
-            .unwrap_or_else(|| "0".into()),
+            .and_then(|p| p.programs)
+            .unwrap_or(0),
         "program_invocations": prog
             .and_then(|p| p.invocations)
-            .unwrap_or_else(|| "0".into()),
+            .unwrap_or(0),
     }))
 }
 
@@ -283,9 +288,9 @@ pub async fn program_stats(
     #[derive(Deserialize, Serialize)]
     struct Row {
         bucket: u64,
-        invocations: String,
-        errors: String,
-        total_cus: String,
+        invocations: u64,
+        errors: u64,
+        total_cus: u64,
     }
     let rows: Vec<Row> = ch.query(&sql).await.map_err(|e| e.to_string())?;
     Ok(json!(rows))

--- a/slv-plugins/rpc-gateway/src/handlers/transfers.rs
+++ b/slv-plugins/rpc-gateway/src/handlers/transfers.rs
@@ -349,22 +349,33 @@ fn parse_pagination_token(s: &str) -> Result<Cursor, String> {
     let inner_instr_idx: i64 = parts[3]
         .parse()
         .map_err(|_| "invalid paginationToken.innerInstrIdx".to_string())?;
-    let type_name = parts[4];
-    if !TRANSFER_TYPE_NAMES[1..].contains(&type_name) {
-        return Err(format!("invalid paginationToken.type: {type_name}"));
+    // Accept both the integer form the encoder now emits and the
+    // legacy name form (`"transfer"`, `"mint"`, …) the early Deno
+    // gateway's parser was written against, so a client paging
+    // through historical tokens doesn't break across the cutover.
+    let type_str = parts[4];
+    let valid = type_str
+        .parse::<u8>()
+        .ok()
+        .map(|n| n >= 1 && (n as usize) < TRANSFER_TYPE_NAMES.len())
+        .unwrap_or(false)
+        || TRANSFER_TYPE_NAMES[1..].contains(&type_str);
+    if !valid {
+        return Err(format!("invalid paginationToken.type: {type_str}"));
     }
     Ok(Cursor { slot, tx_idx, instr_idx, inner_instr_idx })
 }
 
 fn encode_pagination_token(r: &RawRow) -> String {
+    // Emit the raw `transfer_type` UInt8 (= 1..7) rather than its
+    // string name.  Matches the Deno gateway's byte-for-byte wire
+    // shape: it interpolates `RawRow.transfer_type` directly with
+    // `${}` so a CH-emitted integer surfaces as `"1"` in the
+    // token's last segment.
     let type_idx = transfer_type_index(&r.transfer_type);
-    let type_name = TRANSFER_TYPE_NAMES
-        .get(type_idx as usize)
-        .copied()
-        .unwrap_or("transfer");
     format!(
         "{}:{}:{}:{}:{}",
-        r.slot, r.tx_index, r.instr_index, r.inner_index, type_name,
+        r.slot, r.tx_index, r.instr_index, r.inner_index, type_idx,
     )
 }
 
@@ -612,9 +623,11 @@ mod tests {
     }
 
     #[test]
-    fn pagination_token_round_trip() {
-        let tok = "12345:67:8:0:transfer";
-        let cur = parse_pagination_token(tok).unwrap();
+    fn pagination_token_accepts_integer_type() {
+        // The encoder now emits the raw UInt8 (matches the Deno
+        // gateway's wire); the parser must accept `"1".."7"` as
+        // the trailing segment.
+        let cur = parse_pagination_token("12345:67:8:0:1").unwrap();
         assert_eq!(cur.slot, 12345);
         assert_eq!(cur.tx_idx, 67);
         assert_eq!(cur.instr_idx, 8);
@@ -622,7 +635,11 @@ mod tests {
     }
 
     #[test]
-    fn pagination_token_accepts_minus_one_inner() {
+    fn pagination_token_accepts_legacy_name_type() {
+        // Older tokens stored client-side carry the name form
+        // (`"transfer"`, `"mint"`, …).  Keep them parseable so a
+        // client paging through historical state doesn't break
+        // across the cutover.
         let cur = parse_pagination_token("100:0:0:-1:mint").unwrap();
         assert_eq!(cur.inner_instr_idx, -1);
     }
@@ -631,12 +648,37 @@ mod tests {
     fn pagination_token_rejects_unknown_type() {
         let err = parse_pagination_token("1:2:3:0:bogus").unwrap_err();
         assert!(err.contains("invalid paginationToken.type"));
+        // Integer out of range also rejected.
+        let err = parse_pagination_token("1:2:3:0:99").unwrap_err();
+        assert!(err.contains("invalid paginationToken.type"));
     }
 
     #[test]
     fn pagination_token_rejects_wrong_arity() {
         assert!(parse_pagination_token("1:2:3:4").is_err());
         assert!(parse_pagination_token("1:2:3:4:5:6").is_err());
+    }
+
+    #[test]
+    fn encoded_pagination_token_emits_integer_type_segment() {
+        let r = RawRow {
+            signature: "sig".into(),
+            slot: 12345,
+            block_time: 0,
+            transfer_type: json!(1),
+            from_owner: "from".into(),
+            to_owner: "to".into(),
+            from_token_account: None,
+            to_token_account: None,
+            mint: "mint".into(),
+            amount: "0".into(),
+            fee_amount: "0".into(),
+            decimals: 0,
+            tx_index: 67,
+            instr_index: 8,
+            inner_index: 2,
+        };
+        assert_eq!(encode_pagination_token(&r), "12345:67:8:2:1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Side-by-side diff against the Deno gateway (FRA-1 host, Rust on alt port 8890 vs Deno on 8889) found three output-side bugs.

### 1. `jet*` `sum()` columns deserialised as `String`

The Row structs assumed `output_format_json_quote_64bit_integers = true`. The slv-jetstreamer host runs with the server default (= unquoted), so every `jet*` query containing a sum returned `invalid type: integer ... expected a string` instead of the actual rows. Fix: deserialise as `u64`. Wire output unchanged (JS `JSON.stringify(13815495340)` emits the unquoted number too).

### 2. `getTransfersByAddress` paginationToken last segment

Rust emitted `":transfer"` (name); Deno emits `":1"` (integer). The Deno encoder interpolates the column directly with `${}` and ClickHouse delivers it as an integer. Fix: encoder emits the integer; parser accepts both forms so tokens already issued to clients keep working across the cutover.

## Verified

- `cargo check -p slv-rpc-gateway` clean
- `cargo test -p slv-rpc-gateway` — **43 passed, 0 failed**
- Side-by-side parity on FRA-1 (Deno :8889 vs Rust :8890) now reports `✓ identical` for all 10 representative methods (jet* × 5, address-indexed × 2, proxy × 2, jet-namespace catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)