### PR TITLE
chore(slv-plugins): fix stale api/rpc-gateway/ doc references

### DIFF
--- a/slv-plugins/README.md
+++ b/slv-plugins/README.md
@@ -4,7 +4,7 @@ Rust workspace for slv-flavoured plugins on top of
 [anza-xyz/jetstreamer](https://github.com/anza-xyz/jetstreamer).
 
 Each member crate is a thin extension that emits rows into a
-ClickHouse schema served by [`../api/rpc-gateway`](../api/rpc-gateway).
+ClickHouse schema served by [`rpc-gateway`](./rpc-gateway).
 Pair them with the gateway's extended JSON-RPC methods to serve queries
 that vanilla Solana RPC can't answer.
 

--- a/slv-plugins/slv_transfers_plugin/src/lib.rs
+++ b/slv-plugins/slv_transfers_plugin/src/lib.rs
@@ -90,8 +90,7 @@ static SPL_TOKEN_V1_PROGRAM_ID: Lazy<Address> = Lazy::new(|| {
 const ZERO_PUBKEY: [u8; 32] = [0u8; 32];
 
 /// transfer_type Enum8 numeric values — keep in sync with the
-/// gateway handler (`api/rpc-gateway/src/handlers/transfers.ts` in
-/// the slv repo).
+/// gateway handler (`slv-plugins/rpc-gateway/src/handlers/transfers.rs`).
 mod transfer_type {
     pub const TRANSFER: u8 = 1;
     #[allow(dead_code)]


### PR DESCRIPTION
## Summary

PR #386 deleted `api/rpc-gateway/` (the Deno gateway), but two doc
comments in the slv-plugins crates still linked to that path.  This
PR retargets both at the in-workspace Rust gateway.

## Changes

- `slv-plugins/README.md` — link `../api/rpc-gateway` → `./rpc-gateway`.
- `slv-plugins/slv_transfers_plugin/src/lib.rs` — \`transfer_type\`
  enum sync note now references `slv-plugins/rpc-gateway/src/handlers/transfers.rs`
  instead of the deleted `transfers.ts`.

No behaviour change.

## Test plan

- [x] `cargo check -p slv_transfers_plugin` — clean
- [ ] CI green on this PR