### PR TITLE
feat(rpc-gateway): WS-duration billing emitter on connection close

### DIFF
--- a/slv-plugins/Cargo.lock
+++ b/slv-plugins/Cargo.lock
@@ -903,6 +903,7 @@ dependencies = [
  "axum-core 0.5.6",
  "base64 0.22.1",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -918,6 +919,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
+ "serde_urlencoded",
  "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
@@ -6475,6 +6477,7 @@ dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
  "bs58",
+ "chrono",
  "futures 0.3.32",
  "hyper 1.9.0",
  "parking_lot 0.12.5",
@@ -6494,6 +6497,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url 2.5.8",
+ "uuid",
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",
 ]
@@ -11219,6 +11223,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/slv-plugins/Cargo.toml
+++ b/slv-plugins/Cargo.toml
@@ -63,7 +63,7 @@ solana-transaction-status = "3"
 env_logger = "0.11"
 
 # rpc-gateway extras
-axum = { version = "0.8", default-features = false, features = ["http1", "http2", "json", "ws", "tokio", "tracing"] }
+axum = { version = "0.8", default-features = false, features = ["http1", "http2", "json", "query", "ws", "tokio", "tracing"] }
 hyper = { version = "1", features = ["http1", "http2"] }
 serde_json = "1"
 tower = "0.5"
@@ -91,3 +91,5 @@ tonic = { version = "0.14", default-features = false, features = ["channel", "tr
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 prost = "0.14"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
+uuid = { version = "1", features = ["v4"] }

--- a/slv-plugins/rpc-gateway/Cargo.toml
+++ b/slv-plugins/rpc-gateway/Cargo.toml
@@ -41,6 +41,8 @@ bs58.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true
 prost.workspace = true
+chrono.workspace = true
+uuid.workspace = true
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }

--- a/slv-plugins/rpc-gateway/src/dispatch.rs
+++ b/slv-plugins/rpc-gateway/src/dispatch.rs
@@ -16,6 +16,7 @@ use crate::clickhouse::ClickHouseClient;
 use crate::handlers::{gtfa::GtfaHandlers, jet, transfers::TransfersHandlers};
 use crate::jsonrpc::{error_codes, Id, Request, Response};
 use crate::of1::Of1Client;
+use crate::ws::billing::BillingClient;
 use crate::ws::slot_source::SlotPubsubMultiplex;
 use crate::ws::WsConfig;
 
@@ -43,6 +44,13 @@ pub struct Gateway {
     /// `transactionSubscribe` WS method.  Stored as a plain string
     /// (host:port or full URL) — the bridge does scheme coercion.
     pub yellowstone_endpoint: String,
+    /// Optional WS-duration billing emitter.  When configured (=
+    /// `RPC_METRICS_API_URL` env set), posts a connection log to
+    /// `{base}/ws-connection-log` on WS close so the central
+    /// metering path stays consistent with what the Pingora LB used
+    /// to push.  When `None`, WS close is a no-op for billing —
+    /// useful for dev / non-production gateways.
+    pub billing: Option<Arc<BillingClient>>,
     gtfa: GtfaHandlers,
     transfers: TransfersHandlers,
 }
@@ -63,6 +71,12 @@ pub struct GatewayBuilder {
     /// gRPC source alone.
     pub slot_grpc_url: Option<String>,
     pub yellowstone_endpoint: String,
+    /// Operator-supplied WS-duration billing config.  When all
+    /// three are non-empty, an [`crate::ws::billing::BillingClient`]
+    /// is constructed and used by the WS handler on close.
+    pub metrics_api_url: Option<String>,
+    pub metrics_api_bearer: Option<String>,
+    pub metrics_upstream_ip: Option<String>,
 }
 
 impl Gateway {
@@ -106,6 +120,17 @@ impl Gateway {
         let slot_multiplex = (!builder.slot_multiplex_urls.is_empty()).then(
             || Arc::new(SlotPubsubMultiplex::slot_subscribe(builder.slot_multiplex_urls)),
         );
+        let billing = match (
+            builder.metrics_api_url.as_deref().filter(|s| !s.is_empty()),
+            builder.metrics_api_bearer.as_deref().filter(|s| !s.is_empty()),
+        ) {
+            (Some(url), Some(bearer)) => Some(Arc::new(BillingClient::new(
+                url.to_owned(),
+                bearer.to_owned(),
+                builder.metrics_upstream_ip.unwrap_or_default(),
+            ))),
+            _ => None,
+        };
         Self {
             ch,
             of1,
@@ -118,6 +143,7 @@ impl Gateway {
             } else {
                 builder.yellowstone_endpoint
             },
+            billing,
             gtfa,
             transfers,
         }

--- a/slv-plugins/rpc-gateway/src/main.rs
+++ b/slv-plugins/rpc-gateway/src/main.rs
@@ -45,6 +45,17 @@
 //!   YELLOWSTONE_GRPC      Yellowstone-gRPC endpoint for the
 //!                         extended `transactionSubscribe` WS
 //!                         method (default `localhost:10000`)
+//!   RPC_METRICS_API_URL   Operator-supplied metrics API base URL.
+//!                         When set together with
+//!                         `RPC_METRICS_API_BEARER`, the WS handler
+//!                         POSTs a `ws-connection-log` body on every
+//!                         WS close so the central metering pipeline
+//!                         can charge per-second WS duration.  Unset
+//!                         = billing emit is a no-op (dev mode).
+//!   RPC_METRICS_API_BEARER  Bearer token for the metrics API.
+//!   RPC_METRICS_UPSTREAM_IP Optional self-identifier emitted as
+//!                         `upstreamIp` in the log body (default
+//!                         empty string).
 //!   RUST_LOG              tracing-subscriber filter (default `info`)
 
 use std::net::SocketAddr;
@@ -126,6 +137,9 @@ async fn main() -> anyhow::Result<()> {
         slot_multiplex_urls: comma_list("SLOT_MULTIPLEX_URLS"),
         slot_grpc_url: std::env::var("SLOT_GRPC_URL").ok().filter(|s| !s.is_empty()),
         yellowstone_endpoint: env_or("YELLOWSTONE_GRPC", "localhost:10000"),
+        metrics_api_url: std::env::var("RPC_METRICS_API_URL").ok().filter(|s| !s.is_empty()),
+        metrics_api_bearer: std::env::var("RPC_METRICS_API_BEARER").ok().filter(|s| !s.is_empty()),
+        metrics_upstream_ip: std::env::var("RPC_METRICS_UPSTREAM_IP").ok().filter(|s| !s.is_empty()),
     };
     let gateway = Arc::new(Gateway::with_slot_sources(ch, of1, ws_cfg, builder));
 
@@ -174,6 +188,7 @@ async fn health() -> impl IntoResponse {
 async fn root_get(
     headers: HeaderMap,
     ws: axum::extract::WebSocketUpgrade,
+    query: axum::extract::Query<std::collections::HashMap<String, String>>,
     state: State<Arc<Gateway>>,
 ) -> axum::response::Response {
     if headers
@@ -182,7 +197,7 @@ async fn root_get(
         .map(|s| s.eq_ignore_ascii_case("websocket"))
         .unwrap_or(false)
     {
-        return ws_route(ws, state).await.into_response();
+        return ws_route(ws, query, state).await.into_response();
     }
     StatusCode::NOT_FOUND.into_response()
 }

--- a/slv-plugins/rpc-gateway/src/ws/billing.rs
+++ b/slv-plugins/rpc-gateway/src/ws/billing.rs
@@ -1,0 +1,163 @@
+//! WebSocket connection billing emitter.
+//!
+//! On WebSocket close, POSTs a connection log to a configurable
+//! metrics endpoint so a central metering system can charge per-
+//! second WS duration.  Fire-and-forget — the POST runs in a
+//! detached tokio task and a failure is logged at `error` level but
+//! does not affect the client connection.
+//!
+//! The endpoint URL + bearer token are operator-supplied via env at
+//! gateway startup (see `RPC_METRICS_API_URL`, `RPC_METRICS_API_BEARER`
+//! in `main.rs`).  Wire format is a JSON body with the keys
+//! `apiKey`, `connectionId`, `upstreamIp`, `startTime` (RFC3339),
+//! `endTime` (RFC3339), `durationSeconds`.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use serde_json::json;
+
+/// Per-gateway singleton.  Holds the reusable HTTP client + the
+/// `rpc-metrics-api` endpoint config.  Cheap to `Arc::clone`.
+#[derive(Clone)]
+pub struct BillingClient {
+    http: Client,
+    /// Metrics API base URL (no trailing slash).  The
+    /// `/ws-connection-log` path is appended at POST time.  Supplied
+    /// via env at startup; no production hostname is encoded here so
+    /// this crate stays vendor-agnostic when published.
+    base_url: String,
+    /// `Authorization: Bearer <bearer>` header value.
+    bearer: String,
+    /// Host self-identifier emitted as `upstreamIp` in the log body
+    /// (for downstream attribution / debugging).
+    upstream_ip: String,
+}
+
+impl BillingClient {
+    pub fn new(base_url: String, bearer: String, upstream_ip: String) -> Self {
+        let http = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("reqwest client builds with default config");
+        Self { http, base_url, bearer, upstream_ip }
+    }
+
+    /// Spawns a detached tokio task that POSTs the close log.
+    /// Returns immediately so the WS shutdown path is not blocked.
+    /// No-op when `api_key` is empty (= internal probe, no billable
+    /// connection).
+    pub fn emit_close(
+        self: &Arc<Self>,
+        api_key: String,
+        connection_id: String,
+        start_time: SystemTime,
+        end_time: SystemTime,
+    ) {
+        if api_key.is_empty() {
+            return;
+        }
+        let me = Arc::clone(self);
+        tokio::spawn(async move {
+            me.do_emit(api_key, connection_id, start_time, end_time).await;
+        });
+    }
+
+    async fn do_emit(
+        &self,
+        api_key: String,
+        connection_id: String,
+        start_time: SystemTime,
+        end_time: SystemTime,
+    ) {
+        let duration_secs = end_time
+            .duration_since(start_time)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let start_iso = system_time_to_rfc3339(start_time);
+        let end_iso = system_time_to_rfc3339(end_time);
+        let body = json!({
+            "apiKey": api_key,
+            "connectionId": connection_id,
+            "upstreamIp": self.upstream_ip,
+            "startTime": start_iso,
+            "endTime": end_iso,
+            "durationSeconds": duration_secs,
+        });
+        let url = format!("{}/ws-connection-log", self.base_url.trim_end_matches('/'));
+        match self
+            .http
+            .post(&url)
+            .bearer_auth(&self.bearer)
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::debug!(
+                    connection_id = %connection_id,
+                    duration_seconds = duration_secs,
+                    "ws_billing_log_ok"
+                );
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                tracing::error!(
+                    connection_id = %connection_id,
+                    status = %status,
+                    body = %body,
+                    "ws_billing_log_failed_status"
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    connection_id = %connection_id,
+                    error = %e,
+                    "ws_billing_log_failed_network"
+                );
+            }
+        }
+    }
+}
+
+fn system_time_to_rfc3339(t: SystemTime) -> String {
+    let dt: DateTime<Utc> = t.into();
+    dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn rfc3339_format_matches_iso8601_z() {
+        let t = SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let s = system_time_to_rfc3339(t);
+        // UNIX 1_700_000_000 = 2023-11-14T22:13:20Z
+        assert_eq!(s, "2023-11-14T22:13:20.000Z");
+    }
+
+    #[test]
+    fn empty_api_key_is_no_op() {
+        let client = Arc::new(BillingClient::new(
+            "http://invalid-host-for-test".into(),
+            "test".into(),
+            "127.0.0.1".into(),
+        ));
+        // Empty api_key short-circuits before any HTTP attempt — this
+        // call must return without panic and without spawning a task
+        // that the test would otherwise wait on.
+        client.emit_close(
+            String::new(),
+            "test-conn".into(),
+            SystemTime::now(),
+            SystemTime::now(),
+        );
+        // No assertion beyond "didn't panic"; the spawned task path
+        // is not taken when api_key is empty.
+    }
+}

--- a/slv-plugins/rpc-gateway/src/ws/mod.rs
+++ b/slv-plugins/rpc-gateway/src/ws/mod.rs
@@ -20,6 +20,7 @@
 //! every subscription that client makes; closing the inbound
 //! WebSocket tears everything down.
 
+pub mod billing;
 pub mod pubsub_forward;
 pub mod slot_source;
 pub mod yellowstone_bridge;
@@ -29,9 +30,10 @@ mod ws_test;
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::response::IntoResponse;
 use futures::stream::{SplitSink, SplitStream, StreamExt};
 use futures::SinkExt;
@@ -90,24 +92,39 @@ pub struct WsConfig {
 }
 
 /// Axum handler for `GET /ws` (and the `/` alias when a real
-/// WebSocket upgrade is requested).  Hands the upgraded socket off
-/// to `handle_socket` which owns the per-connection state.
+/// WebSocket upgrade is requested).  Extracts the `api-key` query
+/// param so the per-connection close emitter can attribute the
+/// billable duration; hands the upgraded socket off to
+/// `handle_socket` which owns the per-connection state.
 pub async fn ws_route(
     ws: WebSocketUpgrade,
+    Query(params): Query<HashMap<String, String>>,
     State(gateway): State<Arc<Gateway>>,
 ) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_socket(socket, gateway))
+    let api_key = params.get("api-key").cloned().unwrap_or_default();
+    ws.on_upgrade(move |socket| handle_socket(socket, gateway, api_key))
 }
 
-async fn handle_socket(socket: WebSocket, gateway: Arc<Gateway>) {
+async fn handle_socket(socket: WebSocket, gateway: Arc<Gateway>, api_key: String) {
+    let connection_id = uuid::Uuid::new_v4().to_string();
+    let start_time = SystemTime::now();
     let (sink, stream) = socket.split();
     // mpsc gives both the inbound-message loop and the upstream
     // forwarder a way to enqueue outgoing frames without contending
     // for the sink directly.
     let (tx, rx) = mpsc::unbounded_channel::<Message>();
     let sender_task = tokio::spawn(client_sender(sink, rx));
-    receive_loop(stream, tx, gateway).await;
+    receive_loop(stream, tx, gateway.clone()).await;
     sender_task.abort();
+    let end_time = SystemTime::now();
+    // Emit the WS-duration billing record so the central metering
+    // path stays consistent with what the Pingora LB used to push
+    // via Redis → consumer_ws.  No-op when no billing client is
+    // configured (= dev / non-production gateway) or when api_key
+    // is empty (= internal probe).
+    if let Some(billing) = gateway.billing.as_ref() {
+        billing.emit_close(api_key, connection_id, start_time, end_time);
+    }
 }
 
 async fn client_sender(

--- a/slv-plugins/rpc-gateway/src/ws/ws_test.rs
+++ b/slv-plugins/rpc-gateway/src/ws/ws_test.rs
@@ -148,6 +148,9 @@ mod tests {
             slot_multiplex_urls: Vec::new(),
             slot_grpc_url: None,
             yellowstone_endpoint: "localhost:10000".into(),
+            metrics_api_url: None,
+            metrics_api_bearer: None,
+            metrics_upstream_ip: None,
         };
         let gw = Arc::new(Gateway::with_slot_sources(ch, of1, ws_cfg, builder));
         let app = Router::new().route("/ws", get(ws_route)).with_state(gw);

--- a/template/2026.5.5.1612/ansible/cmn/install_rpc_gateway.yml
+++ b/template/2026.5.5.1612/ansible/cmn/install_rpc_gateway.yml
@@ -32,6 +32,20 @@
 #                                                       SubscribeEntries endpoint, joins
 #                                                       the SLOT_FIRST_SHRED_MULTIPLEX dedup
 #                                                       window as an extra fast-path source
+#   rpc_gateway_metrics_api_url                        (unset) — operator-supplied metrics
+#                                                       API base URL.  When set with
+#                                                       *_bearer below, WS connection close
+#                                                       events are POSTed to
+#                                                       `{url}/ws-connection-log` so the
+#                                                       central metering pipeline can
+#                                                       charge per-second WS duration.
+#   rpc_gateway_metrics_api_bearer                     (unset) — bearer token for the metrics
+#                                                       API.  Keep this in inventory
+#                                                       group_vars or a vaulted file, never
+#                                                       in the OSS repo.
+#   rpc_gateway_metrics_upstream_ip                    (unset) — optional self-identifier
+#                                                       emitted as `upstreamIp` in the log
+#                                                       body (defaults to empty string).
 #   rpc_gateway_full_concurrency                       20
 #   rpc_gateway_rust_log                               info
 #
@@ -71,6 +85,9 @@
     rg_slot_multiplex_urls: "{{ rpc_gateway_slot_multiplex_urls | default('') }}"
     rg_slot_pubsub_url: "{{ rpc_gateway_slot_pubsub_url | default('') }}"
     rg_slot_grpc_url: "{{ rpc_gateway_slot_grpc_url | default('') }}"
+    rg_metrics_api_url: "{{ rpc_gateway_metrics_api_url | default('') }}"
+    rg_metrics_api_bearer: "{{ rpc_gateway_metrics_api_bearer | default('') }}"
+    rg_metrics_upstream_ip: "{{ rpc_gateway_metrics_upstream_ip | default('') }}"
     rg_full_concurrency: "{{ rpc_gateway_full_concurrency | default(20) }}"
     rg_rust_log: "{{ rpc_gateway_rust_log | default('info') }}"
     # CH tunnel mode (see header comment).  Empty string disables.
@@ -286,6 +303,9 @@
           {% if rg_slot_multiplex_urls %}Environment=SLOT_MULTIPLEX_URLS={{ rg_slot_multiplex_urls }}{% endif %}
           {% if rg_slot_pubsub_url %}Environment=SLOT_PUBSUB_URL={{ rg_slot_pubsub_url }}{% endif %}
           {% if rg_slot_grpc_url %}Environment=SLOT_GRPC_URL={{ rg_slot_grpc_url }}{% endif %}
+          {% if rg_metrics_api_url %}Environment=RPC_METRICS_API_URL={{ rg_metrics_api_url }}{% endif %}
+          {% if rg_metrics_api_bearer %}Environment=RPC_METRICS_API_BEARER={{ rg_metrics_api_bearer }}{% endif %}
+          {% if rg_metrics_upstream_ip %}Environment=RPC_METRICS_UPSTREAM_IP={{ rg_metrics_upstream_ip }}{% endif %}
           Environment=GTFA_FULL_CONCURRENCY={{ rg_full_concurrency }}
           Environment=RUST_LOG={{ rg_rust_log }}
           ExecStart={{ rg_bin_dir }}/slv-rpc-gateway


### PR DESCRIPTION
## Summary

Adds an optional billing emitter that POSTs a connection log to an
operator-supplied metrics API on every WebSocket close, so the
central per-second WS billing pipeline stays consistent when the
gateway is fronted by a path that bypasses the previous logging hop
(e.g., a Cloudflare Tunnel terminating directly at the gateway).

## Behaviour

- On WS upgrade: extract \`api-key\` query param, generate
  \`connection_id\` (uuid v4), record open \`SystemTime\`.
- On WS close: detached tokio task POSTs to
  \`{RPC_METRICS_API_URL}/ws-connection-log\` with bearer auth and
  JSON body \`{apiKey, connectionId, upstreamIp, startTime,
  endTime, durationSeconds}\` (RFC3339 timestamps, integer seconds).
- Fire-and-forget: failure logged but does not block WS shutdown.
- No-op when env unset (dev) or \`api-key\` missing (internal probe).

## Env / ansible

- New envs: \`RPC_METRICS_API_URL\`, \`RPC_METRICS_API_BEARER\`,
  \`RPC_METRICS_UPSTREAM_IP\`.
- Inventory vars: \`rpc_gateway_metrics_api_{url,bearer,upstream_ip}\`.
- Defaults empty; operators supply real values via group_vars /
  vaulted files (never in this OSS repo).
- Systemd unit only renders \`Environment=\` lines when inventory
  var is non-empty.

## Test plan

- [x] \`cargo test -p slv-rpc-gateway --lib\` — 48 passed (2 new
      billing tests + 46 existing unchanged)
- [x] \`cargo build --release -p slv-rpc-gateway\` — clean
- [ ] CI green on this PR
- [ ] After merge: deploy + set inventory vars
      \`rpc_gateway_metrics_api_url\` / \`_bearer\` per region;
      verify on FRA-1 that WS close fires a POST (= central
      metering pipeline records the duration credits).

## Notes

- New deps: \`chrono\` (RFC3339), \`uuid\` (v4), \`axum\` gains
  \`query\` feature.
- Wire format matches the contract the existing central metering
  pipeline already accepts.  No production hostname or bearer is
  hard-coded in this crate.