### PR TITLE
fix(rpc-gateway): emit slotNotification.parent as a number, never null

### DIFF
--- a/slv-plugins/rpc-gateway/src/ws/mod.rs
+++ b/slv-plugins/rpc-gateway/src/ws/mod.rs
@@ -339,13 +339,24 @@ fn spawn_slot_forwarder(
     let tx = state.tx.clone();
     let handle = tokio::spawn(async move {
         while let Some(update) = subscription.rx.recv().await {
+            // `parent` MUST be a number per the standard Solana
+            // `slotNotification` wire shape — @solana/web3.js's
+            // strict superstruct validator rejects `null` and
+            // throws an unhandled rejection in client apps.  Our
+            // upstream sources (firstShredReceived filter + UDP
+            // shred header) don't carry the parent, so fall back
+            // to `slot - 1` (= correct for ~95 % of slots, off by
+            // a small skip count in the rest; clients that need
+            // the exact parent should use commitment=confirmed
+            // through the standard RPC).
+            let parent = update.parent.unwrap_or_else(|| update.slot.saturating_sub(1));
             let frame = json!({
                 "jsonrpc": "2.0",
                 "method": "slotNotification",
                 "params": {
                     "result": {
                         "slot": update.slot,
-                        "parent": update.parent,
+                        "parent": parent,
                         "root": update.root,
                     },
                     "subscription": sub_id,

--- a/slv-plugins/rpc-gateway/src/ws/ws_test.rs
+++ b/slv-plugins/rpc-gateway/src/ws/ws_test.rs
@@ -205,6 +205,25 @@ mod tests {
                             .pointer("/params/result/slot")
                             .and_then(Value::as_u64)
                             .unwrap();
+                        // `parent` MUST be a number (= the standard
+                        // Solana wire shape, enforced by
+                        // @solana/web3.js's strict superstruct
+                        // validator at the client side).  A `null`
+                        // here would crash dependent JS apps with
+                        // an unhandled rejection.
+                        let parent = body
+                            .pointer("/params/result/parent")
+                            .and_then(Value::as_u64);
+                        assert!(
+                            parent.is_some(),
+                            "slotNotification.parent must be a number, got: {:?}",
+                            body.pointer("/params/result/parent"),
+                        );
+                        // `root` likewise must be a number.
+                        assert!(
+                            body.pointer("/params/result/root").and_then(Value::as_u64).is_some(),
+                            "slotNotification.root must be a number",
+                        );
                         seen.insert(slot);
                     }
                 }


### PR DESCRIPTION
## Summary

The standard Solana \`slotNotification\` wire shape expects
\`params.result.parent\` to be a slot number.  \`@solana/web3.js\`'s
strict superstruct validator throws an unhandled rejection when
\`parent\` is \`null\`, crashing dependent client apps.

Customer report: 3 hours of downtime after a slot tick reached
their app with \`parent: null\`.

## Cause

The fast-path slot sources we layered in over recent PRs
(\`firstShredReceived\` filter, gRPC SubscribeEntries tap, raw
shred UDP listener) all carry the slot number but none carry a
parent slot.  We populated \`SlotUpdate.parent: Option<u64>\` and
let \`None\` serialise as JSON \`null\`.  Internal bench scripts
only asserted on the \`slot\` field so this regression was not
caught.

## Fix

At the WS emit site, fall back to \`slot - 1\` when the upstream
didn't supply a parent.  Correct for ~95 % of slots (= no skips);
off by a small skip count in the rest.  Clients that need the
exact parent should use \`commitment=confirmed\` through the
standard RPC path.

The internal \`SlotUpdate.parent: Option<u64>\` representation is
unchanged so the sources can keep flagging "unknown" without
forcing every emit site to pick a fallback; only the WS JSON
boundary substitutes.

## Test plan

- [x] New assertion in \`ws_test\` pins the wire contract:
      \`slotNotification.parent\` and \`.root\` must both be JSON
      numbers (never null).
- [x] \`cargo test -p slv-rpc-gateway --lib\` — 53 passed
- [x] \`cargo build --release\` clean
- [ ] CI green
- [ ] After merge: deploy to FRA-1, customer re-validates with
      \`@solana/web3.js\`.