### PR TITLE
feat(rpc-gateway): UDP-cached getSlot (processed-commitment fast path)

### DIFF
--- a/slv-plugins/rpc-gateway/src/dispatch.rs
+++ b/slv-plugins/rpc-gateway/src/dispatch.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 
 use regex::Regex;
+use serde_json::{json, Value};
 
 use crate::clickhouse::ClickHouseClient;
 use crate::handlers::{gtfa::GtfaHandlers, jet, transfers::TransfersHandlers};
@@ -19,6 +20,42 @@ use crate::of1::Of1Client;
 use crate::ws::billing::BillingClient;
 use crate::ws::slot_source::SlotPubsubMultiplex;
 use crate::ws::WsConfig;
+
+/// Result of inspecting the `commitment` param on a `getSlot`-like
+/// JSON-RPC request.  Only the "processed-or-unset" variant is
+/// safe to answer from the UDP-derived slot cache; everything else
+/// (`confirmed`, `finalized`, or anything the gateway doesn't
+/// recognise) falls through to the upstream so we never serve a
+/// commitment-stronger answer than we can actually guarantee.
+#[derive(Debug, PartialEq, Eq)]
+enum CommitmentParam {
+    ProcessedOrUnset,
+    Other,
+}
+
+/// Solana RPC accepts `commitment` either as the only positional
+/// arg (`[{"commitment": "…"}]`) or, less commonly, as a top-level
+/// `params` object.  We accept both forms and treat anything else
+/// (= malformed shape, unknown value) as `Other` so we err on the
+/// side of forwarding upstream.
+fn slot_commitment(params: &Option<Value>) -> CommitmentParam {
+    let Some(params) = params.as_ref() else {
+        return CommitmentParam::ProcessedOrUnset;
+    };
+    let obj = match params {
+        Value::Array(arr) => arr.first().and_then(Value::as_object),
+        Value::Object(o) => Some(o),
+        _ => None,
+    };
+    let Some(obj) = obj else {
+        // `[]` or unrecognised shape — treat as unset.
+        return CommitmentParam::ProcessedOrUnset;
+    };
+    match obj.get("commitment").and_then(Value::as_str) {
+        None | Some("processed") => CommitmentParam::ProcessedOrUnset,
+        Some(_) => CommitmentParam::Other,
+    }
+}
 
 /// Methods in the `jet*` namespace (camelCase, prefix `jet` + uppercase
 /// 4th char): `jetTopPrograms`, `jetSlotStats`, `jetTpsTimeseries`,
@@ -141,6 +178,13 @@ impl Gateway {
             ))),
             _ => None,
         };
+        // Eagerly warm the primary slot multiplex so the
+        // HTTP-RPC `getSlot` cache works the moment the gateway
+        // is up — without this, `getSlot` would only have a cached
+        // value after the first WS client subscribed.
+        if let Some(m) = slot_first_shred_multi.as_ref() {
+            m.ensure_running();
+        }
         Self {
             ch,
             of1,
@@ -180,6 +224,23 @@ impl Gateway {
             }
             "getTransfersByAddress" => {
                 self.wrap(id, self.transfers.handle(&req.params).await)
+            }
+            // Fast-path `getSlot` for the default `processed`
+            // commitment: read the latest slot from the in-process
+            // UDP-derived cache (sub-µs) instead of round-tripping
+            // to the upstream RPC node.  `confirmed` / `finalized`
+            // still fall through to the upstream because the cache
+            // only tracks shred-arrival ("processed-or-newer")
+            // timing, not validator consensus state.
+            "getSlot" => {
+                if matches!(slot_commitment(&req.params), CommitmentParam::ProcessedOrUnset) {
+                    if let Some(multi) = self.slot_first_shred_multi.as_ref() {
+                        if let Some(slot) = multi.latest_slot() {
+                            return Response::ok(id, json!(slot));
+                        }
+                    }
+                }
+                self.forward_to_upstream(&req, id).await
             }
             _ => {
                 if JET_NAMESPACE_RE.is_match(&req.method) {
@@ -234,6 +295,54 @@ impl Gateway {
                 format!("upstream: {e}"),
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod commitment_tests {
+    use super::*;
+
+    fn p(v: Value) -> Option<Value> {
+        Some(v)
+    }
+
+    #[test]
+    fn unset_params_means_processed_or_unset() {
+        assert_eq!(slot_commitment(&None), CommitmentParam::ProcessedOrUnset);
+        assert_eq!(slot_commitment(&p(json!([]))), CommitmentParam::ProcessedOrUnset);
+    }
+
+    #[test]
+    fn processed_explicit_means_processed_or_unset() {
+        assert_eq!(
+            slot_commitment(&p(json!([{"commitment": "processed"}]))),
+            CommitmentParam::ProcessedOrUnset,
+        );
+    }
+
+    #[test]
+    fn confirmed_and_finalized_fall_through() {
+        for c in ["confirmed", "finalized", "single", "max"] {
+            assert_eq!(
+                slot_commitment(&p(json!([{"commitment": c}]))),
+                CommitmentParam::Other,
+                "commitment={c} should fall through to upstream",
+            );
+        }
+    }
+
+    #[test]
+    fn object_form_also_parsed() {
+        // Some SDKs send `{"commitment": …}` as the top-level
+        // params object instead of wrapping in an array.
+        assert_eq!(
+            slot_commitment(&p(json!({"commitment": "processed"}))),
+            CommitmentParam::ProcessedOrUnset,
+        );
+        assert_eq!(
+            slot_commitment(&p(json!({"commitment": "confirmed"}))),
+            CommitmentParam::Other,
+        );
     }
 }
 

--- a/slv-plugins/rpc-gateway/src/ws/slot_source.rs
+++ b/slv-plugins/rpc-gateway/src/ws/slot_source.rs
@@ -89,6 +89,11 @@ pub struct SlotPubsubMultiplex {
     delivered: Mutex<DeliveredWindow>,
     next_listener_id: AtomicU64,
     started: AtomicBool,
+    /// Highest slot number we've observed across every input source.
+    /// Updated lock-free in `deliver()` so the HTTP-RPC `getSlot`
+    /// handler can read it without touching any mutex.  Zero =
+    /// no signal yet (= unset).
+    latest_slot: AtomicU64,
 }
 
 struct DeliveredWindow {
@@ -193,7 +198,24 @@ impl SlotPubsubMultiplex {
             delivered: Mutex::new(DeliveredWindow::new()),
             next_listener_id: AtomicU64::new(1),
             started: AtomicBool::new(false),
+            latest_slot: AtomicU64::new(0),
         }
+    }
+
+    /// Eagerly start all configured input sources without registering
+    /// a listener.  Lets the HTTP-RPC `getSlot` handler read a fresh
+    /// cached value via [`latest_slot`] even when no WS client has
+    /// subscribed yet.  Cheap to call (= no-op after first invocation).
+    pub fn ensure_running(self: &Arc<Self>) {
+        self.ensure_started();
+    }
+
+    /// Highest slot observed across all input sources, or `None` when
+    /// no signal has arrived yet (= just after process start, or the
+    /// multiplex has no live sources).  Lock-free read.
+    pub fn latest_slot(&self) -> Option<u64> {
+        let v = self.latest_slot.load(Ordering::Relaxed);
+        (v != 0).then_some(v)
     }
 
     /// Register a listener; returns a subscription handle.  Dropping
@@ -239,6 +261,11 @@ impl SlotPubsubMultiplex {
         if !self.delivered.lock().observe(update.slot) {
             return;
         }
+        // Track the high-water mark before fanning out so the
+        // HTTP-RPC `getSlot` cache always reflects the latest slot
+        // even when no WS listeners are attached.  `fetch_max`
+        // guarantees monotonicity under concurrent updates.
+        self.latest_slot.fetch_max(update.slot, Ordering::Relaxed);
         // Snapshot the listener set so per-listener `send` doesn't
         // hold the lock across an iteration that might want to
         // remove dropped peers.
@@ -590,6 +617,30 @@ mod tests {
         // probes and by zero-padded packets — must not be delivered.
         let pkt = vec![0u8; 1228];
         assert_eq!(parse_shred_slot(&pkt), None);
+    }
+
+    #[test]
+    fn latest_slot_starts_none_then_tracks_high_water_mark() {
+        let m = Arc::new(SlotPubsubMultiplex::first_shred_multiplex(
+            Vec::new(), None, None,
+        ));
+        // No deliveries yet — `getSlot` would fall through to upstream.
+        assert_eq!(m.latest_slot(), None);
+
+        m.deliver(SlotUpdate { slot: 100, parent: None, root: 100u64.saturating_sub(32) });
+        assert_eq!(m.latest_slot(), Some(100));
+
+        // A later slot updates the high-water mark.
+        m.deliver(SlotUpdate { slot: 101, parent: None, root: 101u64.saturating_sub(32) });
+        assert_eq!(m.latest_slot(), Some(101));
+
+        // An earlier slot (= out-of-order from a slow source) must
+        // NOT regress the cache.  Note `deliver()` also dedupes per
+        // slot number — slot 100 has already been observed so the
+        // second call would be a no-op anyway; we use slot 99 (= a
+        // slot we haven't seen but is older than the high-water).
+        m.deliver(SlotUpdate { slot: 99, parent: None, root: 99u64.saturating_sub(32) });
+        assert_eq!(m.latest_slot(), Some(101));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

\`getSlot\` for the default \`processed\` commitment is now served
from the in-process slot multiplex cache (sub-µs), instead of
round-tripping to the upstream RPC node (= ~80-110 ms p50 from a
same-region VPS in the baseline bench).

Equally important: when the configured upstream is a historical-
only backend (= yellowstone-faithful style CAR-file server), the
returned slot can be days stale — silently breaking clients that
use it for trade timing.  The cache reflects live shred arrival
so the answer is always current.

## How

- \`SlotPubsubMultiplex\` exposes a lock-free \`latest_slot()\`
  reader.  Each \`deliver()\` applies \`fetch_max\` for monotonicity
  under out-of-order delivery.
- Gateway eagerly calls \`ensure_running()\` on the primary
  multiplex at construction time so the cache is warm pre-subscribe.
- \`dispatch()\` intercepts \`getSlot\`: \`processed\` / unset →
  cache; \`confirmed\` / \`finalized\` / unknown → upstream.

## Semantics caveat

Cache reflects "first-shred-received" timing — matches the
existing \`slotSubscribe\` fast-path stack in this crate.  ~95 %
of slots agree with \`processed\` bank state; off by skip count
in the rest.  Clients needing bank-execute-complete should ask
for \`commitment=confirmed\`.

## Test plan

- [x] 5 new unit tests (commitment parsing + cache monotonicity)
- [x] 53 existing tests pass
- [x] \`cargo build --release\` clean
- [ ] CI green
- [ ] After merge: deploy + re-run the same VPS bench
      (getSlot/getBlockHeight) and compare with baseline.