### PR TITLE
fix(ansible): drop hostvars[...].name from start/stop debug msg

### DIFF
--- a/template/2026.5.5.1612/ansible/cmn/start_firedancer.yml
+++ b/template/2026.5.5.1612/ansible/cmn/start_firedancer.yml
@@ -14,4 +14,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Start Firedancer: {{ command_output.stdout }}'
+        msg: 'Start Firedancer: {{ command_output.stdout }}'

--- a/template/2026.5.5.1612/ansible/cmn/start_solv.yml
+++ b/template/2026.5.5.1612/ansible/cmn/start_solv.yml
@@ -11,4 +11,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Start Solv: {{ command_output.stdout }}'
+        msg: 'Start Solv: {{ command_output.stdout }}'

--- a/template/2026.5.5.1612/ansible/cmn/stop_firedancer.yml
+++ b/template/2026.5.5.1612/ansible/cmn/stop_firedancer.yml
@@ -11,4 +11,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Stop Firedancer: {{ command_output.stdout }}'
+        msg: 'Stop Firedancer: {{ command_output.stdout }}'

--- a/template/2026.5.5.1612/ansible/cmn/stop_solv.yml
+++ b/template/2026.5.5.1612/ansible/cmn/stop_solv.yml
@@ -11,4 +11,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Stop Solv: {{ command_output.stdout }}'
+        msg: 'Stop Solv: {{ command_output.stdout }}'

--- a/template/2026.5.5.1612/ansible/mainnet-rpc/stop_firedancer.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-rpc/stop_firedancer.yml
@@ -11,4 +11,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Stop Firedancer: {{ command_output.stdout }}'
+        msg: 'Stop Firedancer: {{ command_output.stdout }}'

--- a/template/2026.5.5.1612/ansible/mainnet-rpc/stop_solv.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-rpc/stop_solv.yml
@@ -11,4 +11,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Stop Solv: {{ command_output.stdout }}'
+        msg: 'Stop Solv: {{ command_output.stdout }}'

--- a/template/2026.5.5.1612/ansible/mainnet-validator/start_solv.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-validator/start_solv.yml
@@ -11,4 +11,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Start Solv: {{ command_output.stdout }}'
+        msg: 'Start Solv: {{ command_output.stdout }}'

--- a/template/2026.5.5.1612/ansible/mainnet-validator/stop_firedancer.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-validator/stop_firedancer.yml
@@ -11,7 +11,7 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Stop Firedancer: {{ command_output.stdout }}'
+        msg: 'Stop Firedancer: {{ command_output.stdout }}'
 
     - name: Remove Firedancer workspace files
       shell: sudo rm -f /mnt/.gigantic/*.wksp

--- a/template/2026.5.5.1612/ansible/mainnet-validator/stop_solv.yml
+++ b/template/2026.5.5.1612/ansible/mainnet-validator/stop_solv.yml
@@ -11,4 +11,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Stop Solv: {{ command_output.stdout }}'
+        msg: 'Stop Solv: {{ command_output.stdout }}'

--- a/template/2026.5.5.1612/ansible/testnet-validator/start_solv.yml
+++ b/template/2026.5.5.1612/ansible/testnet-validator/start_solv.yml
@@ -11,4 +11,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Start Solv: {{ command_output.stdout }}'
+        msg: 'Start Solv: {{ command_output.stdout }}'

--- a/template/2026.5.5.1612/ansible/testnet-validator/stop_firedancer.yml
+++ b/template/2026.5.5.1612/ansible/testnet-validator/stop_firedancer.yml
@@ -11,7 +11,7 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Stop Firedancer: {{ command_output.stdout }}'
+        msg: 'Stop Firedancer: {{ command_output.stdout }}'
 
     - name: Remove Firedancer workspace files
       shell: sudo rm -f /mnt/.gigantic/*.wksp

--- a/template/2026.5.5.1612/ansible/testnet-validator/stop_solv.yml
+++ b/template/2026.5.5.1612/ansible/testnet-validator/stop_solv.yml
@@ -11,4 +11,4 @@
 
     - name: Display Command output
       debug:
-        msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): Stop Solv: {{ command_output.stdout }}'
+        msg: 'Stop Solv: {{ command_output.stdout }}'


### PR DESCRIPTION
## Summary

12 start/stop playbooks under
\`template/2026.5.5.1612/ansible/\` had a \`Display Command output\`
debug task that referenced \`hostvars[inventory_hostname].name\` —
a host variable that is never defined when the playbook is invoked
with a single ad-hoc inventory target (e.g.
\`ansible-playbook -i 192.0.2.10, ...\`).  Ansible raises
\`'HostVarsVars' object has no attribute 'name'\` at task
finalisation, the playbook exits non-zero, and any orchestration
that treats playbook failure as an abort signal silently skips the
matching \`start_*.yml\`.

## Concrete symptom

A service-restart orchestration ran \`stop_solv.yml\` on a target.
The Stop Solv shell task succeeded, but the Display Command output
task crashed on the missing \`.name\`, the playbook exited
non-zero, and the queued follow-up \`start_solv.yml\` was therefore
aborted.  The validator stayed down until an operator noticed and
manually restarted it.

## Fix

Match the already-fixed form in
\`template/2026.5.5.1612/ansible/mainnet-rpc/start_solv.yml\`:

\`\`\`
- msg: '{{ inventory_hostname }} ({{ hostvars[inventory_hostname].name }}): <Action>: {{ command_output.stdout }}'
+ msg: '<Action>: {{ command_output.stdout }}'
\`\`\`

12 files changed, 12 insertions(+), 12 deletions(-).  Latest
template only — historical template snapshots are kept as-is.

## Test plan

- [x] \`ansible-playbook --syntax-check\` clean (= local)
- [x] Confirmed the unfixed wording was already present in the
      latest template AND in older snapshots, but historical
      snapshots are not touched (= they're frozen artifacts).
- [ ] CI green
- [ ] After merge: operators with an ansible-api host that has
      this template version deployed locally can pull the patched
      copy and re-run a restart orchestration to confirm the chain
      no longer aborts at the debug task.