### PR TITLE
fix(validator): recipe restart-safety on Agave 4.1+ (port range + restart-only flags)

### DIFF
--- a/cli/lib/addMainnetInventory.ts
+++ b/cli/lib/addMainnetInventory.ts
@@ -36,7 +36,7 @@ const addMainnetInventory = async (
       validator_type: 'firedancer-jito',
       region: '',
       port_rpc: 8899,
-      dynamic_port_range: '8000-8025',
+      dynamic_port_range: '8000-8030',
       relayer_url: 'http://localhost:11226',
       block_engine_url: 'http://ny.mainnet.relayer.jito.wtf:8100',
       shred_receiver_address: '',

--- a/cli/src/ai/console/tools.ts
+++ b/cli/src/ai/console/tools.ts
@@ -12,10 +12,7 @@ import {
 } from '@/ai/console/systemPrompt.ts'
 import { DISCORD_LINK } from '@cmn/constants/url.ts'
 import { loadAgentContext } from '@/ai/agentConfig/loader.ts'
-import {
-  isKnownAgentId,
-  ALL_AGENT_IDS,
-} from '@/ai/agentConfig/registry.ts'
+import { ALL_AGENT_IDS, isKnownAgentId } from '@/ai/agentConfig/registry.ts'
 import {
   resolveAgentMdPath,
   resolveSkillMdPath,
@@ -159,7 +156,6 @@ export type ToolDefinition = {
   description: string
   parameters: Record<string, unknown>
 }
-
 
 // Core tools — safe orchestration helpers available after bootstrap
 export const CORE_TOOLS: ToolDefinition[] = [
@@ -522,7 +518,8 @@ function checkWalletGuard(command: string): string | null {
     },
     {
       re: />\s*wallet\.json\b/,
-      reason: 'refusing to truncate or overwrite wallet.json via shell redirect',
+      reason:
+        'refusing to truncate or overwrite wallet.json via shell redirect',
     },
     {
       re: new RegExp(`\\brm${rmFlags}\\s+[^\\n]*${home}/\\.slv(/|\\s|$|['"])`),
@@ -546,8 +543,7 @@ function checkWalletGuard(command: string): string | null {
 async function executeRunCommand(command: string): Promise<string> {
   const guardReason = checkWalletGuard(command)
   if (guardReason !== null) {
-    const msg =
-      `Command blocked by wallet safety guard: ${guardReason}\n\n` +
+    const msg = `Command blocked by wallet safety guard: ${guardReason}\n\n` +
       `Command: ${command}\n\n` +
       `This is a hard guard that runs before confirmation to protect wallet.json and ~/.slv from accidental deletion. Do not retry with a rephrased command — either delegate to the Setzer sub-agent (agent='Setzer') for bot/app work, or ask the user to run the command manually if they truly intend it.`
     if (!tuiInstance) {
@@ -1199,7 +1195,7 @@ Use write_file to create \`${home}/.slv/inventory.<network>.validators.yml\`:
       region: <region>
       snapshot_url: ""  # Auto-detected from nearest region
       commission_bps: 0
-      dynamic_port_range: "8900-8925"
+      dynamic_port_range: "8900-8930"
       port_rpc: 7211
 \`\`\`
 

--- a/cli/src/rpc/init/devnetInitRpc.ts
+++ b/cli/src/rpc/init/devnetInitRpc.ts
@@ -58,7 +58,7 @@ export const devnetInitRpc = async (
     rpc_type: rpc_type as RpcType,
     port_rpc: 7211,
     richat_version: VERSION_RICHAT,
-    dynamic_port_range: '8000-8025',
+    dynamic_port_range: '8000-8030',
     validator_type: rpcTypes.validatorType as SolanaNodeType,
     region: 'ny',
     limit_ledger_size: 200000000,

--- a/cli/src/rpc/init/mainnetInitRpc.ts
+++ b/cli/src/rpc/init/mainnetInitRpc.ts
@@ -110,7 +110,7 @@ export const mainnetInitRpc = async (
     name: identity_account,
     rpc_type: rpc_type as RpcType,
     port_rpc: 7211,
-    dynamic_port_range: '8000-8025',
+    dynamic_port_range: '8000-8030',
     validator_type: rpcTypes.validatorType as SolanaNodeType,
     region: getNearRegion.region,
     limit_ledger_size: 200000000,

--- a/cli/src/rpc/init/testnetInitRpc.ts
+++ b/cli/src/rpc/init/testnetInitRpc.ts
@@ -102,7 +102,7 @@ export const testnetInitRpc = async (
     name: identity_account,
     rpc_type: rpc_type as RpcType,
     port_rpc: 7211,
-    dynamic_port_range: '8000-8025',
+    dynamic_port_range: '8000-8030',
     validator_type: rpcTypes.validatorType as SolanaNodeType,
     region: getNearRegion.region,
     limit_ledger_size: 200000000,

--- a/cli/src/validator/init/initMainnetConfig.ts
+++ b/cli/src/validator/init/initMainnetConfig.ts
@@ -149,7 +149,7 @@ const initMainnetConfig = async (
     region: getNearRegion.region,
     commission_bps: Number(commissionBps),
     port_rpc: 7211,
-    dynamic_port_range: '8900-8925',
+    dynamic_port_range: '8900-8930',
     relayer_url,
     block_engine_url: blockEngineRegion,
     shred_receiver_address: String(shredstream_address),

--- a/cli/src/validator/init/initTestnetConfig.ts
+++ b/cli/src/validator/init/initTestnetConfig.ts
@@ -126,7 +126,7 @@ const initTestnetConfig = async (
     shred_receiver_address: String(getNearRegion.info.shredReceiver),
     snapshot_url: '',
     port_rpc: 7211,
-    dynamic_port_range: '8900-8925',
+    dynamic_port_range: '8900-8930',
     ...xdpConfig,
   }
   await updateInventory(name, configTestnet)

--- a/template/2026.5.21.1448/jinja/devnet-rpc/start-validator.sh.j2
+++ b/template/2026.5.21.1448/jinja/devnet-rpc/start-validator.sh.j2
@@ -16,7 +16,7 @@ exec agave-validator \
 --known-validator dv3qDFk1DTF36Z62bNvrCXe9sKATA6xvVy6A798xxAS \
 --only-known-rpc \
 --expected-genesis-hash EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG \
---dynamic-port-range {{ dynamic_port_range | default("8900-8925") }}  \
+--dynamic-port-range {{ dynamic_port_range | default("8900-8930") }}  \
 --full-rpc-api \
 --no-voting \
 --rpc-port {{ port_rpc | default(8899, true) }} \

--- a/template/2026.5.21.1448/jinja/mainnet-pythnet/start-pythnet.sh.j2
+++ b/template/2026.5.21.1448/jinja/mainnet-pythnet/start-pythnet.sh.j2
@@ -22,7 +22,7 @@ exec /usr/local/bin/solana-validator \
   --rpc-bind-address {{ pythnet_rpc_bind | default('0.0.0.0') }} \
   --full-rpc-api \
   --enable-rpc-transaction-history \
-  --dynamic-port-range {{ pythnet_dynamic_port_range | default('8000-8020') }} \
+  --dynamic-port-range {{ pythnet_dynamic_port_range | default('8000-8030') }} \
   --gossip-port {{ pythnet_gossip_port | default(8001) }} \
   --account-index program-id \
   --ledger {{ pythnet_ledger_mount | default('/mnt/ledger') }}/pythnet/ledger \

--- a/template/2026.5.21.1448/jinja/mainnet-rpc/start-mainnet-rpc-grpc.sh.j2
+++ b/template/2026.5.21.1448/jinja/mainnet-rpc/start-mainnet-rpc-grpc.sh.j2
@@ -20,7 +20,7 @@ exec agave-validator \
 --no-voting \
 --private-rpc \
 --no-skip-initial-accounts-db-clean \
---dynamic-port-range 8000-8020 \
+--dynamic-port-range 8000-8030 \
 --rpc-bind-address 0.0.0.0 \
 --rpc-port {{ port_rpc }} \
 --no-port-check \

--- a/template/2026.5.21.1448/jinja/mainnet-rpc/start-mainnet-rpc-index.sh.j2
+++ b/template/2026.5.21.1448/jinja/mainnet-rpc/start-mainnet-rpc-index.sh.j2
@@ -21,7 +21,7 @@ exec agave-validator \
 --no-voting \
 --private-rpc \
 --no-skip-initial-accounts-db-clean \
---dynamic-port-range 8000-8020 \
+--dynamic-port-range 8000-8030 \
 --rpc-bind-address 0.0.0.0 \
 --rpc-port {{ port_rpc }} \
 --no-port-check \

--- a/template/2026.5.21.1448/jinja/mainnet-rpc/start-mainnet-rpc-tx.sh.j2
+++ b/template/2026.5.21.1448/jinja/mainnet-rpc/start-mainnet-rpc-tx.sh.j2
@@ -21,7 +21,7 @@ exec agave-validator \
 --no-voting \
 --private-rpc \
 --no-skip-initial-accounts-db-clean \
---dynamic-port-range 8000-8020 \
+--dynamic-port-range 8000-8030 \
 --rpc-bind-address 0.0.0.0 \
 --rpc-port {{ port_rpc }} \
 --no-port-check \

--- a/template/2026.5.21.1448/jinja/mainnet-rpc/start-mainnet-rpc.sh.j2
+++ b/template/2026.5.21.1448/jinja/mainnet-rpc/start-mainnet-rpc.sh.j2
@@ -22,7 +22,7 @@ exec agave-validator \
 --private-rpc \
 --enable-cpi-and-log-storage \
 --no-skip-initial-accounts-db-clean \
---dynamic-port-range 8000-8020 \
+--dynamic-port-range 8000-8030 \
 --rpc-bind-address 0.0.0.0 \
 --rpc-port {{ port_rpc }} \
 --no-port-check \

--- a/template/2026.5.21.1448/jinja/mainnet-rpc/start-validator.sh.j2
+++ b/template/2026.5.21.1448/jinja/mainnet-rpc/start-validator.sh.j2
@@ -17,7 +17,7 @@ exec agave-validator \
 --only-known-rpc \
 --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
 --expected-shred-version 50093 \
---dynamic-port-range {{ dynamic_port_range | default("8900-8925") }}  \
+--dynamic-port-range {{ dynamic_port_range | default("8900-8930") }}  \
 --no-voting \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --rpc-bind-address 0.0.0.0 \

--- a/template/2026.5.21.1448/jinja/mainnet-validator/start-validator.sh.j2
+++ b/template/2026.5.21.1448/jinja/mainnet-validator/start-validator.sh.j2
@@ -18,7 +18,7 @@ exec agave-validator \
 --only-known-rpc \
 --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
 --expected-shred-version 50093 \
---dynamic-port-range {{ dynamic_port_range | default("8000-8025") }} \
+--dynamic-port-range {{ dynamic_port_range | default("8000-8030") }} \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --wal-recovery-mode skip_any_corrupted_record \
 --use-snapshot-archives-at-startup when-newest \

--- a/template/2026.5.21.1448/jinja/testnet-rpc/start-validator.sh.j2
+++ b/template/2026.5.21.1448/jinja/testnet-rpc/start-validator.sh.j2
@@ -15,7 +15,7 @@ exec agave-validator \
 --known-validator 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv \
 --only-known-rpc \
 --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
---dynamic-port-range {{ dynamic_port_range | default("8900-8925") }}  \
+--dynamic-port-range {{ dynamic_port_range | default("8900-8930") }}  \
 --no-voting \
 --full-rpc-api \
 --rpc-port {{ port_rpc | default(8899, true) }} \

--- a/template/2026.5.21.1448/jinja/testnet-validator/start-validator-agave.sh.j2
+++ b/template/2026.5.21.1448/jinja/testnet-validator/start-validator-agave.sh.j2
@@ -14,9 +14,13 @@ exec agave-validator \
 --dynamic-port-range {{ dynamic_port_range | default("8000-8030") }} \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --wal-recovery-mode skip_any_corrupted_record \
---wait-for-supermajority {{ wait_for_supermajority | default("383520372") }} \
+{% if wait_for_supermajority is defined %}
+--wait-for-supermajority {{ wait_for_supermajority }} \
+{% endif %}
 --expected-shred-version {{ expected_shred_version | default("57087") }} \
---expected-bank-hash {{ expected_bank_hash | default("YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA") }} \
+{% if expected_bank_hash is defined %}
+--expected-bank-hash {{ expected_bank_hash }} \
+{% endif %}
 --limit-ledger-size {{ limit_ledger_size | default(200000000) }} \
 --no-port-check \
 {% if xdp_enabled | default(false) and xdp_interface | default('') %}

--- a/template/2026.5.21.1448/jinja/testnet-validator/start-validator-agave.sh.j2
+++ b/template/2026.5.21.1448/jinja/testnet-validator/start-validator-agave.sh.j2
@@ -11,7 +11,7 @@ exec agave-validator \
 --known-validator 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on \
 --only-known-rpc \
 --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
---dynamic-port-range {{ dynamic_port_range | default("8000-8025") }} \
+--dynamic-port-range {{ dynamic_port_range | default("8000-8030") }} \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --wal-recovery-mode skip_any_corrupted_record \
 --wait-for-supermajority {{ wait_for_supermajority | default("383520372") }} \

--- a/template/2026.5.21.1448/jinja/testnet-validator/start-validator-jito.sh.j2
+++ b/template/2026.5.21.1448/jinja/testnet-validator/start-validator-jito.sh.j2
@@ -14,9 +14,13 @@ exec agave-validator \
 --dynamic-port-range {{ dynamic_port_range | default("8000-8030") }} \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --wal-recovery-mode skip_any_corrupted_record \
---wait-for-supermajority {{ wait_for_supermajority | default("383520372") }} \
+{% if wait_for_supermajority is defined %}
+--wait-for-supermajority {{ wait_for_supermajority }} \
+{% endif %}
 --expected-shred-version {{ expected_shred_version | default("57087") }} \
---expected-bank-hash {{ expected_bank_hash | default("YFxSkDcvSPiA7EQpSTbCsWbJvNYMAsWXGvwGc3bXHEA") }} \
+{% if expected_bank_hash is defined %}
+--expected-bank-hash {{ expected_bank_hash }} \
+{% endif %}
 --limit-ledger-size {{ limit_ledger_size | default(200000000) }} \
 --no-port-check \
 {% if xdp_enabled | default(false) and xdp_interface | default('') %}

--- a/template/2026.5.21.1448/jinja/testnet-validator/start-validator-jito.sh.j2
+++ b/template/2026.5.21.1448/jinja/testnet-validator/start-validator-jito.sh.j2
@@ -11,7 +11,7 @@ exec agave-validator \
 --known-validator 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on \
 --only-known-rpc \
 --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
---dynamic-port-range {{ dynamic_port_range | default("8000-8025") }} \
+--dynamic-port-range {{ dynamic_port_range | default("8000-8030") }} \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --wal-recovery-mode skip_any_corrupted_record \
 --wait-for-supermajority {{ wait_for_supermajority | default("383520372") }} \

--- a/template/2026.5.21.1448/jinja/testnet-validator/start-validator.sh.j2
+++ b/template/2026.5.21.1448/jinja/testnet-validator/start-validator.sh.j2
@@ -9,7 +9,7 @@ exec agave-validator \
 --entrypoint entrypoint2.testnet.solana.com:8001 \
 --entrypoint entrypoint3.testnet.solana.com:8001 \
 --known-validator 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on \
---dynamic-port-range {{ dynamic_port_range | default("8000-8025") }} \
+--dynamic-port-range {{ dynamic_port_range | default("8000-8030") }} \
 --rpc-port {{ port_rpc | default(8899, true) }} \
 --wal-recovery-mode skip_any_corrupted_record \
 {% if wait_for_supermajority is defined %}


### PR DESCRIPTION
## Problem

Agave/Jito **4.1.0+** rejects a `--dynamic-port-range` smaller than **27 ports**:

```
error: Invalid value for '--dynamic-port-range <MIN_PORT-MAX_PORT>': Port range is too small. Try --dynamic-port-range 8900-8926
```

The recipe defaults were 26 ports (`8000-8025`, `8900-8925`) — and `8000-8020` (21) for pythnet — so a freshly deployed/upgraded 4.1+ validator **crash-loops instantly** at start (`ExecStart … status=1/FAILURE`, ~3ms CPU). Older versions accepted 26 ports, so this only surfaces on the version bump.

## Fix

Bump every `--dynamic-port-range` default (and the init/inventory defaults that feed it) to a **31-port** range:
- `8000-8025` → `8000-8030`
- `8900-8925` → `8900-8930`
- `8000-8020` → `8000-8030` (pythnet)

Covers validator, RPC, and pythnet start templates plus the TypeScript init defaults (`initTestnetConfig`, `initMainnetConfig`, `addMainnetInventory`, the RPC inits, and the AI console tool). Firedancer TOML configs use a separate parser and are left unchanged.

Existing inventories that already set `dynamic_port_range` explicitly are unaffected; this only changes the fallback default. Hosts with a too-small explicit value should widen it to ≥27 ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)