### PR TITLE
fix(firedancer): network-aware version, SBF install conflict, fdctl symlink force

### DIFF
--- a/template/2026.6.6.1502/ansible/cmn/update_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/cmn/update_firedancer.yml
@@ -12,7 +12,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: v{{ mainnet_validators.version_firedancer }}
+        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive
@@ -51,6 +51,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/devnet-rpc/install_jito.yml
+++ b/template/2026.6.6.1502/ansible/devnet-rpc/install_jito.yml
@@ -61,6 +61,15 @@
         version: '{{ jito_version_resolved }}'
         force: yes
 
+    - name: Remove stale cargo-build-sbf/cargo-test-sbf (avoid cargo-install conflict)
+      become: no
+      file:
+        path: '{{ jito_install_dir }}/bin/{{ item }}'
+        state: absent
+      loop:
+        - cargo-build-sbf
+        - cargo-test-sbf
+
     - name: Build Jito Solana (cargo-install-all)
       become: no
       shell: |

--- a/template/2026.6.6.1502/ansible/devnet-rpc/setup_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/devnet-rpc/setup_firedancer.yml
@@ -53,6 +53,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/mainnet-rpc/install_jito.yml
+++ b/template/2026.6.6.1502/ansible/mainnet-rpc/install_jito.yml
@@ -61,6 +61,15 @@
         version: '{{ jito_version_resolved }}'
         force: yes
 
+    - name: Remove stale cargo-build-sbf/cargo-test-sbf (avoid cargo-install conflict)
+      become: no
+      file:
+        path: '{{ jito_install_dir }}/bin/{{ item }}'
+        state: absent
+      loop:
+        - cargo-build-sbf
+        - cargo-test-sbf
+
     - name: Build Jito Solana (cargo-install-all)
       become: no
       shell: |

--- a/template/2026.6.6.1502/ansible/mainnet-rpc/setup_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/mainnet-rpc/setup_firedancer.yml
@@ -14,7 +14,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
+        version: v{{ mainnet_rpcs.version_firedancer }}
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive

--- a/template/2026.6.6.1502/ansible/mainnet-rpc/setup_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/mainnet-rpc/setup_firedancer.yml
@@ -14,7 +14,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: v{{ mainnet_validators.version_firedancer }}
+        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive
@@ -53,6 +53,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/mainnet-validator/install_jito.yml
+++ b/template/2026.6.6.1502/ansible/mainnet-validator/install_jito.yml
@@ -52,6 +52,15 @@
         version: '{{ jito_version }}'
         force: yes
 
+    - name: Remove stale cargo-build-sbf/cargo-test-sbf (avoid cargo-install conflict)
+      become: no
+      file:
+        path: '{{ jito_install_dir }}/bin/{{ item }}'
+        state: absent
+      loop:
+        - cargo-build-sbf
+        - cargo-test-sbf
+
     - name: Build Jito Solana (cargo-install-all)
       become: no
       shell: |

--- a/template/2026.6.6.1502/ansible/mainnet-validator/setup_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/mainnet-validator/setup_firedancer.yml
@@ -19,7 +19,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
+        version: v{{ mainnet_validators.version_firedancer }}
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive

--- a/template/2026.6.6.1502/ansible/mainnet-validator/setup_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/mainnet-validator/setup_firedancer.yml
@@ -19,7 +19,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: v{{ mainnet_validators.version_firedancer }}
+        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive
@@ -58,6 +58,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/mainnet-validator/update_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/mainnet-validator/update_firedancer.yml
@@ -12,7 +12,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
+        version: v{{ mainnet_validators.version_firedancer }}
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive

--- a/template/2026.6.6.1502/ansible/mainnet-validator/update_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/mainnet-validator/update_firedancer.yml
@@ -12,7 +12,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: v{{ mainnet_validators.version_firedancer }}
+        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive
@@ -51,6 +51,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/testnet-rpc/install_jito.yml
+++ b/template/2026.6.6.1502/ansible/testnet-rpc/install_jito.yml
@@ -61,6 +61,15 @@
         version: '{{ jito_version_resolved }}'
         force: yes
 
+    - name: Remove stale cargo-build-sbf/cargo-test-sbf (avoid cargo-install conflict)
+      become: no
+      file:
+        path: '{{ jito_install_dir }}/bin/{{ item }}'
+        state: absent
+      loop:
+        - cargo-build-sbf
+        - cargo-test-sbf
+
     - name: Build Jito Solana (cargo-install-all)
       become: no
       shell: |

--- a/template/2026.6.6.1502/ansible/testnet-rpc/setup_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/testnet-rpc/setup_firedancer.yml
@@ -53,6 +53,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/testnet-rpc/update_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/testnet-rpc/update_firedancer.yml
@@ -12,7 +12,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
+        version: v{{ testnet_rpcs.version_firedancer }}
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive

--- a/template/2026.6.6.1502/ansible/testnet-rpc/update_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/testnet-rpc/update_firedancer.yml
@@ -12,7 +12,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: v{{ mainnet_validators.version_firedancer }}
+        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive
@@ -51,6 +51,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/testnet-validator/install_jito.yml
+++ b/template/2026.6.6.1502/ansible/testnet-validator/install_jito.yml
@@ -52,6 +52,15 @@
         version: '{{ jito_version }}'
         force: yes
 
+    - name: Remove stale cargo-build-sbf/cargo-test-sbf (avoid cargo-install conflict)
+      become: no
+      file:
+        path: '{{ jito_install_dir }}/bin/{{ item }}'
+        state: absent
+      loop:
+        - cargo-build-sbf
+        - cargo-test-sbf
+
     - name: Build Jito Solana (cargo-install-all)
       become: no
       shell: |

--- a/template/2026.6.6.1502/ansible/testnet-validator/setup_firedancer_agave.yml
+++ b/template/2026.6.6.1502/ansible/testnet-validator/setup_firedancer_agave.yml
@@ -56,6 +56,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/testnet-validator/setup_firedancer_jito.yml
+++ b/template/2026.6.6.1502/ansible/testnet-validator/setup_firedancer_jito.yml
@@ -56,6 +56,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/testnet-validator/update_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/testnet-validator/update_firedancer.yml
@@ -12,7 +12,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: v{{ mainnet_validators.version_firedancer }}
+        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive
@@ -51,6 +51,7 @@
         src: /home/solv/firedancer/build/native/gcc/bin/fdctl
         dest: /usr/local/bin/fdctl
         state: link
+        force: yes
       become: yes
       become_user: root
 

--- a/template/2026.6.6.1502/ansible/testnet-validator/update_firedancer.yml
+++ b/template/2026.6.6.1502/ansible/testnet-validator/update_firedancer.yml
@@ -12,7 +12,7 @@
         dest: /home/solv/firedancer
         update: yes
         force: yes
-        version: "v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer | default(mainnet_validators.version_firedancer) }}"
+        version: v{{ testnet_validators.version_firedancer }}
 
     - name: Initialize git submodules
       command: git submodule update --init --recursive

--- a/template/2026.6.6.1502/jinja/testnet-rpc/start-validator.sh.j2
+++ b/template/2026.6.6.1502/jinja/testnet-rpc/start-validator.sh.j2
@@ -50,9 +50,11 @@ exec agave-validator \
 --rpc-send-transaction-also-leader \
 {% endif %}
 {% endif %}
---no-port-check{% if rpc_type == 'Geyser gRPC' or rpc_type == 'Index RPC + gRPC' %} \
+--no-port-check \
+{% if rpc_type == 'Geyser gRPC' or rpc_type == 'Index RPC + gRPC' %}
 --rpc-pubsub-enable-block-subscription \
 --rpc-pubsub-enable-vote-subscription \
-{% endif %}{% if validator_type == 'jito' %}
---shred-receiver-address {{ shred_receiver_address | default("64.130.35.224:1002") }}
+{% endif %}
+{% if validator_type == 'jito' %}
+--shred-receiver-address {{ shred_receiver_address | default("64.130.35.224:1002") }} \
 {% endif %}


### PR DESCRIPTION
Three Firedancer recipe bugs hit while updating a live devnet Firedancer RPC (fdctl 0.820 → 0.911, CLI → 4.1.0-beta.2-jito).

## 1. `version_firedancer` was always read from the mainnet block
`update_firedancer.yml` / `setup_firedancer.yml` hardcoded `version: v{{ mainnet_validators.version_firedancer }}`, regardless of the target network. Updating a **testnet/devnet** Firedancer node forced you to overwrite the **mainnet** version field in `versions.yml`.

Now it resolves the host's own inventory group:
```jinja
v{{ vars[group_names | difference(['all', 'ungrouped']) | first].version_firedancer
    | default(mainnet_validators.version_firedancer) }}
```
The `mainnet_validators` fallback keeps old behavior if the lookup ever comes up empty (no regression). Verified live: for a `devnet_rpcs` host it resolves to the `devnet_rpcs` value, not the mainnet one.

## 2. `install_jito` aborts on leftover SBF binaries
`cargo-install-all.sh` fails with `binary cargo-build-sbf already exists in destination` when a prior build left binaries in `<jito_dir>/bin`. Added a cleanup task that removes the stale `cargo-build-sbf` / `cargo-test-sbf` before the build (compile cache is preserved, so the re-run is fast).

## 3. fdctl symlink refused to overwrite a real file
The `state: link` task for `/usr/local/bin/fdctl` failed with *"refusing to convert from file to symlink"* when a real binary file already lived there. Added `force: yes`.

## Notes
- All changed playbooks pass YAML parse; Bug #1's expression was validated against the live inventory with `ansible -m debug`.
- Known follow-up (not in this PR): the Firedancer `make` build runs in `/home/solv/firedancer`, the same path systemd's ExecStart runs, so an in-place rebuild overwrites the running binary and triggers a crash/auto-restart. A clean fix (stage + swap + graceful restart) is larger and left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)